### PR TITLE
change `int32_t` to `int` in `safeRealloc()`

### DIFF
--- a/c/alloc.c
+++ b/c/alloc.c
@@ -622,7 +622,7 @@ void safeFree(char *data, int size){
   safeFree31(data,size);
 }
 
-void *safeRealloc(void *ptr, int32_t size, int32_t oldSize, char *site) {
+void *safeRealloc(void *ptr, int size, int oldSize, char *site) {
   void *new;
 
   new = safeMalloc(size, site);

--- a/h/alloc.h
+++ b/h/alloc.h
@@ -70,7 +70,7 @@ char *safeMalloc64ByToken(int size, char *site, long long token);
 void safeFree64(char *data, int size);
 void safeFree64ByToken(char *data, int size, long long token);
 
-void *safeRealloc(void *ptr, int32_t size, int32_t oldSize, char *site);
+void *safeRealloc(void *ptr, int size, int oldSize, char *site);
 
 #if defined(__ZOWE_OS_ZOS)
 /* 64-bit allocator and de-allocator v2. */


### PR DESCRIPTION
The header used `int32_t` but didn't include stdint or zowetypes.

That broke the compile for some files which either didn't include 
stdint/zowetypes, or included alloc.h before stdint/zowetypes.

Since `int32_t` and `int` are abosultely the same in all of our use
cases, the simper thing is to change the types to int (like the
rest of the functions in the file)

Signed-off-by: Fyodor Kovin <fkovin@rocketsoftware.com>