### PR TITLE
Make stcbase.h and socketmgmt.h self-contained

### DIFF
--- a/h/socketmgmt.h
+++ b/h/socketmgmt.h
@@ -13,6 +13,8 @@
 #ifndef __SOCKETMGMT__
 #define __SOCKETMGMT__ 1
 
+#include "bpxnet.h"
+#include "utils.h"
 
 typedef struct SXChainElement_tag{
   char *data;

--- a/h/stcbase.h
+++ b/h/stcbase.h
@@ -32,10 +32,13 @@
   - referring to HttpServer as "struct HttpServer" is less strict than using HttpServer
  */
 
-#include "zowetypes.h"
+#include "bpxnet.h"
 #include "collections.h"
 #include "le.h"
 #include "logging.h"
+#include "socketmgmt.h"
+#include "utils.h"
+#include "zowetypes.h"
 
 #define STC_MODULE_GENERIC          0x00000000
 #define STC_MODULE_JEDHTTP          0x00010000


### PR DESCRIPTION
While working on a plugin, it was discovered that ```stcbase.h``` and ```socketmgmt.h``` could not be included by themselves. This fix adds includes headers so that ```stcbase.h``` and ```socketmgmt.h``` don't depend on the order they're included or on what other header are included (or not) before them.