### PR TITLE
[WIP] Bugfix: Check dataset name length in respondWithDatasetMetadata

### DIFF
--- a/c/datasetjson.c
+++ b/c/datasetjson.c
@@ -1676,8 +1676,11 @@ void respondWithDatasetMetadata(HttpResponse *response) {
   int memberNameLength = 0;
 
   if (lParenIndex > 0){
-    nullTerminate(memName.value, sizeof(memName.value) - 1);
-    memberNameLength = sizeof(memName.value) - 1;
+    for(memberNameLength; memberNameLength < 8; memberNameLength++){
+      if(memName.value[memberNameLength] == ' ' || memName.value[memberNameLength] == '\0'){
+        break;
+      }
+    }
   } else {
     memberNameLength = 0;
     memset(memName.value, '\0', sizeof(memName.value));

--- a/c/datasetjson.c
+++ b/c/datasetjson.c
@@ -1668,6 +1668,10 @@ void respondWithDatasetMetadata(HttpResponse *response) {
   if (lParenIndex > 0){
     int rParenIndex = lastIndexOf(datasetOrMember, dsnLen, ')');
     int encodedMemberNameLength = rParenIndex-lParenIndex;
+    if(lParenIndex > 45){
+      respondWithError(response,HTTP_STATUS_BAD_REQUEST,"Dataset name must be no longer than 44 characters");
+      return;
+    }
     if (encodedMemberNameLength == 1) {
       respondWithError(response,HTTP_STATUS_BAD_REQUEST,"No member name given within parenthesis");
       return;
@@ -1701,7 +1705,11 @@ void respondWithDatasetMetadata(HttpResponse *response) {
     dsn = pdsDSN;
     dsnLen = lParenIndex+1;
   }
-  else{
+  else if(dsnLen > 44){
+    respondWithError(response,HTTP_STATUS_BAD_REQUEST,"Dataset name must be no longer than 44 characters");
+    return;
+  }
+  else {
     dsn = datasetOrMember;
   }
   HttpRequestParam *detailParam = getCheckedParam(request,"detail");

--- a/c/datasetjson.c
+++ b/c/datasetjson.c
@@ -1675,6 +1675,13 @@ void respondWithDatasetMetadata(HttpResponse *response) {
   extractDatasetAndMemberName(absDsnPath, &dsnName, &memName);
   memberNameLength = strlen(memName.value);
   dsnLen = strlen(dsnName.value);
+  for(int i = 0; dsnName.value[i] != '\0' && i < dsnLen; i++){
+      if(dsnName.value[i] == ' '){
+        dsnName.value[i] = '\0';
+        break;
+      }
+  }
+  //printf("dsnName: '%s' | len: %d \nmemName: '%s' | len: %d", dsnName.value, dsnLen, memName.value, memberNameLength);
   HttpRequestParam *detailParam = getCheckedParam(request,"detail");
   char *detailArg = (detailParam ? detailParam->stringValue : NULL);
 


### PR DESCRIPTION
This pull request fixes the following ABEND:
-Dataset name length checking before storing on heap

Steps reproduce bug:
1. Launch a ZSS instance
2. Authenticate
3. Create GET request to /datasetMetadata/name/ with a very long dataset name. Example: /datasetMetadata/name/asdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfsdfasdfasdfasdaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa 
4. Note ABEND

Signed-off-by: Timothy Gerstel <tim.gerstel@gmail.com>