### PR TITLE
Service must fail if impersonation has not been successful

### DIFF
--- a/c/httpserver.c
+++ b/c/httpserver.c
@@ -2489,6 +2489,35 @@ static int endImpersonating(HttpService *service, HttpRequest *request) {
 #endif /*__ZOWE_OS_ZOS */
 }
 
+static int isImpersonationValid(HttpService *service, int isImpersonating) {
+
+  if (!isImpersonating != !service->doImpersonation) {
+    return FALSE;
+  }
+
+  return TRUE;
+}
+
+static void reportImpersonationError(HttpService *service, int isImpersonating) {
+
+  if (!isImpersonating && service->doImpersonation) {
+    zowelog(NULL, LOG_COMP_HTTPSERVER, ZOWE_LOG_SEVERE,
+            "Error: service has no impersonation; make sure process user has "
+            "sufficient authority:\n"
+            "  z/OS: program control flag must be set, UPDATE access to "
+            "BPX.SERVER and BPX.DAEMON SAF resources is required\n"
+            "  Other platforms: impersonation is not supported\n");
+    return;
+  }
+
+  if (isImpersonating && !service->doImpersonation) {
+    zowelog(NULL, LOG_COMP_HTTPSERVER, ZOWE_LOG_SEVERE,
+            "Error: service runs with impersonation when none is required\n");
+    return;
+  }
+
+}
+
 int extractBasicAuth(HttpRequest *request, HttpHeader *authHeader){
   ShortLivedHeap *slh = request->slh;
   char *asciiHeader = authHeader->value;
@@ -2894,6 +2923,31 @@ static void serializeConsiderCloseEnqueue(HttpConversation *conversation, int su
   return;
 }
 
+static void serveRequest(HttpService* service, HttpResponse* response,
+                         HttpRequest* request) {
+
+  if ((SERVICE_TYPE_FILES == service->serviceType) ||
+      (SERVICE_TYPE_FILES_SECURE == service->serviceType)) {
+    serveFile(service, response);
+  } else if (service->serviceType == SERVICE_TYPE_PROXY) {
+    proxyServe(service, request, response);
+  } else {
+    char* serviceArgProblem = NULL;
+    if (serviceArgProblem = processServiceRequestParams(service, response)) {
+      respondWithError(response, 404, serviceArgProblem);
+      // Response is finished on return
+    } else {
+      if (service->serviceType == SERVICE_TYPE_SIMPLE_TEMPLATE) {
+        serveSimpleTemplate(service, response);
+        // Response is finished on return
+      } else {
+        service->serviceFunction(service, response);
+      }
+    }
+  }
+
+}
+
 static int handleHttpService(HttpServer *server,
                              HttpService *service,
                              HttpRequest *request,
@@ -2991,29 +3045,21 @@ static int handleHttpService(HttpServer *server,
     respondWithError(response,401,"Not Authorized");
     // Response is finished on return
   } else {
+
     int impersonating = startImpersonating(service, request);
-    if ((SERVICE_TYPE_FILES == service->serviceType) ||
-            (SERVICE_TYPE_FILES_SECURE == service->serviceType)) {
-      serveFile(service, response);
-    } else if (service->serviceType == SERVICE_TYPE_PROXY) {
-      proxyServe(service, request, response);
+
+    if (isImpersonationValid(service, impersonating)) {
+      serveRequest(service, response, request);
     } else {
-      char *serviceArgProblem = NULL;
-      if (serviceArgProblem = processServiceRequestParams(service, response)) {
-        respondWithError(response, 404, serviceArgProblem);
-        // Response is finished on return
-      } else {
-        if (service->serviceType == SERVICE_TYPE_SIMPLE_TEMPLATE) {
-          serveSimpleTemplate(service, response);
-          // Response is finished on return
-        } else {
-          service->serviceFunction(service, response);
-        }
-      }
+      reportImpersonationError(service, impersonating);
+      respondWithError(response, HTTP_STATUS_FORBIDDEN,
+                       "Impersonation error");
     }
+
     if (impersonating) {
       endImpersonating(service, request);
     }
+
   }
 #ifdef DEBUG
   printf("service=%s auth succeeded\n",service->name);


### PR DESCRIPTION
The following changes have been made:
* Return 403 if impersonation hasn't been successful
* Print an error message with possible causes of the unsuccessful impersonation
* Minor refactoring to make the impersonation logic clearer when handling a request