### PR TITLE
Dataset eof bug

### DIFF
--- a/c/datasetjson.c
+++ b/c/datasetjson.c
@@ -90,7 +90,6 @@ int streamDataset(Socket *socket, char *filename, int recordLength, jsonPrinter 
         contentLength = contentLength + bytesRead;
       }
       else if (bytesRead == 0){
-        printf("Reached end of dataset\n");
         break;
       }
       else {

--- a/c/datasetjson.c
+++ b/c/datasetjson.c
@@ -79,19 +79,23 @@ int streamDataset(Socket *socket, char *filename, int recordLength, jsonPrinter 
   char buffer[bufferSize];
   memset(buffer,0,bufferSize);
   jsonStartArray(jPrinter,"records");
-
   int contentLength = 0;
   int bytesRead = 0;
   if (in) {
-      while (!feof(in)){      
+      while (!feof(in)){
         bytesRead = fread(buffer,1,recordLength,in);
-        memset(buffer+bytesRead,0,recordLength-bytesRead);
-        jsonAddString(jPrinter, NULL, buffer);
-        if (bytesRead < 0 && ferror(in)){
-          printf("Error reading DSN=%s, rc=%d\n",filename,bytesRead);
-        }
-        else{
+		if (bytesRead > 0){
+          memset(buffer+bytesRead,0,recordLength-bytesRead);
+          jsonAddString(jPrinter, NULL, buffer);
           contentLength = contentLength + bytesRead;
+		}
+		else if (bytesRead == 0){
+          printf("Reached end of dataset\n");
+          break;
+		}
+		else {
+          printf("Error reading DSN=%s, rc=%d\n",filename,bytesRead);
+		  break;
         }
       }
       fclose(in);

--- a/c/datasetjson.c
+++ b/c/datasetjson.c
@@ -82,23 +82,23 @@ int streamDataset(Socket *socket, char *filename, int recordLength, jsonPrinter 
   int contentLength = 0;
   int bytesRead = 0;
   if (in) {
-      while (!feof(in)){
-        bytesRead = fread(buffer,1,recordLength,in);
-		if (bytesRead > 0){
-          memset(buffer+bytesRead,0,recordLength-bytesRead);
-          jsonAddString(jPrinter, NULL, buffer);
-          contentLength = contentLength + bytesRead;
-		}
-		else if (bytesRead == 0){
-          printf("Reached end of dataset\n");
-          break;
-		}
-		else {
-          printf("Error reading DSN=%s, rc=%d\n",filename,bytesRead);
-		  break;
-        }
+    while (!feof(in)){
+      bytesRead = fread(buffer,1,recordLength,in);
+      if (bytesRead > 0){
+        memset(buffer+bytesRead,0,recordLength-bytesRead);
+        jsonAddString(jPrinter, NULL, buffer);
+        contentLength = contentLength + bytesRead;
       }
-      fclose(in);
+      else if (bytesRead == 0){
+        printf("Reached end of dataset\n");
+        break;
+      }
+      else {
+        printf("Error reading DSN=%s, rc=%d\n",filename,bytesRead);
+        break;
+      }
+    }
+    fclose(in);
   }
   else {
       printf("FAILED TO OPEN FILE\n");


### PR DESCRIPTION
While reading in lines from the dataset, the function streamDataset() did not check if an entry was of size 0 (indicating end of file). By adding a conditional check, the extra blank line is no longer printed.