### PR TITLE
Add BPXPOL to open-source library; poll on socket before BPXWRT

### DIFF
--- a/c/fdpoll.c
+++ b/c/fdpoll.c
@@ -1,0 +1,48 @@
+#include "fdpoll.h"
+
+#ifdef __ZOWE_OS_ZOS
+#ifdef _LP64
+
+#pragma linkage(BPX4POL,OS)
+#define BPXPOL BPX4POL
+
+#else
+
+#pragma linkage(BPX1POL,OS)
+#define BPXPOL BPX1POL
+
+#endif
+
+int fdPoll(PollItem* fds, short nmqs, short nfds, int timeout, int *returnCode, int *reasonCode) {
+  int returnValue;
+  int *reasonCodePtr;
+
+#ifndef _LP64
+  reasonCodePtr = (int*) (0x80000000 | ((int)reasonCode));
+#else
+  reasonCodePtr = reasonCode;
+#endif
+
+  int counts = (nmqs << 16) | nfds;
+
+  BPXPOL(&fds,
+         &counts,
+         &timeout,
+         &returnValue,
+         returnCode,
+         reasonCodePtr);
+
+  return returnValue;
+}
+#elif defined(__ZOWE_OS_LINUX)
+#include <errno.h>
+
+int fdPoll(PollItem* fds, short nmqs, short nfds, int timeout, int *returnCode, int *reasonCode) {
+  int status = poll(fds, nfds, timeout);
+  *returnCode = *reasonCode = (status >= 0 ? 0 : errno);
+  return status;
+}
+
+#else
+#error No implemention for fdpoll.h
+#endif

--- a/h/fdpoll.h
+++ b/h/fdpoll.h
@@ -1,0 +1,50 @@
+#ifndef __ZOWE_FDPOLL_
+#define __ZOWE_FDPOLL_ 1
+
+#include "zowetypes.h"
+
+#ifdef __ZOWE_OS_ZOS
+#define POLLEPRI         0x0010
+#define POLLEWRBAND      0x0008
+#define POLLEWRNORM      0x0004
+#define POLLEOUT         0x0004
+#define POLLEIN          0x0003
+#define POLLERDBAND      0x0002
+#define POLLERDNORM      0x0001
+
+#define POLLRNVAL        0x0080
+#define POLLRHUP         0x0040
+#define POLLRERR         0x0020
+#define POLLRPRI         0x0010
+#define POLLRWRBAND      0x0008
+#define POLLRWRNORM      0x0004
+#define POLLROUT         0x0004
+#define POLLRIN          0x0003
+#define POLLRRDBAND      0x0002
+#define POLLRRDNORM      0x0001
+
+typedef struct PollItem_tag {
+  int fd; /* or mq, on z/OS only... */
+  short events;
+  short revents;
+} PollItem;
+
+#elif defined(__ZOWE_OS_LINUX)
+#include <poll.h>
+typedef struct pollfd PollItem;
+
+#define POLLEIN  POLLIN
+#define POLLRIN  POLLIN
+#define POLLEOUT POLLOUT
+#define POLLROUT POLLOUT
+#define POLLRHUP POLLHUP
+
+#else
+#error Unknown OS
+#endif
+
+
+/* File descriptor items must precede message queue items. */
+int fdPoll(PollItem* fds, short nmqs, short nfds, int timeout, int *returnCode, int *reasonCode);
+
+#endif


### PR DESCRIPTION
This should help the performance of downloading files by eliminating the constant failed BPXWRT calls when attemping to write to a full socket.