### PR TITLE
Update the z/OS version check to support z/OS 2.4

### DIFF
--- a/c/le.c
+++ b/c/le.c
@@ -107,7 +107,7 @@ char *getCAA(){
 }
 
 #ifndef LE_MAX_SUPPORTED_ZOS
-#define LE_MAX_SUPPORTED_ZOS 0x01020300u
+#define LE_MAX_SUPPORTED_ZOS 0x01020400u
 #endif
 
 void abortIfUnsupportedCAA() {


### PR DESCRIPTION
There is an OS version check that prevents the LE related code from running on an unsupported z/OS version. This protects the code from using CAA incorrectly in case it gets updates with the OS. The current version is 2.3, this pull-request updates the corresponding ```#define``` to use the 2.4 value.

Fixes zowe/zss#15
