### PR TITLE
Fix variable passing in getSTCK() and getSTCKU()

### DIFF
--- a/c/timeutls.c
+++ b/c/timeutls.c
@@ -83,11 +83,7 @@ void getSTCK(int64 *stckPtr){
 
   __asm(ASM_PREFIX
         " STCK %0 "
-        :
-        :
-        "m"(stck)
-        :
-        "r15");
+        :"=m"(stck));
   *stckPtr = stck;
 }
 
@@ -96,11 +92,7 @@ void getSTCKU(uint64 *stckPtr){
 
   __asm(ASM_PREFIX
         " STCK %0 "
-        :
-        :
-        "m"(stck)
-        :
-        "r15");
+        :"=m"(stck));
   *stckPtr = stck;
 }
 


### PR DESCRIPTION
The output variable was passed to the asm block as an input variable
instead, thus with some compile options (not always!) the function
failed to produce an output.

Second part of what used to be https://github.com/zowe/zowe-common-c/pull/29