### PR TITLE
Remove use of ASCII as EBCDIC; fix unterminated string handling

### DIFF
--- a/c/httpserver.c
+++ b/c/httpserver.c
@@ -1439,8 +1439,6 @@ static char *getNative(char *s){
   return native;
 }
 
-static char message[] ={ 0x65, 0x66, 0x67, 0x0d, 0x0a, 0x0};
-
 /* makeHttpResponse alloc's the response structure on the passed SLH,
  * but now infuses the HttpResponse with its own SLH */
 HttpResponse *makeHttpResponse(HttpRequest *request, ShortLivedHeap *slh, Socket *socket){
@@ -3595,13 +3593,13 @@ void respondWithUnixDirectory(HttpResponse *response, char* absolutePath, int js
 
 // Response must ALWAYS be finished on return
 void respondWithUnixFileNotFound(HttpResponse* response, int jsonMode) {
-  setResponseStatus(response,404,message);
   if (jsonMode == 0) {
     char message[] = "File not found";
     int len = strlen(message);
 
     addStringHeader(response,"Server","jdmfws");
     setContentType(response,"text/plain");
+    setResponseStatus(response,404,"Not Found");
     addIntHeader(response,"Content-Length",len);
     writeHeader(response);
 

--- a/c/jcsi.c
+++ b/c/jcsi.c
@@ -366,7 +366,7 @@ EntryDataSet *getHLQs(char *typesAllowed, int typesCount, int workAreaSize, char
   int pos = 0;  
   for (int i = 0; i < 29; i++){
     if (entrySets[i]->length > 0) {
-      for (int j = 0; entrySets[i]->entries[j]->name && j < entrySets[i]->length;j++){
+      for (int j = 0; j < entrySets[i]->length; j++){
         combinedEntrySet->entries[pos++]=entrySets[i]->entries[j];
       }
     }


### PR DESCRIPTION
1. httpserver uses an ASCII string as an EBCDIC string
2. Multiple bugfixes in csi code:
    -  No need to allocate DSCB1 buffers on the heap
    -  No need to check a struct field for NULL (entry->name) - it can't be NULL
    -  Use jsonAddUnterminatedString for space padded unterminated strings
    -  Fix a double free - dsn pointer derived from either an SLH or a local buffer