### PR TITLE
Add convenience function to roll up headers used for REST JSON responses

### DIFF
--- a/c/dataservice.c
+++ b/c/dataservice.c
@@ -328,6 +328,13 @@ int makeHttpDataServiceUrlMask(DataService *dataService, char *urlMaskBuffer, in
   return 0;
 }
 
+void setDefaultJSONRESTHeaders(HttpResponse *response) {
+  setContentType(response, "application/json");
+  addStringHeader(response, "Server", "jdmfws");
+  addStringHeader(response, "Transfer-Encoding", "chunked");
+  addStringHeader(response, "Cache-control", "no-store");
+  addStringHeader(response, "Pragma", "no-cache");
+}
 
 /*
   This program and the accompanying materials are

--- a/c/dataservice.c
+++ b/c/dataservice.c
@@ -328,14 +328,6 @@ int makeHttpDataServiceUrlMask(DataService *dataService, char *urlMaskBuffer, in
   return 0;
 }
 
-void setDefaultJSONRESTHeaders(HttpResponse *response) {
-  setContentType(response, "application/json");
-  addStringHeader(response, "Server", "jdmfws");
-  addStringHeader(response, "Transfer-Encoding", "chunked");
-  addStringHeader(response, "Cache-control", "no-store");
-  addStringHeader(response, "Pragma", "no-cache");
-}
-
 /*
   This program and the accompanying materials are
   made available under the terms of the Eclipse Public License v2.0 which accompanies

--- a/c/datasetjson.c
+++ b/c/datasetjson.c
@@ -1032,9 +1032,7 @@ void respondWithDataset(HttpResponse* response, char* absolutePath, int jsonMode
 
   jsonPrinter *jPrinter = respondWithJsonPrinter(response);
   setResponseStatus(response, 200, "OK");
-  setContentType(response, "text/json");
-  addStringHeader(response,"Server","jdmfws");
-  addStringHeader(response,"Transfer-Encoding","chunked");
+  setDefaultJSONRESTHeaders(response);
  
   writeHeader(response);
 
@@ -1316,9 +1314,8 @@ void respondWithVSAMDataset(HttpResponse* response, char* absolutePath, hashtabl
 
   jsonPrinter *jPrinter = respondWithJsonPrinter(response);
   setResponseStatus(response, 200, "OK");
-  setContentType(response, "text/json");
-  addStringHeader(response,"Server","jdmfws");
-  addStringHeader(response,"Transfer-Encoding","chunked");
+  setDefaultJSONRESTHeaders(response); 
+
   writeHeader(response);
 
   printf("Streaming data for %s\n", absolutePath);
@@ -1482,9 +1479,7 @@ void respondWithDatasetMetadata(HttpResponse *response) {
 
   jsonPrinter *jPrinter = respondWithJsonPrinter(response);
   setResponseStatus(response, 200, "OK");
-  setContentType(response, "text/json");
-  addStringHeader(response, "Server", "jdmfws");
-  addStringHeader(response, "Transfer-Encoding", "chunked");
+  setDefaultJSONRESTHeaders(response);
   writeHeader(response);
   char volser[7];
   memset(volser,0,7);  
@@ -1574,9 +1569,7 @@ void respondWithHLQNames(HttpResponse *response, MetadataQueryCache *metadataQue
 #ifdef __ZOWE_OS_ZOS
   HttpRequest *request = response->request;
   setResponseStatus(response, 200, "OK");
-  setContentType(response, "text/json");
-  addStringHeader(response, "Server", "jdmfws");
-  addStringHeader(response, "Transfer-Encoding", "chunked");
+  setDefaultJSONRESTHeaders(response);
   jsonPrinter *jPrinter = respondWithJsonPrinter(response);
   writeHeader(response);
   EntryDataSet *hlqSet;

--- a/c/httpfileservice.c
+++ b/c/httpfileservice.c
@@ -47,9 +47,7 @@
 
 void response200WithMessage(HttpResponse *response, char *msg) {
   setResponseStatus(response,200,"OK");
-  addStringHeader(response, "Server", "jdmfws");
-  setContentType(response, "text/json");
-  addStringHeader(response,"Transfer-Encoding","chunked");
+  setDefaultJSONRESTHeaders(response);
   addStringHeader(response,"Connection","close");
   writeHeader(response);
   jsonPrinter *out = respondWithJsonPrinter(response);
@@ -560,9 +558,7 @@ void respondWithUnixFileMetadata(HttpResponse *response, char *absolutePath) {
     jsonPrinter *out = respondWithJsonPrinter(response);
 
     setResponseStatus(response, 200, "OK");
-    setContentType(response, "text/json");
-    addStringHeader(response, "Server", "jdmfws");
-    addStringHeader(response, "Transfer-Encoding", "chunked");
+    setDefaultJSONRESTHeaders(response);
     writeHeader(response);
 
     int decimalMode = fileUnixMode(&info);

--- a/c/httpserver.c
+++ b/c/httpserver.c
@@ -3801,10 +3801,12 @@ void respondWithUnixFileNotFound(HttpResponse* response, int jsonMode) {
 void respondWithJsonError(HttpResponse *response, char *error, int statusCode, char *statusMessage) {
   jsonPrinter *out = respondWithJsonPrinter(response);
 
-  setContentType(response, "text/json");
+  setContentType(response, "application/json");
   setResponseStatus(response,statusCode,statusMessage);
   addStringHeader(response, "Server", "jdmfws");
   addStringHeader(response, "Transfer-Encoding", "chunked");
+  addStringHeader(response, "Cache-control", "no-store");
+  addStringHeader(response, "Pragma", "no-cache");
   writeHeader(response);
 
   jsonStart(out);

--- a/c/httpserver.c
+++ b/c/httpserver.c
@@ -3804,6 +3804,13 @@ void respondWithUnixFileNotFound(HttpResponse* response, int jsonMode) {
   }
 }
 
+void setDefaultJSONRESTHeaders(HttpResponse *response) {
+  setContentType(response, "application/json");
+  addStringHeader(response, "Server", "jdmfws");
+  addStringHeader(response, "Transfer-Encoding", "chunked");
+  addStringHeader(response, "Cache-control", "no-store");
+  addStringHeader(response, "Pragma", "no-cache");
+}
 
 // Response must ALWAYS be finished on return
 void respondWithJsonError(HttpResponse *response, char *error, int statusCode, char *statusMessage) {

--- a/c/httpserver.c
+++ b/c/httpserver.c
@@ -3635,6 +3635,8 @@ void respondWithUnixFile2(HttpService* service, HttpResponse* response, char* ab
 
     if (!modified) {
       setResponseStatus(response, 304, "Not modified");
+      addStringHeader(response, "Cache-control", "no-store");
+      addStringHeader(response, "Pragma", "no-cache");
       addStringHeader(response, "Server", "jdmfws");
       addCacheRelatedHeaders(response, mtime, etag);
       writeHeader(response);
@@ -3670,6 +3672,8 @@ void respondWithUnixFile2(HttpService* service, HttpResponse* response, char* ab
 
     setResponseStatus(response,200,"OK");
     addStringHeader(response,"Server","jdmfws");
+    addStringHeader(response, "Cache-control", "no-store");
+    addStringHeader(response, "Pragma", "no-cache");
     addIntHeader(response,"Content-Length",fileSize); /* Is this safe post-conversion??? */
     setContentType(response, mimeType);
     addCacheRelatedHeaders(response, mtime, etag);
@@ -3753,6 +3757,8 @@ void respondWithUnixDirectory(HttpResponse *response, char* absolutePath, int js
   fflush(stdout);
 #endif
   setResponseStatus(response,200,"OK");
+  addStringHeader(response, "Cache-control", "no-store");
+  addStringHeader(response, "Pragma", "no-cache");  
   addStringHeader(response,"Server","jdmfws");
   addStringHeader(response,"Transfer-Encoding","chunked");
   if (jsonMode == 0) {
@@ -3782,6 +3788,8 @@ void respondWithUnixFileNotFound(HttpResponse* response, int jsonMode) {
     addStringHeader(response,"Server","jdmfws");
     setContentType(response,"text/plain");
     setResponseStatus(response,404,"Not Found");
+    addStringHeader(response, "Cache-control", "no-store");
+    addStringHeader(response, "Pragma", "no-cache");
     addIntHeader(response,"Content-Length",len);
     writeHeader(response);
 
@@ -3800,13 +3808,8 @@ void respondWithUnixFileNotFound(HttpResponse* response, int jsonMode) {
 // Response must ALWAYS be finished on return
 void respondWithJsonError(HttpResponse *response, char *error, int statusCode, char *statusMessage) {
   jsonPrinter *out = respondWithJsonPrinter(response);
-
-  setContentType(response, "application/json");
   setResponseStatus(response,statusCode,statusMessage);
-  addStringHeader(response, "Server", "jdmfws");
-  addStringHeader(response, "Transfer-Encoding", "chunked");
-  addStringHeader(response, "Cache-control", "no-store");
-  addStringHeader(response, "Pragma", "no-cache");
+  setDefaultJSONRESTHeaders(response);
   writeHeader(response);
 
   jsonStart(out);

--- a/h/dataservice.h
+++ b/h/dataservice.h
@@ -83,10 +83,7 @@ void initalizeWebPlugin(WebPlugin *plugin, HttpServer *server);
 HttpService *makeHttpDataService(DataService *dataService, HttpServer *server);
 int makeHttpDataServiceUrlMask(DataService *dataService, char *urlMaskBuffer, int urlMaskBufferSize, char *productPrefix);
 
-/**
-   Convenience function to set headers specific to sending small JSON objects for a REST API
- */
-void setDefaultJSONRESTHeaders(HttpResponse *response);
+
 
 #endif /* __DATASERVICE__ */
 

--- a/h/dataservice.h
+++ b/h/dataservice.h
@@ -83,6 +83,11 @@ void initalizeWebPlugin(WebPlugin *plugin, HttpServer *server);
 HttpService *makeHttpDataService(DataService *dataService, HttpServer *server);
 int makeHttpDataServiceUrlMask(DataService *dataService, char *urlMaskBuffer, int urlMaskBufferSize, char *productPrefix);
 
+/**
+   Convenience function to set headers specific to sending small JSON objects for a REST API
+ */
+void setDefaultJSONRESTHeaders(HttpResponse *response);
+
 #endif /* __DATASERVICE__ */
 
 

--- a/h/httpserver.h
+++ b/h/httpserver.h
@@ -524,7 +524,10 @@ int streamTextForFile(Socket *socket, UnixFile *in, int encoding,
 int makeHTMLForDirectory(HttpResponse *response, char *dirname, char *stem, int includeDotted);
 int makeJSONForDirectory(HttpResponse *response, char *dirname, int includeDotted);
 
-
+/**
+   Convenience function to set headers specific to sending small JSON objects for a REST API
+ */
+void setDefaultJSONRESTHeaders(HttpResponse *response);
 
 int setHttpParseTrace(int toWhat);
 int setHttpDispatchTrace(int toWhat);


### PR DESCRIPTION
Implements https://github.com/zowe/zss/issues/11
Accomplished by adding a utility function for calling to set up some default headers. I put this in dataservice.h since its most likely to be used by dataservices. Couldn't think of a better place.

Aside from adding headers instructing receivers not to cache the results, this change also unifies the content type of json. The majority of our code used MIME "text/json", but the official MIME type is "application/json", so hopefully this improves compatibility in edge cases.