### PR TITLE
correct function prototypes: use the correct C99 form `void foo(void)`

### DIFF
--- a/c/zos.c
+++ b/c/zos.c
@@ -65,7 +65,7 @@ int testAuth(void)
 
 #define PROBLEM_STATE 0x00010000
 
-int extractPSW(){
+int extractPSW(void) {
   int highWord;
   __asm(ASM_PREFIX
         " EPSW 0,0 \n"
@@ -120,7 +120,7 @@ int setKey(int key){
   return oldKey;
 }
 
-int64 getR12(){
+int64 getR12(void) {
   int64 value;
   __asm(ASM_PREFIX
 #ifdef _LP64
@@ -135,7 +135,7 @@ int64 getR12(){
   return value;
 }
 
-int64 getR13(){
+int64 getR13(void) {
   int64 value;
   __asm(ASM_PREFIX
 #ifdef _LP64
@@ -199,64 +199,64 @@ int ddnameExists(char *ddname){
 
 /* CVT Stuff */
 
-CVT *getCVT(){
+CVT *getCVT(void) {
   int * __ptr32 mem = (int * __ptr32) 0;
   int * __ptr32 theCVT = (int * __ptr32)(*(mem+(0x10/4)));
   return (CVT*)theCVT;
 }
 
-Addr31 getATCVT(){
+Addr31 getATCVT(void) {
   int * __ptr32 mem = (int * __ptr32) 0;
   int * __ptr32 theATCVT = (int * __ptr32)(*(mem+(ATCVT_ADDRESS/4)));
   return theATCVT;
 }
 
-void *getIEACSTBL(){
+void *getIEACSTBL(void) {
   CVT *cvt = getCVT();
   return cvt->cvtcsrt;
 }
 
-cvtfix *getCVTPrefix(){
+cvtfix *getCVTPrefix(void) {
   char *theCVT = (char*)getCVT();
   return (cvtfix*)(theCVT-256);
 }
 
-ECVT *getECVT(){
+ECVT *getECVT(void) {
   CVT *cvt = getCVT();
   return (ECVT*)(cvt->cvtecvt);
 }
 
-char *getSysplexName (){
+char *getSysplexName (void) {
   ECVT *ecvt = getECVT();
   return ecvt->ecvtsplx;
 }
 
-char *getSystemName (){
+char *getSystemName (void) {
   char *ecvt = (char*)getECVT();
   return ecvt+0x158;
 }
 
-TCB *getTCB(){
+TCB *getTCB(void) {
   int *mem = (int*)0;
   return (TCB*)mem[CURRENT_TCB/sizeof(int)];
 }
 
-STCB *getSTCB(){
+STCB *getSTCB(void) {
   TCB *tcb = getTCB();
   return (STCB*)(tcb->tcbstcb);
 }
 
-OTCB *getOTCB(){
+OTCB *getOTCB(void) {
   STCB *stcb = getSTCB();
   return (OTCB*)(stcb->stcbotcb);
 }
 
-ASCB *getASCB(){
+ASCB *getASCB(void) {
   int *mem = (int*)0;
   return (ASCB*)(mem[CURRENT_ASCB/sizeof(int)]&0x7FFFFFFF);
 }
 
-ASXB *getASXB(){
+ASXB *getASXB(void) {
   ASCB *ascb = getASCB();
   return (ASXB*)ascb->ascbasxb;
 }
@@ -272,7 +272,7 @@ JSAB *getJSAB(ASCB *ascb){
   return jsab;
 }
 
-ACEE *getCurrentACEE(){
+ACEE *getCurrentACEE(void) {
   TCB *tcb = getTCB();
   ASXB *asxb = getASXB();
 

--- a/h/zos.h
+++ b/h/zos.h
@@ -40,7 +40,7 @@
 #endif
 
 
-int extractPSW();
+int extractPSW(void);
 int supervisorMode(int enable);
 int setKey(int key);
 int ddnameExists(char *ddname);
@@ -472,11 +472,11 @@ typedef struct rcvt_tag {
   char   unmapped27A[0x904-0x27A];
 } RCVT;
 
-CVT *getCVT();
-Addr31 getATCVT();
-void *getIEACSTBL();
-cvtfix *getCVTPrefix();
-ECVT *getECVT();
+CVT *getCVT(void);
+Addr31 getATCVT(void);
+void *getIEACSTBL(void);
+cvtfix *getCVTPrefix(void);
+ECVT *getECVT(void);
 
 typedef struct ocvt_tag{  /* see SYS1.MACLIB(BPXZOCVT) */
   char eyecatcher[4]; /* "OCVT" */
@@ -965,22 +965,22 @@ typedef struct JESCT_tag{
   Addr31 jesxb603; /* pointer to restart component message module (iefxb603) */
 } JESCT;
 
-TCB *getTCB();
-STCB *getSTCB();
-OTCB *getOTCB();
-ASCB *getASCB();
-ASXB *getASXB();
+TCB *getTCB(void);
+STCB *getSTCB(void);
+OTCB *getOTCB(void);
+ASCB *getASCB(void);
+ASXB *getASXB(void);
 ASSB *getASSB(ASCB *ascb);
 JSAB *getJSAB(ASCB *ascb);
 
 
-char *getSystemName ();
-char *getSysplexName();
+char *getSystemName (void);
+char *getSysplexName(void);
 
-ACEE *getCurrentACEE();
+ACEE *getCurrentACEE(void);
 TCB *getFirstChildTCB(TCB *tcb);
-TCB *getParentTCB();
-TCB *getNextSiblingTCB();
+TCB *getParentTCB(TCB *tcb);
+TCB *getNextSiblingTCB(TCB *tcb);
 
 /* TCB Tree
 
@@ -1183,8 +1183,8 @@ int safStat(int options, char *safClass, char *copy, int copyLen, int *racfStatu
 
 int getSafProfileMaxLen(char *safClass, int trace);
 
-int64 getR12();
-int64 getR13();
+int64 getR12(void);
+int64 getR13(void);
 
 void *loadByName(char *moduleName, int *statusPtr);
 


### PR DESCRIPTION
Signed-off-by: Fyodor Kovin <fkovin@rocketsoftware.com>