### PR TITLE
Staging

### DIFF
--- a/c/dataservice.c
+++ b/c/dataservice.c
@@ -328,7 +328,6 @@ int makeHttpDataServiceUrlMask(DataService *dataService, char *urlMaskBuffer, in
   return 0;
 }
 
-
 /*
   This program and the accompanying materials are
   made available under the terms of the Eclipse Public License v2.0 which accompanies

--- a/c/datasetjson.c
+++ b/c/datasetjson.c
@@ -1032,9 +1032,7 @@ void respondWithDataset(HttpResponse* response, char* absolutePath, int jsonMode
 
   jsonPrinter *jPrinter = respondWithJsonPrinter(response);
   setResponseStatus(response, 200, "OK");
-  setContentType(response, "text/json");
-  addStringHeader(response,"Server","jdmfws");
-  addStringHeader(response,"Transfer-Encoding","chunked");
+  setDefaultJSONRESTHeaders(response);
  
   writeHeader(response);
 
@@ -1316,9 +1314,8 @@ void respondWithVSAMDataset(HttpResponse* response, char* absolutePath, hashtabl
 
   jsonPrinter *jPrinter = respondWithJsonPrinter(response);
   setResponseStatus(response, 200, "OK");
-  setContentType(response, "text/json");
-  addStringHeader(response,"Server","jdmfws");
-  addStringHeader(response,"Transfer-Encoding","chunked");
+  setDefaultJSONRESTHeaders(response); 
+
   writeHeader(response);
 
   printf("Streaming data for %s\n", absolutePath);
@@ -1482,9 +1479,7 @@ void respondWithDatasetMetadata(HttpResponse *response) {
 
   jsonPrinter *jPrinter = respondWithJsonPrinter(response);
   setResponseStatus(response, 200, "OK");
-  setContentType(response, "text/json");
-  addStringHeader(response, "Server", "jdmfws");
-  addStringHeader(response, "Transfer-Encoding", "chunked");
+  setDefaultJSONRESTHeaders(response);
   writeHeader(response);
   char volser[7];
   memset(volser,0,7);  
@@ -1574,9 +1569,7 @@ void respondWithHLQNames(HttpResponse *response, MetadataQueryCache *metadataQue
 #ifdef __ZOWE_OS_ZOS
   HttpRequest *request = response->request;
   setResponseStatus(response, 200, "OK");
-  setContentType(response, "text/json");
-  addStringHeader(response, "Server", "jdmfws");
-  addStringHeader(response, "Transfer-Encoding", "chunked");
+  setDefaultJSONRESTHeaders(response);
   jsonPrinter *jPrinter = respondWithJsonPrinter(response);
   writeHeader(response);
   EntryDataSet *hlqSet;

--- a/c/httpfileservice.c
+++ b/c/httpfileservice.c
@@ -47,9 +47,7 @@
 
 void response200WithMessage(HttpResponse *response, char *msg) {
   setResponseStatus(response,200,"OK");
-  addStringHeader(response, "Server", "jdmfws");
-  setContentType(response, "text/json");
-  addStringHeader(response,"Transfer-Encoding","chunked");
+  setDefaultJSONRESTHeaders(response);
   addStringHeader(response,"Connection","close");
   writeHeader(response);
   jsonPrinter *out = respondWithJsonPrinter(response);
@@ -560,9 +558,7 @@ void respondWithUnixFileMetadata(HttpResponse *response, char *absolutePath) {
     jsonPrinter *out = respondWithJsonPrinter(response);
 
     setResponseStatus(response, 200, "OK");
-    setContentType(response, "text/json");
-    addStringHeader(response, "Server", "jdmfws");
-    addStringHeader(response, "Transfer-Encoding", "chunked");
+    setDefaultJSONRESTHeaders(response);
     writeHeader(response);
 
     int decimalMode = fileUnixMode(&info);

--- a/c/httpserver.c
+++ b/c/httpserver.c
@@ -3448,8 +3448,8 @@ char *getMimeType(char *extension, int *isBinary){
 static void respondWithUnixFileInternal(HttpResponse* response, char* absolutePath, int jsonMode, int secureFlag);
 static void respondWithUnixDirectoryInternal(HttpResponse* response, char* absolutePath, int jsonMode, int secureFlag);
 
-static void respondWithUnixFile(HttpResponse* response, char* absolutePath, int jsonMode);
-static void respondWithUnixFile2(HttpService* service, HttpResponse* response, char* absolutePath, int jsonMode, int autocvt);
+static void respondWithUnixFile(HttpResponse* response, char* absolutePath, int jsonMode, bool asB64);
+static void respondWithUnixFile2(HttpService* service, HttpResponse* response, char* absolutePath, int jsonMode, int autocvt, bool asB64);
 void respondWithUnixDirectory(HttpResponse *response, char* absolutePath, int jsonMode);
 void respondWithUnixFileSafer(HttpResponse* response, char* absolutePath, int jsonMode);
 void respondWithUnixDirectorySafer(HttpResponse* response, char* absolutePath, int jsonMode);
@@ -3482,7 +3482,7 @@ static uint64_t makeFileEtag(FileInfo *file) {
 
 // Response must ALWAYS be finished on return
 void respondWithUnixFileContents2 (HttpService* service, HttpResponse* response, char* absolutePath, int jsonMode) {
-  respondWithUnixFileContentsWithAutocvtMode(service, response, absolutePath, jsonMode, 1);
+  respondWithUnixFileContentsWithAutocvtMode(service, response, absolutePath, jsonMode, TRUE);
   // Response is finished on return
 }
 
@@ -3505,7 +3505,16 @@ void respondWithUnixFileContentsWithAutocvtMode (HttpService* service, HttpRespo
     respondWithUnixDirectory(response, absolutePath, jsonMode);
     // Response is finished on return
   } else {
-    respondWithUnixFile2(service, response, absolutePath, jsonMode, autocvt);
+    bool asB64 = TRUE;
+    char *base64Param = getQueryParam(response->request, "mode");
+
+    if (NULL != base64Param) {
+      if (!strcmp(strupcase(base64Param), "RAW")) {
+        asB64 = FALSE;
+      }
+    }
+
+    respondWithUnixFile2(service, response, absolutePath, jsonMode, autocvt, asB64);
     // Response is finished on return
   }
 }
@@ -3609,7 +3618,7 @@ bool isCachedCopyModified(HttpRequest *req, uint64_t etag, time_t mtime) {
 }
 
 // Response must ALWAYS be finished on return
-void respondWithUnixFile2(HttpService* service, HttpResponse* response, char* absolutePath, int jsonMode, int autocvt) {
+void respondWithUnixFile2(HttpService* service, HttpResponse* response, char* absolutePath, int jsonMode, int autocvt, bool asB64) {
   FileInfo info;
   int returnCode;
   int reasonCode;
@@ -3635,6 +3644,8 @@ void respondWithUnixFile2(HttpService* service, HttpResponse* response, char* ab
 
     if (!modified) {
       setResponseStatus(response, 304, "Not modified");
+      addStringHeader(response, "Cache-control", "no-store");
+      addStringHeader(response, "Pragma", "no-cache");
       addStringHeader(response, "Server", "jdmfws");
       addCacheRelatedHeaders(response, mtime, etag);
       writeHeader(response);
@@ -3646,8 +3657,7 @@ void respondWithUnixFile2(HttpService* service, HttpResponse* response, char* ab
                             FILE_OPTION_READ_ONLY,
                             0, 0,
                             &returnCode, &reasonCode);
-    if (NULL == in)
-    {
+    if (NULL == in) {
       sprintf(tmperr, "Forbidden (rc=%d, rsn=0x%x)", returnCode, reasonCode);
       if (jsonMode) {
         respondWithJsonError(response, "Forbidden", 403, tmperr);
@@ -3670,7 +3680,9 @@ void respondWithUnixFile2(HttpService* service, HttpResponse* response, char* ab
 
     setResponseStatus(response,200,"OK");
     addStringHeader(response,"Server","jdmfws");
-    addIntHeader(response,"Content-Length",fileSize); /* Is this safe post-conversion??? */
+    addStringHeader(response, "Cache-control", "no-store");
+    addStringHeader(response, "Pragma", "no-cache");
+    addIntHeader(response, "Content-Length", asB64 ? 4 * ((fileSize + 2) / 3) : fileSize); /* Is this safe post-conversion??? */
     setContentType(response, mimeType);
     addCacheRelatedHeaders(response, mtime, etag);
 
@@ -3680,13 +3692,14 @@ void respondWithUnixFile2(HttpService* service, HttpResponse* response, char* ab
       service->customHeadersFunction(service, response);
     }
 
-    if (isBinary || ccsid == -1){
+    if (isBinary || ccsid == -1) {
       writeHeader(response);
 #ifdef DEBUG
       printf("Streaming binary for %s\n", absolutePath);
 #endif
-      streamBinaryForFile(response->socket, in);
-    } else{
+      
+      streamBinaryForFile(response->socket, in, asB64);
+    } else {
       writeHeader(response);
 #ifdef DEBUG
       printf("Streaming %d for %s\n", ccsid, absolutePath);
@@ -3716,9 +3729,9 @@ void respondWithUnixFile2(HttpService* service, HttpResponse* response, char* ab
 #endif
         ;
       if (ccsid == 0) {
-        streamTextForFile(response->socket, in, ENCODING_SIMPLE, NATIVE_CODEPAGE, webCodePage);
+        streamTextForFile(response->socket, in, ENCODING_SIMPLE, NATIVE_CODEPAGE, webCodePage, asB64);
       } else {
-        streamTextForFile(response->socket, in, ENCODING_SIMPLE, ccsid, webCodePage);
+        streamTextForFile(response->socket, in, ENCODING_SIMPLE, ccsid, webCodePage, asB64);
       }
 
 #ifdef USE_CONTINUE_RESPONSE_HACK
@@ -3741,8 +3754,8 @@ void respondWithUnixFile2(HttpService* service, HttpResponse* response, char* ab
 }
 
 // Response must ALWAYS be finished on return
-void respondWithUnixFile(HttpResponse* response, char* absolutePath, int jsonMode) {
-  respondWithUnixFile2(NULL, response, absolutePath, jsonMode, 1);
+void respondWithUnixFile(HttpResponse* response, char* absolutePath, int jsonMode, bool asB64) {
+  respondWithUnixFile2(NULL, response, absolutePath, jsonMode, 1, asB64);
   // Response is finished on return
 }
 
@@ -3753,6 +3766,8 @@ void respondWithUnixDirectory(HttpResponse *response, char* absolutePath, int js
   fflush(stdout);
 #endif
   setResponseStatus(response,200,"OK");
+  addStringHeader(response, "Cache-control", "no-store");
+  addStringHeader(response, "Pragma", "no-cache");  
   addStringHeader(response,"Server","jdmfws");
   addStringHeader(response,"Transfer-Encoding","chunked");
   if (jsonMode == 0) {
@@ -3782,6 +3797,8 @@ void respondWithUnixFileNotFound(HttpResponse* response, int jsonMode) {
     addStringHeader(response,"Server","jdmfws");
     setContentType(response,"text/plain");
     setResponseStatus(response,404,"Not Found");
+    addStringHeader(response, "Cache-control", "no-store");
+    addStringHeader(response, "Pragma", "no-cache");
     addIntHeader(response,"Content-Length",len);
     writeHeader(response);
 
@@ -3796,15 +3813,19 @@ void respondWithUnixFileNotFound(HttpResponse* response, int jsonMode) {
   }
 }
 
+void setDefaultJSONRESTHeaders(HttpResponse *response) {
+  setContentType(response, "application/json");
+  addStringHeader(response, "Server", "jdmfws");
+  addStringHeader(response, "Transfer-Encoding", "chunked");
+  addStringHeader(response, "Cache-control", "no-store");
+  addStringHeader(response, "Pragma", "no-cache");
+}
 
 // Response must ALWAYS be finished on return
 void respondWithJsonError(HttpResponse *response, char *error, int statusCode, char *statusMessage) {
   jsonPrinter *out = respondWithJsonPrinter(response);
-
-  setContentType(response, "text/json");
   setResponseStatus(response,statusCode,statusMessage);
-  addStringHeader(response, "Server", "jdmfws");
-  addStringHeader(response, "Transfer-Encoding", "chunked");
+  setDefaultJSONRESTHeaders(response);
   writeHeader(response);
 
   jsonStart(out);
@@ -3814,12 +3835,15 @@ void respondWithJsonError(HttpResponse *response, char *error, int statusCode, c
   finishResponse(response);
 }
 
-int streamBinaryForFile(Socket *socket, UnixFile *in){
+#define ENCODE64_SIZE(SZ) (2 + 4 * ((SZ + 2) / 3))
+
+int streamBinaryForFile(Socket *socket, UnixFile *in, bool asB64) {
   int returnCode = 0;
   int reasonCode = 0;
   char buffer[FILE_STREAM_BUFFER_SIZE+4];
+  int encodedLength;
 
-  while (!fileEOF(in)){
+  while (!fileEOF(in)) {
     int bytesRead = fileRead(in,buffer,FILE_STREAM_BUFFER_SIZE,&returnCode,&reasonCode);
     if (bytesRead <= 0) {
       zowelog(NULL, LOG_COMP_HTTPSERVER, ZOWE_LOG_DEBUG2,
@@ -3827,19 +3851,28 @@ int streamBinaryForFile(Socket *socket, UnixFile *in){
               returnCode, reasonCode);
       return 0;
     }
-    writeFully(socket,buffer,bytesRead);
+
+    char *encodedBuffer = NULL;
+    if (asB64) {
+      encodedBuffer = encodeBase64(NULL, buffer, bytesRead, &encodedLength, FALSE);
+    }
+    char *outPtr = asB64 ? encodedBuffer : buffer;
+    int outLen = asB64 ? encodedLength : bytesRead;
+    writeFully(socket, outPtr, outLen);
+    if (NULL != encodedBuffer) safeFree31(encodedBuffer, ENCODE64_SIZE(bytesRead)+1);
   }
 
   return 0;
 }
   
 int streamTextForFile(Socket *socket, UnixFile *in, int encoding,
-                      int sourceCCSID, int targetCCSID){
+                      int sourceCCSID, int targetCCSID, bool asB64) {
   int returnCode = 0;
   int reasonCode = 0;
   int bytesSent = 0;
   char buffer[FILE_STREAM_BUFFER_SIZE+4];
   char translation[(2*FILE_STREAM_BUFFER_SIZE)+4]; /* UTF inflation tolerance */
+  int encodedLength;
 
 
   /* Q: How do we find character encoding for unix file? 
@@ -3891,11 +3924,11 @@ int streamTextForFile(Socket *socket, UnixFile *in, int encoding,
                             &reasonCode);
 
         if (inLen != translationLength) {
-          printf("streamTextForFile(%d (%s), %d (%s), %d, %d, %d): "
+          printf("streamTextForFile(%d (%s), %d (%s), %d, %d, %d, %d): "
                  "after sending %d bytes got translation length error; expected %d, got %d\n",
                  socket->sd, socket->debugName, 
                  in->fd, in->pathname,
-                 encoding, sourceCCSID, targetCCSID, bytesSent, inLen, translationLength);
+                 encoding, sourceCCSID, targetCCSID, asB64, bytesSent, inLen, translationLength);
         }
         if (TRACE_CHARSET_CONVERSION){
           printf("convertCharset transLen=%d\n",translationLength);
@@ -3910,8 +3943,17 @@ int streamTextForFile(Socket *socket, UnixFile *in, int encoding,
         outPtr = translation;
         outLen = (unsigned int) translationLength;
       }
+      int allocSize = 0;
+      char *encodedBuffer = NULL;
+      if (asB64) {
+        allocSize = ENCODE64_SIZE(outLen)+1;
+        encodedBuffer = encodeBase64(NULL, outPtr, outLen, &encodedLength, FALSE);
+        outPtr = encodedBuffer;
+        outLen = encodedLength;
+      }
       writeFully(socket,outPtr,(int) outLen);
-      bytesSent += outLen;
+      if (NULL != encodedBuffer) safeFree31(encodedBuffer, allocSize);
+      bytesSent += encodedLength;
     }
     break;
   case ENCODING_CHUNKED:
@@ -3926,10 +3968,10 @@ int streamTextForFile(Socket *socket, UnixFile *in, int encoding,
     break;
   }
   if (traceSocket > 0) {
-    printf("streamTextForFile(%d (%s), %d (%s), %d, %d, %d) sent %d bytes\n",
+    printf("streamTextForFile(%d (%s), %d (%s), %d, %d, %d, %d) sent %d bytes\n",
            socket->sd, socket->debugName, 
            in->fd, in->pathname,
-           encoding, sourceCCSID, targetCCSID, bytesSent);
+           encoding, sourceCCSID, targetCCSID, asB64, bytesSent);
   }
   return 1;
 }

--- a/h/dataservice.h
+++ b/h/dataservice.h
@@ -83,6 +83,8 @@ void initalizeWebPlugin(WebPlugin *plugin, HttpServer *server);
 HttpService *makeHttpDataService(DataService *dataService, HttpServer *server);
 int makeHttpDataServiceUrlMask(DataService *dataService, char *urlMaskBuffer, int urlMaskBufferSize, char *productPrefix);
 
+
+
 #endif /* __DATASERVICE__ */
 
 

--- a/h/httpserver.h
+++ b/h/httpserver.h
@@ -518,13 +518,16 @@ int registerHttpService(HttpServer *server, HttpService *service);
 int registerHttpServiceOfLastResort(HttpServer *server, HttpService *service);
 int processHttpFragment(HttpRequestParser *parser, char *data, int len);
 int mainHttpLoop(HttpServer *server);
-int streamBinaryForFile(Socket *socket, UnixFile *in);
+int streamBinaryForFile(Socket *socket, UnixFile *in, bool asB64);
 int streamTextForFile(Socket *socket, UnixFile *in, int encoding,
-                      int sourceCCSID, int targetCCSID);
+                      int sourceCCSID, int targetCCSID, bool asB64);
 int makeHTMLForDirectory(HttpResponse *response, char *dirname, char *stem, int includeDotted);
 int makeJSONForDirectory(HttpResponse *response, char *dirname, int includeDotted);
 
-
+/**
+   Convenience function to set headers specific to sending small JSON objects for a REST API
+ */
+void setDefaultJSONRESTHeaders(HttpResponse *response);
 
 int setHttpParseTrace(int toWhat);
 int setHttpDispatchTrace(int toWhat);


### PR DESCRIPTION
Changed default behavior of /unixfile/contents/ to return Base64 Encoded bytes of the file.

**DO NOT MERGE THIS UNTIL THE FOLLOWING IS RESOLVED**
- [ ] File Transfer App needs to ask for "mode=raw" to get raw bytes again.
- [ ] File Editor needs to Base64 Decode the byte stream before displaying on the screen.
- [ ] Other users of /unixfile/ API need to be modified similarly.