### PR TITLE
SRB support in the recovery facility

### DIFF
--- a/c/recovery.c
+++ b/c/recovery.c
@@ -237,6 +237,93 @@ static ESTAEXFeedback deleteESTAEX() {
   return localFeedback;
 }
 
+static void setFRR(void * __ptr32 userExit, void *userData,
+                   bool nonInterruptible) {
+
+  int wasProblem = supervisorMode(TRUE);
+  int oldKey = setKey(0);
+
+  union {
+    void *userData;
+    char data[24];
+  } * __ptr32 parmArea = NULL;
+
+  if (nonInterruptible) {
+
+    __asm(
+        ASM_PREFIX
+        "         SYSSTATE PUSH                                                  \n"
+        "         SYSSTATE OSREL=ZOSV1R8                                         \n"
+        "         SETFRR A"
+        ",FRRAD=(%[frr])"
+        ",WRKREGS=(9,10)"
+        ",PARMAD=%[parm]"
+        ",CANCEL=NO"
+        ",MODE=FULLXM"
+        ",SDWALOC31=YES                                                          \n"
+        "         SYSSTATE POP                                                   \n"
+        : [parm]"=m"(parmArea)
+        : [frr]"r"(userExit)
+        : "r9", "r10"
+    );
+
+  } else {
+
+    __asm(
+        ASM_PREFIX
+        "         SYSSTATE PUSH                                                  \n"
+        "         SYSSTATE OSREL=ZOSV1R8                                         \n"
+        "         SETFRR A"
+        ",FRRAD=(%[frr])"
+        ",WRKREGS=(9,10)"
+        ",PARMAD=%[parm]"
+        ",CANCEL=YES"
+        ",MODE=FULLXM"
+        ",SDWALOC31=YES                                                          \n"
+        "         SYSSTATE POP                                                   \n"
+        : [parm]"=m"(parmArea)
+        : [frr]"r"(userExit)
+        : "r9", "r10"
+    );
+
+  }
+
+  parmArea->userData = userData;
+
+  setKey(oldKey);
+  if (wasProblem) {
+    supervisorMode(FALSE);
+  }
+
+}
+
+static void deleteFRR(void) {
+
+  int wasProblem = supervisorMode(TRUE);
+  int oldKey = setKey(0);
+
+  __asm(
+      ASM_PREFIX
+      "         SYSSTATE PUSH                                                  \n"
+      "         SYSSTATE OSREL=ZOSV1R8                                         \n"
+      "         SETFRR D,WRKREGS=(9,10)                                        \n"
+#ifndef METTLE
+      "* Prevent LE compiler errors caused by the way XL C treats __asm        \n"
+      "         NOPR  0                                                        \n"
+#endif
+      "         SYSSTATE POP                                                   \n"
+      :
+      :
+      : "r9", "r10"
+  );
+
+  setKey(oldKey);
+  if (wasProblem) {
+    supervisorMode(FALSE);
+  }
+
+}
+
 static void *storageObtain(int size){
   char * __ptr32 data = NULL;
   __asm(
@@ -303,8 +390,11 @@ static void * __ptr32 getRecoveryRouterAddress() {
       "         LARL  10,RCVEXIT                                               \n"
       "         USING RCVEXIT,10                                               \n"
       /* validate input */
+      "         LT    2,X'21C'            CHECK IF WE HAVE TCB                 \n"
+      "         BZ    RCVLSDWA            NO, SKIP SDWA CHECK                  \n"
       "         CHI   0,12                HAVE SDWA?                           \n"
       "         JE    RCVRET              NO, LEAVE                            \n"
+      "RCVLSDWA DS    0H                                                       \n"
       "         LGR   9,1                 SDWA WILL BE IN R9                   \n"
       "         USING SDWA,9                                                   \n"
       "         LTGF  2,SDWAPARM          LOAD RECOVERY PARMS HANDLE           \n"
@@ -396,6 +486,8 @@ static void * __ptr32 getRecoveryRouterAddress() {
       "         LA    5,RSTDMTLT          DUMP TITLE                           \n"
       "         TM    RCXFLAG1,R@CF1PCC   IS THIS PC?                          \n"
       "         BNZ   RCVFRL25            YES, USE A SPECIAL SDUMPX CALL       \n"
+      "         LT    2,X'21C'            ARE WE SRB?                          \n"
+      "         BZ    RCVFRL25            YES, USE A SPECIAL SDUMPX CALL       \n"
       "         SDUMPX  PLISTVER=3,HDRAD=(5),TYPE=FAILRC,"
       ",SDATA=("
       "ALLNUC,ALLPSA,COUPLE,CSA,"
@@ -459,6 +551,10 @@ static void * __ptr32 getRecoveryRouterAddress() {
       "RCVFRL4  DS    0H                  RETRY PROCESSING                     \n"
       "         TM    RSTFLG1,R@F1RTRY    ARE WE RETRYING?                     \n"
       "         BZ    RCVFRL5             NO, REMOVE AND LEAVE                 \n"
+      "         LA    3,1                 STACKED STATE 1                      \n"
+      "         ESTA  2,3                 GET STATE                            \n"
+      "         SRL   2,16                MOVE KEY TO BIT 24-27                \n"
+      "         SPKA  0(2)                GO TO ORIGINAL KEY (PKM APPROVED)    \n"
       "         LLGT  4,SDWAXPAD          LOAD EXTENSION POINTERS ADDRESS      \n"
       "         USING SDWAPTRS,4                                               \n"
       "         LLGT  5,SDWASRVP          LOAD RECORDABLE EXTENSION            \n"
@@ -467,10 +563,6 @@ static void * __ptr32 getRecoveryRouterAddress() {
       "         LTR   4,4                 IS IT THERE?                         \n"
       "         BZ    RCVRET              NO, LEAVE                            \n"
       "         USING SDWARC4,4                                                \n"
-      "         LA    3,1                 STACKED STATE 1                      \n"
-      "         ESTA  2,3                 GET STATE                            \n"
-      "         SRL   2,16                MOVE KEY TO BIT 24-27                \n"
-      "         SPKA  0(2)                GO TO ORIGINAL KEY (PKM APPROVED)    \n"
       "         MVC   SDWAG64,RSTRGPR     MOVE OUR REGISTERS                   \n"
       "         MVC   SDWALSLV,RSTLSTKN   MOVE LINKAGE STACK TOKEN             \n"
       "         LLGT  7,RSTRTRAD          LOAD RETRY ADDRESS                   \n"
@@ -479,12 +571,12 @@ static void * __ptr32 getRecoveryRouterAddress() {
       "         BZ    RCVFRL48            NO, USE SETRP WITHOUT RECORD=YES     \n"
       "RCVFRL47 DS    0H                  SETRP WITH LOGREC                    \n"
       "         SETRP RC=4,RECORD=YES"
-      ",DUMP=NO,RETREGS=64,FRESDWA=YES"
+      ",DUMP=NO,RETREGS=64,RETRY15=YES,FRESDWA=YES"
       ",RETADDR=(7)                                                            \n"
       "         B     RCVRET              LEAVE                                \n"
       "RCVFRL48 DS    0H                  SETRP WITHOUT LOGREC                 \n"
       "         SETRP RC=4,RECORD=NO"
-      ",DUMP=NO,RETREGS=64,FRESDWA=YES"
+      ",DUMP=NO,RETREGS=64,RETRY15=YES,FRESDWA=YES"
       ",RETADDR=(7)                                                            \n"
       "         B     RCVRET              LEAVE                                \n"
       "RCVFRL5  DS    0H                  ENTRY REMOVAL                        \n"
@@ -666,7 +758,8 @@ void recoveryDESCTs(){
       "R@STABND EQU   X'02'                                                    \n"
       "R@STIREC EQU   X'04'                                                    \n"
       "RSTLSTKN DS    2X                                                       \n"
-      "RSTRESRV DS    5X                                                       \n"
+      "RSTKEY   DS    1X                                                       \n"
+      "RSTRESRV DS    4X                                                       \n"
       "RSTSDRC  DS    F                                                        \n"
       "RSTRGPR  DS    16D                                                      \n"
       "RSTCGPR  DS    16D                                                      \n"
@@ -679,6 +772,10 @@ void recoveryDESCTs(){
 
       "         DS    0H                                                       \n"
       "         IHASDWA                                                        \n"
+      "         EJECT ,                                                        \n"
+      "         IHAFRRS                                                        \n"
+      "         EJECT ,                                                        \n"
+      "         IHAPSA                                                         \n"
       "         EJECT ,                                                        \n"
 #ifndef METTLE
       "         DS    0H                                                       \n"
@@ -834,8 +931,17 @@ static StackedState getStackedState(StackedStateExtractionCode code) {
 
 int recoveryEstablishRouter(int flags) {
 
+  /* Which DU are we? */
+  bool isTCB = getTCB() ? true : false;
+
   /* set dummy ESPIE */
-  bool isESPIERequired = flags & RCVR_ROUTER_FLAG_PC_CAPABLE ? false : true;
+  bool isESPIERequired = false;
+  if (!(flags & RCVR_ROUTER_FLAG_PC_CAPABLE)) {
+    if (isTCB) {
+      isESPIERequired = true;
+    }
+  }
+
   int previousESPIEToken = 0;
   if (isESPIERequired) {
     previousESPIEToken = setDummyESPIE();
@@ -865,27 +971,39 @@ int recoveryEstablishRouter(int flags) {
       :
   );
 
-  /* ESTAEX */
-  char estaexFlags = 0;
-  if (flags & RCVR_ROUTER_FLAG_NON_INTERRUPTIBLE) {
-    estaexFlags |= RCVR_ESTAEX_FLAG_NON_INTERRUPTIBLE;
-  }
-  if (flags & RCVR_ROUTER_FLAG_RUN_ON_TERM) {
-    estaexFlags |= RCVR_ESTAEX_FLAG_RUN_ON_TERM;
-  }
 
-  ESTAEXFeedback feedback = setESTAEX(getRecoveryRouterAddress(), context, estaexFlags);
-  if (feedback.returnCode != 0) {
-#if RECOVERY_TRACING
-    printf("error: set ESTAEX RC = %d, RSN = %d\n", feedback.returnCode, feedback.reasonCode);
-#endif
-    if (previousESPIEToken != 0) {
-      resetESPIE(previousESPIEToken);
-      previousESPIEToken = 0;
+  if (isTCB) {
+
+    /* ESTAEX */
+    char estaexFlags = 0;
+    if (flags & RCVR_ROUTER_FLAG_NON_INTERRUPTIBLE) {
+      estaexFlags |= RCVR_ESTAEX_FLAG_NON_INTERRUPTIBLE;
     }
-    storageRelease((char *)context, sizeof(RecoveryContext));
-    context = NULL;
-    return RC_RCV_SET_ESTAEX_FAILED;
+    if (flags & RCVR_ROUTER_FLAG_RUN_ON_TERM) {
+      estaexFlags |= RCVR_ESTAEX_FLAG_RUN_ON_TERM;
+    }
+
+    ESTAEXFeedback feedback = setESTAEX(getRecoveryRouterAddress(), context,
+                                        estaexFlags);
+    if (feedback.returnCode != 0) {
+#if RECOVERY_TRACING
+      printf("error: set ESTAEX RC = %d, RSN = %d\n",
+             feedback.returnCode, feedback.reasonCode);
+#endif
+      if (previousESPIEToken != 0) {
+        resetESPIE(previousESPIEToken);
+        previousESPIEToken = 0;
+      }
+      storageRelease((char *)context, sizeof(RecoveryContext));
+      context = NULL;
+      return RC_RCV_SET_ESTAEX_FAILED;
+    }
+
+  } else {
+
+    setFRR(getRecoveryRouterAddress(), context,
+           flags & RCVR_ROUTER_FLAG_NON_INTERRUPTIBLE);
+
   }
 
   return RC_RCV_OK;
@@ -1046,12 +1164,23 @@ int recoveryRemoveRouter() {
 
   int returnCode = RC_RCV_OK;
 
+  /* Which DU are we? */
+  bool isTCB = getTCB() ? true : false;
+
+  if (isTCB) {
+
   ESTAEXFeedback feedback = deleteESTAEX();
   if (feedback.returnCode != 0) {
 #if RECOVERY_TRACING
     printf("error: delete ESTAEX RC = %d, RSN = %d\n", feedback.returnCode, feedback.reasonCode);
 #endif
     returnCode = RC_RCV_DEL_ESTAEX_FAILED;
+  }
+
+  } else {
+
+    deleteFRR();
+
   }
 
   if (context->previousESPIEToken != 0) {
@@ -1299,16 +1428,36 @@ int recoveryPush(char *name, int flags, char *dumpTitle,
 
   newEntry->linkageStackToken = linkageStackToken;
 
+  /* Extract key from the newly created stacked state. IPK cannot be used
+   * as it requires the extract-authority set.
+   * This value will be used to restore the current's recovery state key if
+   * it changes during the recovery process - this usually happens under an SRB
+   * when SETRP retry with key 0. */
+  StackedState stackedState = getStackedState(STACKED_STATE_EXTRACTION_CODE_01);
+  newEntry->key = (stackedState.state01.psw & 0x00F0000000000000LLU) >> 48;
+
   __asm(
+
+      /*
+       * Register use:
+       *
+       * R2       - work register (addressability, key for SPKA)
+       * R9       - recovery state
+       * R10,R11  - address and size of the stack frame buffer for MVCL
+       * R14,R15  - address and size of the stack frame for MVCL
+       *
+       */
+
       ASM_PREFIX
       "&LX      SETA  &LX+1                                                    \n"
-      "&L1      SETC  'RETRY&LX'                                               \n"
-      "&L2      SETC  'EXIT&LX'                                                \n"
-      "         LLGTR 9,%0               LOAD NEW RECOVERY STATE ENTRY         \n"
+      "&LRETRY  SETC  'RETRY&LX'                                               \n"
+      "&LRSTORE SETC  'RSTR&LX'                                                \n"
+      "&LEXIT   SETC  'EXIT&LX'                                                \n"
+      "&LRSEYE  SETC  'RSEC&LX'                                                \n"
       "         PUSH  USING                                                    \n"
       "         DROP                                                           \n"
       "         USING RCVSTATE,9                                               \n"
-      "         LARL  10,&L1             GET RETRY ADDRESS                     \n"
+      "         LARL  10,&LRETRY         GET RETRY ADDRESS                     \n"
       "         ST    10,RSTRTRAD        STORE RETRY ADDRESS FOR SETRP         \n"
       "         LA    10,RSTSTFR         ADDRESS OF STACK FRAME BUFFER         \n"
       "         LA    11,L'RSTSTFR       SIZE OF STACK FRAME BUFFER            \n"
@@ -1327,10 +1476,17 @@ int recoveryPush(char *name, int flags, char *dumpTitle,
       "         LG    10,128(13)         ADDRESS OF PREVIOUS SAVE AREA         \n"
       "         MVC   RSTCGPR(120),8(10) CALLER'S REGISTERS                    \n"
 #endif
-      "         LARL  9,&L2              EXIT ADDRESS                          \n"
-      "         B     0(9)               BRANCH AROUND RETRY BLOCK             \n"
+      "         J     &LEXIT             BRANCH AROUND RETRY BLOCK             \n"
       /* retry block */
-      "&L1      DS    0H                                                       \n"
+      "&LRETRY  DS    0H                                                       \n"
+      "         LARL  2,&LRSEYE          LOAD EYECATCHER CONSTANT ADDRESS      \n"
+      "         CLC   RSTEYECT,0(2)      STATE EYECATCHER IS VALID?            \n"
+      "         JE    &LRSTORE           YES, CONTINUE                         \n"
+      "         ABEND 1                  SOMETHING WENT TERRIBLY WRONG         \n"
+      "&LRSEYE  DC    CL8'RSRSENTR'      STATE EYECATCHER CONSTANT             \n"
+      "&LRSTORE DS    0H                                                       \n"
+      "         LLC   2,RSTKEY           LOAD KEY TO R2                        \n"
+      "         SPKA  0(2)               RESTORE KEY                           \n"
       "         MVCL  14,10              RESTORE STACK FRAME ON RETRY          \n"
 #if !defined(_LP64)
       "         L     10,4(13)           ADDRESS OF PREVIOUS SAVE AREA         \n"
@@ -1340,11 +1496,15 @@ int recoveryPush(char *name, int flags, char *dumpTitle,
       "         MVC   8(120,10),RSTCGPR  RESTORE CALLER'S REGISTERS            \n"
 #endif
       /* exit */
-      "&L2      DS    0H                                                       \n"
+      "&LEXIT   DS    0H                                                       \n"
       "         POP   USING                                                    \n"
+#ifndef METTLE
+      "* Prevent LE compiler errors caused by the way XL C treats __asm        \n"
+      "         NOPR  0                                                        \n"
+#endif
       :
-      : "r"(newEntry)
-      : "r9", "r10", "r11", "r14", "r15"
+      : "NR:r9"(newEntry)
+      : "r2", "r10", "r11", "r14", "r15"
   );
 
   if (newEntry->state & RECOVERY_STATE_ABENDED) {

--- a/h/recovery.h
+++ b/h/recovery.h
@@ -241,7 +241,8 @@ typedef struct RecoveryStateEntry_tag {
 #define RECOVERY_STATE_ABENDED          0x02
 #define RECOVERY_STATE_INFO_RECORDED    0x04
   int16_t linkageStackToken;
-  char reserved[5];
+  int8_t key;
+  char reserved[4];
   int sdumpxRC;
   long long retryGPRs[16];
   long long callerGRPs[16];   /* used for Metal 31/64 and LE 31 */


### PR DESCRIPTION
Changes:
* Use FRR when running under an SRB
* Bypass the SDWA check under an SRB
* Use the FRR exit key when accessing SDWA field (to prevent 0C4 when
SDWA is fetch protected)
* Tell SETRP to restore R15 as this behavior is different from ESTAE
* Verify that the state structure after is valid we've retried
* Save and restore the caller's key in recoveryPush - SETRP restores the
key used at the time of SETFRR which may be different from what we want
* Use better names for the labels in the recovery push asm