### PR TITLE
Link delete

### DIFF
--- a/c/httpfileservice.c
+++ b/c/httpfileservice.c
@@ -84,9 +84,12 @@ bool doesFileExist(char *absolutePath) {
 
   status = fileInfo(absolutePath, &info, &returnCode, &reasonCode);
   if (status == -1) {
-    return false;
+    /* Test whether it is a symbolic */
+    status = symbolicFileInfo(absolutePath, &info, &returnCode, &reasonCode);
+    if (status == -1) {
+      return false;
+    }
   }
-  
   return true;
 }
 
@@ -172,6 +175,10 @@ static int deleteUnixFile(char *absolutePath) {
   FileInfo info = {0};
 
   status = fileInfo(absolutePath, &info, &returnCode, &reasonCode);
+  /* if not a file, then check to see if it is a symbolic link */
+  if (status == -1) {
+    status = symbolicFileInfo(absolutePath, &info, &returnCode, &reasonCode);
+  }
   if (status == -1) {
     zowelog(NULL, LOG_COMP_RESTFILE, ZOWE_LOG_WARNING,
             "Failed to stat file %s, (returnCode = 0x%x, reasonCode = 0x%x)\n",

--- a/c/httpfileservice.c
+++ b/c/httpfileservice.c
@@ -138,8 +138,11 @@ void createUnixDirectoryAndRespond(HttpResponse *response, char *absolutePath, i
 static int deleteUnixDirectory(char *absolutePath) {
   int returnCode = 0, reasonCode = 0, status = 0;
   FileInfo info = {0};
-  
+ 
   status = fileInfo(absolutePath, &info, &returnCode, &reasonCode);
+  if (status == -1) {
+    status = symbolicFileInfo(absolutePath, &info, &returnCode, &reasonCode);
+  }
   if (status == -1) {
     zowelog(NULL, LOG_COMP_RESTFILE, ZOWE_LOG_WARNING,
             "Failed to stat directory %s, (returnCode = 0x%x, reasonCode = 0x%x)\n",

--- a/c/zosfile.c
+++ b/c/zosfile.c
@@ -1093,10 +1093,14 @@ static int getValidDirectoryEntries(int entries, char *entryBuffer, const char *
 }
   
 int directoryDeleteRecursive(const char *pathName, int *retCode, int *resCode){
-  int returnCode = 0, reasonCode = 0, status = 0;
-  FileInfo info = {0};
-  
+  int returnCode = 0, reasonCode = 0, status = 0, symstatus = 0;
+  FileInfo    info = {0};
+  FileInfo syminfo = {0};
+ 
   status = fileInfo(pathName, &info, &returnCode, &reasonCode);
+  if (status == -1) {
+    status = symbolicFileInfo(pathName, &info, &returnCode, &reasonCode);
+  }
   if (status == -1){
     *retCode = returnCode;
     *resCode = reasonCode;
@@ -1134,14 +1138,18 @@ int directoryDeleteRecursive(const char *pathName, int *retCode, int *resCode){
     char pathBuffer[USS_MAX_PATH_LENGTH + 1] = {0};
     snprintf(pathBuffer, sizeof(pathBuffer), "%s/%s", pathName, entryArray[i]);
 
-    status = fileInfo(pathBuffer, &info, &returnCode, &reasonCode);
-    if (status == -1){
+    status    = fileInfo(pathBuffer, &info, &returnCode, &reasonCode);
+    symstatus = symbolicFileInfo(pathName, &syminfo, &returnCode, &reasonCode);
+
+    if ((status == -1) && (symstatus == -1)){
       *retCode = returnCode;
       *resCode = reasonCode;
       return -1;
     }
 
-    if (fileInfoIsDirectory(&info)) {
+    /* If pathBuffer is directory, then recursively call.    */
+    /* Note: system marks symbolic as a directory            */
+    if ((status != -1 ) && fileInfoIsDirectory(&info)) {
       status = directoryDeleteRecursive(pathBuffer, retCode, resCode);
       if (status == -1) {
         return -1;


### PR DESCRIPTION
For symbolic links, the fileInfo functions returns the stats of the file the link is pointing, not the status of the link itself.  Place in additional calls to symbolicFileInfo to obtain this  information.