### PR TITLE
Dynaically grow the JSON tokenizer buffer

### DIFF
--- a/c/alloc.c
+++ b/c/alloc.c
@@ -622,6 +622,20 @@ void safeFree(char *data, int size){
   safeFree31(data,size);
 }
 
+void *safeRealloc(void *ptr, int32_t size, int32_t oldSize, char *site) {
+  void *new;
+
+  new = safeMalloc(size, site);
+  if (new == NULL) {
+    return NULL;
+  }
+  if ((ptr != NULL) && (oldSize > 0)) {
+    memmove(new, ptr, oldSize);
+    safeFree(ptr, oldSize);
+  }
+  return new;
+}
+
 #ifdef __ZOWE_OS_ZOS
 
 #ifdef METTLE
@@ -1088,7 +1102,6 @@ int safeFree64v3(void *data, unsigned long long size, int *sysRC, int *sysRSN) {
 
 #endif /* END of METTLE */
 #endif /* END of __ZOWE_OS_ZOS */
-
 
 /*
   This program and the accompanying materials are

--- a/c/json.c
+++ b/c/json.c
@@ -720,6 +720,10 @@ int jsonCheckIOErrorFlag(jsonPrinter *p) {
 #define JSON_TOKEN_BUFFER_SIZE  16384
 #endif
 
+#ifndef JSON_TOKEN_BUFFER_SIZE_LIMIT
+#define JSON_TOKEN_BUFFER_SIZE_LIMIT  104857600 /* 100 MB (for one token) */
+#endif
+
 typedef struct JsonParser_tag JsonParser;
 typedef struct JsonTokenizer_tag JsonTokenizer;
 typedef struct JsonToken_tag JsonToken;
@@ -953,6 +957,25 @@ void jsonParseFail(JsonParser *parser, char *formatString, ...) {
   }
 }
 
+static int
+jsonTokenizerGrowBuffer(JsonTokenizer *t) {
+  if (t->bufferSize >= INT32_MAX / 2) {
+    return -1;
+  }
+  int newSize = 2 * t->bufferSize;
+  if (newSize >= JSON_TOKEN_BUFFER_SIZE_LIMIT) {
+    return -1;
+  }
+  void *newBuffer = safeRealloc(t->buffer, newSize,
+      t->bufferSize, "JSON token buffer");
+  if (newBuffer == NULL) {
+    return -1;
+  }
+  t->buffer = newBuffer;
+  t->bufferSize = newSize;
+  return 0;
+}
+
 static 
 int jsonTokenizerRead(JsonTokenizer *t) {
   if (t->unreadChar != 0) {
@@ -1004,7 +1027,6 @@ JsonToken *makeJsonToken(JsonTokenizer* tokenizer, int type, char *text) {
 
 static 
 JsonToken *getStringToken(JsonTokenizer *tokenizer) {
-  char *buffer = tokenizer->buffer;
   int pos = 0;
   int badString = FALSE;
   
@@ -1020,36 +1042,46 @@ JsonToken *getStringToken(JsonTokenizer *tokenizer) {
     } else if (lookahead == '\\') {
       int backSlash = jsonTokenizerRead(tokenizer);
       int c = jsonTokenizerRead(tokenizer);
-      if (pos < tokenizer->bufferSize) {
-        switch (c) {
-          case 'b':
-            buffer[pos++] = '\b';
-            break;
-          case 'n':
-            buffer[pos++] = '\n';
-            break;
-          case 'f':
-            buffer[pos++] = '\f';
-            break;
-          case 'r':
-            buffer[pos++] = '\r';
-            break;
-          case 't':
-            buffer[pos++] = '\t';
-            break;
-          default:
-            buffer[pos++] = c;
+      if (pos >= tokenizer->bufferSize) {
+        int growRc = jsonTokenizerGrowBuffer(tokenizer);
+        if (growRc < 0) {
+          break;
         }
+      }
+      switch (c) {
+        case 'b':
+          tokenizer->buffer[pos++] = '\b';
+          break;
+        case 'n':
+          tokenizer->buffer[pos++] = '\n';
+          break;
+        case 'f':
+          tokenizer->buffer[pos++] = '\f';
+          break;
+        case 'r':
+          tokenizer->buffer[pos++] = '\r';
+          break;
+        case 't':
+          tokenizer->buffer[pos++] = '\t';
+          break;
+        default:
+          tokenizer->buffer[pos++] = c;
       }
     } else {
       int c = jsonTokenizerRead(tokenizer);
-      if (isprint(c) && pos < tokenizer->bufferSize) {
-        buffer[pos++] = c;
+      if (isprint(c)) {
+        if (pos >= tokenizer->bufferSize) {
+          int growRc = jsonTokenizerGrowBuffer(tokenizer);
+          if (growRc < 0) {
+            break;
+          }
+        }
+        tokenizer->buffer[pos++] = c;
       }
     }
   }
   char *text = jsonTokenizerAlloc(tokenizer, pos + 1);
-  memcpy(text, buffer, pos);
+  memcpy(text, tokenizer->buffer, pos);
   if (badString) {
     return makeJsonToken(tokenizer, JSON_TOKEN_UNTERMINATED_STRING, text);
   } else {

--- a/h/alloc.h
+++ b/h/alloc.h
@@ -70,6 +70,8 @@ char *safeMalloc64ByToken(int size, char *site, long long token);
 void safeFree64(char *data, int size);
 void safeFree64ByToken(char *data, int size, long long token);
 
+void *safeRealloc(void *ptr, int32_t size, int32_t oldSize, char *site);
+
 #if defined(__ZOWE_OS_ZOS)
 /* 64-bit allocator and de-allocator v2. */
 char *safeMalloc64v2(unsigned long long size, int zeroOut, char *site,


### PR DESCRIPTION
The buffer used to be fixed size. Now it grows dynamically up to a
compile time specified limit.

