### PR TITLE
Discard LPA module if a different version has been detected.

### DIFF
--- a/c/crossmemory.c
+++ b/c/crossmemory.c
@@ -2859,6 +2859,41 @@ static int addGlobalArea(const CrossMemoryServerName *serverName, CrossMemorySer
 #endif
 }
 
+/* This timestamp value will be updated every time this file gets re-assembled */
+static CMSBuildTimestamp getServerBuildTimestamp() {
+
+  CMSBuildTimestamp timestamp = {0};
+
+  __asm(
+      ASM_PREFIX
+
+      "         MACRO                                                          \n"
+      "&LABEL   GENTIMST                                                       \n"
+      "MODTIME  DS    0D                                                       \n"
+      "         DC    CL26'&SYSCLOCK'                                          \n"
+      "         DC    CL6' '                                                   \n"
+      "         MEND  ,                                                        \n"
+
+      "L$MDTBGN DS    0H                                                       \n"
+      "         PUSH  USING                                                    \n"
+      "         DROP                                                           \n"
+      "         LARL  10,L$MDTBGN                                              \n"
+      "         USING L$MDTBGN,10                                              \n"
+
+      "         MVC   0(32,%[timestamp]),MODTIME                               \n"
+      "         J     L$MDTEXT                                                 \n"
+      "         GENTIMST                                                       \n"
+
+      "L$MDTEXT DS    0H                                                       \n"
+      "         POP   USING                                                    \n"
+      :
+      : [timestamp]"r"(&timestamp)
+      : "r10"
+  );
+
+  return timestamp;
+}
+
 static int allocateGlobalResources(CrossMemoryServer *server) {
 
 #ifndef CROSS_MEMORY_SERVER_DEBUG
@@ -2871,6 +2906,7 @@ static int allocateGlobalResources(CrossMemoryServer *server) {
     zowelog(NULL, LOG_COMP_ID_CMS, ZOWE_LOG_SEVERE, CMS_LOG_GLB_AREA_NOT_SET_MSG, getRC);
     return getRC;
   }
+  char * __ptr32 moduleAddressLPA = NULL;
 
   if (globalArea == NULL) {
 
@@ -2906,48 +2942,103 @@ static int allocateGlobalResources(CrossMemoryServer *server) {
 
     globalArea->serverFlags = 0;
 
-    if (globalArea->lpaModuleInfo.outputInfo.stuff.successInfo.loadPointAddr != NULL) {
+    moduleAddressLPA =
+        globalArea->lpaModuleInfo.outputInfo.stuff.successInfo.loadPointAddr;
+
+#ifdef CMS_LPA_DEV_MODE
+
+    /* Compiling with CMS_LPA_DEV_MODE will force the server to remove the
+     * exiting module every time you start the server. This will help avoid
+     * abandoning too many module in LPA when during development. */
+    if (moduleAddressLPA != NULL) {
+
       int lpaDeleteRSN = 0;
       int lpaDeleteRC = csvdylpaDelete(&globalArea->lpaModuleInfo, &lpaDeleteRSN);
       if (lpaDeleteRC != 0) {
         zowelog(NULL, LOG_COMP_ID_CMS, ZOWE_LOG_SEVERE, CMS_LOG_LPA_DELETE_FAILURE_MSG, lpaDeleteRC, lpaDeleteRSN);
         return RC_CMS_LPA_DELETE_FAILED;
       }
+
+      moduleAddressLPA = NULL;
+      memset(&globalArea->lpaModuleTimestamp, 0, sizeof(CMSBuildTimestamp));
       memset(&globalArea->lpaModuleInfo, 0, sizeof(LPMEA));
+
     } else {
       zowelog(NULL, LOG_COMP_ID_CMS, ZOWE_LOG_WARNING, CMS_LOG_LPMEA_INVALID_MSG);
       zowedump(NULL, LOG_COMP_ID_CMS, ZOWE_LOG_WARNING, (char *)&globalArea->lpaModuleInfo, sizeof(LPMEA));
     }
 
+#else
+
+    /* Does the module in LPA match our private storage module? */
+    CMSBuildTimestamp privateModuleTimestamp = getServerBuildTimestamp();
+    if (memcmp(&privateModuleTimestamp, &globalArea->lpaModuleTimestamp,
+               sizeof(CMSBuildTimestamp))) {
+
+      /* No, discard the LPA module. */
+      zowelog(NULL, LOG_COMP_ID_CMS, ZOWE_LOG_WARNING,
+              CMS_LOG_BUILD_TIME_MISMATCH_MSG, moduleAddressLPA,
+              globalArea->lpaModuleTimestamp.value, privateModuleTimestamp.value);
+      zowedump(NULL, LOG_COMP_ID_CMS, ZOWE_LOG_WARNING,
+               (char *)&globalArea->lpaModuleInfo, sizeof(LPMEA));
+      wtoPrintf(CMS_LOG_BUILD_TIME_MISMATCH_MSG, moduleAddressLPA,
+                globalArea->lpaModuleTimestamp.value, privateModuleTimestamp.value);
+
+      moduleAddressLPA = NULL;
+      memset(&globalArea->lpaModuleTimestamp, 0, sizeof(CMSBuildTimestamp));
+      memset(&globalArea->lpaModuleInfo, 0, sizeof(LPMEA));
+
+    }
+
+#endif /* CMS_LPA_DEV_MODE */
+
   }
 
+  /* Update the server information in the global area. */
   server->globalArea = globalArea;
   globalArea->serverName = server->name;
   globalArea->localServerAddress = server;
   globalArea->serverFlags |= server->flags;
   globalArea->serverASID = getMyPASID();
 
-  int lpaAddRSN = 0;
-  int lpaAddRC = csvdylpaAdd(&server->lpaCodeInfo, &server->ddname, &server->dsname, &lpaAddRSN);
-  if (lpaAddRC != 0) {
-    zowelog(NULL, LOG_COMP_ID_CMS, ZOWE_LOG_SEVERE, CMS_LOG_LPA_LOAD_FAILURE_MSG, lpaAddRC, lpaAddRSN);
-    return RC_CMS_LPA_ADD_FAILED;
+  /* Load the module to LPA if needed, otherwise re-use the existing module. */
+  if (moduleAddressLPA == NULL) {
+
+    int lpaAddRSN = 0;
+    int lpaAddRC = csvdylpaAdd(&server->lpaCodeInfo, &server->ddname, &server->dsname, &lpaAddRSN);
+    if (lpaAddRC != 0) {
+      zowelog(NULL, LOG_COMP_ID_CMS, ZOWE_LOG_SEVERE, CMS_LOG_LPA_LOAD_FAILURE_MSG, lpaAddRC, lpaAddRSN);
+      return RC_CMS_LPA_ADD_FAILED;
+    }
+    globalArea->lpaModuleInfo = server->lpaCodeInfo;
+
+    zowelog(NULL, LOG_COMP_ID_CMS, ZOWE_LOG_DEBUG, CMS_LOG_DEBUG_MSG_ID
+            " module successfully loaded into LPA @ 0x%p, LPMEA:\n",
+            moduleAddressLPA);
+    zowedump(NULL, LOG_COMP_ID_CMS, ZOWE_LOG_DEBUG,
+             (char *)&server->lpaCodeInfo, sizeof(LPMEA));
+
+  } else {
+
+    server->lpaCodeInfo = globalArea->lpaModuleInfo;
+
+    zowelog(NULL, LOG_COMP_ID_CMS, ZOWE_LOG_DEBUG, CMS_LOG_DEBUG_MSG_ID
+            " LPA module will be re-used @ 0x%p, LPMEA:\n", moduleAddressLPA);
+    zowedump(NULL, LOG_COMP_ID_CMS, ZOWE_LOG_DEBUG,
+             (char *)&server->lpaCodeInfo, sizeof(LPMEA));
+
   }
 
-  memcpy(&globalArea->lpaModuleInfo, &server->lpaCodeInfo, sizeof(LPMEA));
-  memcpy(globalArea->serviceTable, server->serviceTable, sizeof(globalArea->serviceTable));
-
-  char * __ptr32 moduleAddressLPA = *(char * __ptr32 *)&server->lpaCodeInfo.outputInfo.stuff.successInfo.loadPointAddr;
+  /* The required module is in LPA, update the corresponding fields. */
+  globalArea->lpaModuleTimestamp = getServerBuildTimestamp();
+  moduleAddressLPA = server->lpaCodeInfo.outputInfo.stuff.successInfo.loadPointAddr;
   server->moduleAddressLPA = moduleAddressLPA;
+
+  /* Prepare the service table */
   initializeServiceTable(server);
-
-  zowelog(NULL, LOG_COMP_ID_CMS, ZOWE_LOG_DEBUG, CMS_LOG_DEBUG_MSG_ID" module successfully loaded into LPA @ 0x%p, LPMEA:\n", moduleAddressLPA);
-  zowedump(NULL, LOG_COMP_ID_CMS, ZOWE_LOG_DEBUG, (char *)&server->lpaCodeInfo, sizeof(LPMEA));
-
-  globalArea->localServerAddress = server;
-  memcpy(&globalArea->lpaModuleInfo, &server->lpaCodeInfo, sizeof(LPMEA));
   memcpy(globalArea->serviceTable, server->serviceTable, sizeof(globalArea->serviceTable));
 
+  /* Prepare the PC-cp handler. */
   char *handlerAddressLocal = (char *)handlePCCP;
   char *moduleAddressLocal = (char *)getMyModuleAddressAndSize(NULL);
   char *handlerAddressLPA = handlerAddressLocal - moduleAddressLocal + moduleAddressLPA;

--- a/h/crossmemory.h
+++ b/h/crossmemory.h
@@ -235,6 +235,10 @@ typedef struct CrossMemoryService_tag {
 #define CROSS_MEMORY_SERVER_VERSION             2
 #define CROSS_MEMORY_SERVER_DISCARDED_VERSION   0xDEADDA7A
 
+typedef struct CMSTimestamp_tag {
+  char value[32];
+} CMSBuildTimestamp;
+
 typedef struct CrossMemoryServerGlobalArea_tag {
 
   char eyecatcher[8];
@@ -254,7 +258,8 @@ typedef struct CrossMemoryServerGlobalArea_tag {
   int ecsaBlockCount; /* must be on a 4-byte boundary for atomicIncrement */
 #define CMS_MAX_ECSA_BLOCK_NUMBER 32
 #define CMS_MAX_ECSA_BLOCK_SIZE   65536
-  char reserved2[48];
+  CMSBuildTimestamp lpaModuleTimestamp;
+  char reserved2[16];
 
   int (* __ptr32 pccpHandler)();
   LPMEA lpaModuleInfo;
@@ -783,6 +788,12 @@ CrossMemoryServerName cmsMakeServerName(const char *nameNullTerm);
 #endif
 #define CMS_LOG_NT_NAME_FAILURE_MSG_TEXT        "%s NAME (NT) not created, %s"
 #define CMS_LOG_NT_NAME_FAILURE_MSG             CMS_LOG_NT_NAME_FAILURE_MSG_ID" "CMS_LOG_NT_NAME_FAILURE_MSG_TEXT
+
+#ifndef CMS_LOG_BUILD_TIME_MISMATCH_MSG_ID
+#define CMS_LOG_BUILD_TIME_MISMATCH_MSG_ID      CMS_MSG_PRFX"0240W"
+#endif
+#define CMS_LOG_BUILD_TIME_MISMATCH_MSG_TEXT    "Discarding outdated LPA module at %p (%26.26s - %26.26s)"
+#define CMS_LOG_BUILD_TIME_MISMATCH_MSG          CMS_LOG_BUILD_TIME_MISMATCH_MSG_ID" "CMS_LOG_BUILD_TIME_MISMATCH_MSG_TEXT
 
 #endif /* H_CROSSMEMORY_H_ */
 


### PR DESCRIPTION
It is unsafe to call CSVDYLPA DELETE. This feature will only be
available in dev mode. In release mode, we'll never attempt to
delete the server module from LPA, and will just abandon it if
the module timestamp doesn't match the timestamp of the private
storage module.

Signed-off-by: Irek Fakhrutdinov <ifakhrutdinov@rocketsoftware.com>