### PR TITLE
[WIP] New query parameter for inclusion additional qualifiers

### DIFF
--- a/c/datasetjson.c
+++ b/c/datasetjson.c
@@ -1776,18 +1776,14 @@ void respondWithDatasetMetadata(HttpResponse *response) {
     printf("dsn: %s\nperiod pos: %d\nasterisk pos: %d\ndblAsterisk pos: %d\n dsn len: %d\n", dsn, periodPos, asteriskPos, dblAsteriskPos, dsnLen);
 	  if(asteriskPos < 0 && dblAsteriskPos < 0){
       if(periodPos < 0 || periodPos != dsnLen - 1){ //-1 for null terminator.  Query in form of hlq1.hlq2
-        printf("lol\n");
         count = snprintf(dsn, DSN_MAX_LEN + 1, "%s.**", dsn);
 		  }else if(periodPos == dsnLen - 1){ //not sure if this case is ever valid, trailing periods seem to be truncated
-        printf("lmao\n");
         count = snprintf(dsn, DSN_MAX_LEN + 1, "%s**", dsn);
 		  }
 	  }else{
       if(asteriskPos == dsnLen - 1 && periodPos != asteriskPos - 1 && dblAsteriskPos < 0){ //query in form of hlq1.hlq2*
-        printf("Appending period dbl asterisk\n");
         count = snprintf(dsn, DSN_MAX_LEN + 1, "%s.**", dsn); 
       }else if(asteriskPos == dsnLen - 1 && periodPos == asteriskPos - 1){
-        printf("ayy lmao\n");
         count = snprintf(dsn, DSN_MAX_LEN + 1, "%s*", dsn);
       }
 	  }


### PR DESCRIPTION
Added new request parameter indicating whether or not to include additional qualifiers for dataset searches.  Modified query input to more closely represent 3.4 searching

Do not merge without:
https://github.com/zowe/zss/pull/75

Related to:
https://github.com/zowe/zlux-platform/pull/34
https://github.com/zowe/zlux-app-manager/pull/138
https://github.com/zowe/zlux-file-explorer/pull/33

Signed-off-by: Timothy Gerstel <tim.gerstel@gmail.com>