### PR TITLE
Add the ability to skip SAF check for privileged callers of a cross memory server.

### DIFF
--- a/c/crossmemory.c
+++ b/c/crossmemory.c
@@ -1028,15 +1028,12 @@ static uint64_t getCallersPSW(void) {
 
 static bool isCallerPrivileged(void) {
 
-#define CMS_PSW_USER_KEY_MASK       0x0080000000000000LLU
-#define CMS_PSW_PROBLEM_STATE_MASK  0x0001000000000000LLU
+static const uint64_t pswUserKeyMask        = 0x0080000000000000LLU;
+static const uint64_t pswProblemStateMask   = 0x0001000000000000LLU;
 
   uint64_t psw = getCallersPSW();
-  bool isSystemKey        = (psw & CMS_PSW_USER_KEY_MASK)       ? false : true;
-  bool isSupervisorState  = (psw & CMS_PSW_PROBLEM_STATE_MASK)  ? false : true;
-
-#undef CMS_PSW_USER_KEY_MASK
-#undef CMS_PSW_PROBLEM_STATE_MASK
+  bool isSystemKey        = (psw & pswUserKeyMask)      ? false : true;
+  bool isSupervisorState  = (psw & pswProblemStateMask) ? false : true;
 
   return isSystemKey || isSupervisorState;
 }

--- a/c/crossmemory.c
+++ b/c/crossmemory.c
@@ -1136,11 +1136,15 @@ static bool isInternalPCSSCall(CrossMemoryServerGlobalArea *globalArea) {
   return globalArea->serverASID == getMyPASID() && globalArea->serverASID == getMySASID();
 }
 
+static bool isAuthCheckRequired(const CrossMemoryServerGlobalArea *globalArea) {
+  return globalArea->serverFlags & CROSS_MEMORY_SERVER_FLAG_CHECKAUTH;
+}
+
 static bool isCallerAuthorized(CrossMemoryServerGlobalArea *globalArea,
                                bool noSAFRequested) {
 
   if (noSAFRequested) {
-    if (isCallerPrivileged()) {
+    if (isCallerPrivileged() && !isAuthCheckRequired(globalArea)) {
       return TRUE;
     }
   }
@@ -1938,6 +1942,9 @@ CrossMemoryServer *makeCrossMemoryServer2(
   }
   if (flags & CMS_SERVER_FLAG_COLD_START) {
     server->flags |= CROSS_MEMORY_SERVER_FLAG_COLD_START;
+  }
+  if (flags & CMS_SERVER_FLAG_CHECKAUTH) {
+    server->flags |= CROSS_MEMORY_SERVER_FLAG_CHECKAUTH;
   }
 
   int allocResourcesRC = allocServerResources(server);

--- a/h/crossmemory.h
+++ b/h/crossmemory.h
@@ -284,6 +284,7 @@ typedef struct CrossMemoryServer_tag {
 #define CROSS_MEMORY_SERVER_FLAG_READY        0x00000002
 #define CROSS_MEMORY_SERVER_FLAG_TERM_STARTED 0x00000004
 #define CROSS_MEMORY_SERVER_FLAG_TERM_ENDED   0x00000008
+#define CROSS_MEMORY_SERVER_FLAG_CHECKAUTH    0x00000010
   STCBase * __ptr32 base;
   CMSStarCallback * __ptr32 startCallback;
   CMSStopCallback * __ptr32 stopCallback;
@@ -377,6 +378,7 @@ ZOWE_PRAGMA_PACK_RESET
 #define CMS_SERVER_FLAG_NONE                  0x00000000
 #define CMS_SERVER_FLAG_COLD_START            0x00000001
 #define CMS_SERVER_FLAG_DEBUG                 0x00000002
+#define CMS_SERVER_FLAG_CHECKAUTH             0x00000004
 
 #define CMS_SERVICE_FLAG_NONE                 0x00000000
 #define CMS_SERVICE_FLAG_SPACE_SWITCH         0x00000001

--- a/h/crossmemory.h
+++ b/h/crossmemory.h
@@ -315,7 +315,10 @@ typedef struct CrossMemoryServerParmList_tag {
   CrossMemoryServerName serverName;
   int serviceID;
   int serviceRC;
-  int reserved;
+  char reserved[2];
+  uint16_t flags;
+#define CMS_PARMLIST_FLAG_NONE            0x0000
+#define CMS_PARMLIST_FLAG_NO_SAF_CHECK    0x0001
   PAD_LONG(1, void *callerData);
 } CrossMemoryServerParmList;
 
@@ -358,6 +361,7 @@ ZOWE_PRAGMA_PACK_RESET
 #define cmsAddConfigParm CMADDPRM
 #define cmsCallService CMCMSRCS
 #define cmsCallService2 CMCALLS2
+#define cmsCallService3 CMCALLS3
 #define cmsPrintf CMCMSPRF
 #define cmsGetConfigParm CMGETPRM
 #define cmsGetPCLogLevel CMGETLOG
@@ -409,10 +413,16 @@ void cmsAllocateECSAStorage2(CrossMemoryServerGlobalArea *globalArea,
 void cmsFreeECSAStorage2(CrossMemoryServerGlobalArea *globalArea,
                          void **dataPtr, unsigned int size);
 
+/* client side definitions */
+#define CMS_CALL_FLAG_NONE                0x00000000
+#define CMS_CALL_FLAG_NO_SAF_CHECK        0x00000001
+
 /* client side functions */
 int cmsCallService(const CrossMemoryServerName *serverName, int functionID, void *parmList, int *serviceRC);
 int cmsCallService2(CrossMemoryServerGlobalArea *cmsGlobalArea,
                     int serviceID, void *parmList, int *serviceRC);
+int cmsCallService3(CrossMemoryServerGlobalArea *cmsGlobalArea,
+                    int serviceID, void *parmList, int flags, int *serviceRC);
 int cmsPrintf(const CrossMemoryServerName *serverName, const char *formatString, ...);
 int cmsGetConfigParm(const CrossMemoryServerName *serverName, const char *name,
                      CrossMemoryServerConfigParm *parm);


### PR DESCRIPTION
 The purpose of this enhancement is to allow calling cross-memory servers from system exits.

A new public function has been added that allows passing flags to cross-memory calls. At the moment there is only one flag - the "skip SAF check" flag. The flags makes it possible to skip the SAF check if the caller is either in:
* Supervisor state
* System key (key 0-7)

If the caller is in neither of those states, the flag is ignored.
