### PR TITLE
Warn if need TLS and TLS isnt being used

### DIFF
--- a/c/httpserver.c
+++ b/c/httpserver.c
@@ -1420,6 +1420,7 @@ static int decodeSessionToken(ShortLivedHeap *slh,
 HttpServer *makeHttpServer2(STCBase *base,
                            InetAddr *addr,
                            int port,
+                           int tlsFlags,
                            int *returnCode, int *reasonCode){
 
   SessionTokenKey sessionTokenKey = {0};
@@ -1427,7 +1428,7 @@ HttpServer *makeHttpServer2(STCBase *base,
     return NULL;
   }
 
-  Socket *listenerSocket = tcpServer(addr,port,returnCode,reasonCode);
+  Socket *listenerSocket = tcpServer2(addr,port,tlsFlags,returnCode,reasonCode);
   if (listenerSocket == NULL){
     return NULL;
   }
@@ -4854,19 +4855,17 @@ static int httpHandleTCP(STCBase *base,
 #if defined(__ZOWE_OS_ZOS) || defined(USE_RS_SSL)
       int sxStatus = sxUpdateTLSInfo(peerExtension,
                                      1); /* prevent multiple ioctl calls on repeated reads */
-  #ifdef DEBUG
       if (0 != sxStatus) {
         printf("error from sxUpdateTLSInfo: %d\n", sxStatus);
       } else if ((RS_TLS_WANT_TLS & peerExtension->tlsFlags) &&
                  (0 == (RS_TLS_HAVE_TLS & peerExtension->tlsFlags)))
       {
-        printf("WARNING: Before readWork, Want TLS and don't have it.\n");
+        printf("*** WARNING: Connection is insecure! TLS needed but not found on socket. ***\n");
       } else if ((RS_TLS_WANT_PEERCERT & peerExtension->tlsFlags) &&
                  (0 == (RS_TLS_HAVE_PEERCERT & peerExtension->tlsFlags)))
       {
-        printf("WARNING: Before readWork, Want peer certificate and don't have it.\n");
+        printf("*** WARNING: Connection is insecure! Peer certificate wanted but not found. ***\n");
       }
-  #endif
 #endif
 
   #ifdef DEBUG

--- a/c/httpserver.c
+++ b/c/httpserver.c
@@ -1524,7 +1524,7 @@ int httpServerSetSessionTokenKey(HttpServer *server, unsigned int size,
 }
 
 HttpServer *makeHttpServer(STCBase *base, int port, int *returnCode, int *reasonCode){
-  return makeHttpServer2(base, NULL, port, returnCode, reasonCode);
+  return makeHttpServer2(base, NULL, 0, port, returnCode, reasonCode);
 }
 
 int registerHttpService(HttpServer *server, HttpService *service){

--- a/h/httpserver.h
+++ b/h/httpserver.h
@@ -402,7 +402,7 @@ HttpRequest *dequeueHttpRequest(HttpRequestParser *parser);
 HttpRequestParser *makeHttpRequestParser(ShortLivedHeap *slh);
 HttpResponse *makeHttpResponse(HttpRequest *request, ShortLivedHeap *slh, Socket *socket);
 
-HttpServer *makeHttpServer2(STCBase *base, InetAddr *ip, int port, int *returnCode, int *reasonCode);
+HttpServer *makeHttpServer2(STCBase *base, InetAddr *ip, int tlsFlags, int port, int *returnCode, int *reasonCode);
 HttpServer *makeHttpServer(STCBase *base, int port, int *returnCode, int *reasonCode);
 
 #ifdef USE_RS_SSL


### PR DESCRIPTION
Because the ZSS server doesnt implement TLS of its own, if we determine that we're in a case where it is important (say, listening on external interface), then we want to alert the admin if TLS was needed but not being used. When using AT-TLS, this warning should not be seen.