### PR TITLE
ISGENQ wrapper fixes/improvements:

### DIFF
--- a/h/crossmemory.h
+++ b/h/crossmemory.h
@@ -15,6 +15,7 @@
 
 #ifdef METTLE
 #include <metal/metal.h>
+#include <metal/stddef.h>
 #include <metal/stdlib.h>
 #else
 #include <stdlib.h>

--- a/h/isgenq.h
+++ b/h/isgenq.h
@@ -63,6 +63,9 @@ int isgenqTestLock(const QName *qname,
 
 int isgenqReleaseLock(ENQToken *token, int *reasonCode);
 
+#define IS_ISGENQ_LOCK_OBTAINED($isgenqRC, $isgenqRSN) \
+    ($isgenqRC <= 4 && ((unsigned)$isgenqRSN & 0xFFFF) != 0x0404)
+
 #endif /* H_ISGENQ_H_ */
 
 


### PR DESCRIPTION
- IS_ISGENQ_LOCK_OBTAINED macro
- Workaround for a bug in the Metal headers

First part of what used to be https://github.com/zowe/zowe-common-c/pull/29