### PR TITLE
500 for delete is 400 to differentiate server failure

### DIFF
--- a/c/httpfileservice.c
+++ b/c/httpfileservice.c
@@ -68,15 +68,12 @@ bool isDir(char *absolutePath) {
   FileInfo info = {0};
 
   status = fileInfo(absolutePath, &info, &returnCode, &reasonCode);
-  if (status == -1) {
-    return -1;
-  }
 
   return (fileInfoIsDirectory(&info));
 }
 
 /* Returns a boolean value for whether or not
- * the specified file exists.
+ * the specified file/directory exists.
  */
 bool doesFileExist(char *absolutePath) {
   int returnCode = 0, reasonCode = 0, status = 0;  
@@ -160,7 +157,7 @@ void deleteUnixDirectoryAndRespond(HttpResponse *response, char *absolutePath) {
     response200WithMessage(response, "Successfully deleted a directory");
   }
   else {
-    respondWithJsonError(response, "Failed to delete a directory", 500, "Internal Server Error");
+    respondWithJsonError(response, "Failed to delete a directory", 400, "Bad Request");
   }
 }
 
@@ -195,7 +192,7 @@ void deleteUnixFileAndRespond(HttpResponse *response, char *absolutePath) {
     response200WithMessage(response, "Successfully deleted a file");
   }
   else {
-    respondWithJsonError(response, "Failed to delete a file", 500, "Internal Server Error");
+    respondWithJsonError(response, "Failed to delete a file", 400, "Bad Request");
   }
 }
 


### PR DESCRIPTION
- Reorganized logic to use boolean better and changed a 500 to a 400 to better differentiate a probable permission problem from a general server error.

For some reason, Git closed my previous pull request when I pushed to the same branch. Original comments, suggestions, and then fixes were previously addressed here: https://github.com/zowe/zowe-common-c/pull/89

Signed-off-by: Leanid Astrakou <lastrakou@rocketsoftware.com>