### PR TITLE
Unixfile/contents:  Allow ISO8859-1 encoding

### DIFF
--- a/c/charsets.c
+++ b/c/charsets.c
@@ -212,8 +212,7 @@ int getCharsetCode(const char *charsetName) {
   strupcase (localArray);
 
   if ((!strcmp(localArray, "ISO-8859-1"))  ||
-      (!strcmp(localArray, "ISO8859-1")))
-     {
+      (!strcmp(localArray, "ISO8859-1"))) {
     return CCSID_ISO_8859_1;
   }
   else if (!strcmp(localArray, "IBM-1047")) {

--- a/c/charsets.c
+++ b/c/charsets.c
@@ -200,22 +200,24 @@ int convertCharset(char *input,
 }
 
 int getCharsetCode(char *charsetName) {
-  if (!strcmp(charsetName, "ISO-8859-1")) {
+  if ((!strcmp(strupcase(charsetName), "ISO-8859-1"))  ||
+      (!strcmp(strupcase(charsetName), "ISO8859-1")))
+     {
     return CCSID_ISO_8859_1;
   }
-  else if (!strcmp(charsetName, "IBM-1047")) {
+  else if (!strcmp(strupcase(charsetName), "IBM-1047")) {
     return CCSID_IBM1047;
   }
-  else if (!strcmp(charsetName, "UTF-8")) {
+  else if (!strcmp(strupcase(charsetName), "UTF-8")) {
     return CCSID_UTF_8;
   }
-  else if (!strcmp(charsetName, "UTF-16")) {
+  else if (!strcmp(strupcase(charsetName), "UTF-16")) {
     return CCSID_UTF_16;
   }
-  else if (!strcmp(charsetName, "UTF-16BE")) {
+  else if (!strcmp(strupcase(charsetName), "UTF-16BE")) {
     return CCSID_UTF_16_BE;
   }
-  else if (!strcmp(charsetName, "UTF-16LE")) {
+  else if (!strcmp(strupcase(charsetName), "UTF-16LE")) {
     return CCSID_UTF_16_LE;
   }
   else {

--- a/c/charsets.c
+++ b/c/charsets.c
@@ -201,15 +201,14 @@ int convertCharset(char *input,
 
 #define CHARSETNAME_SIZE 15
 int getCharsetCode(const char *charsetName) {
-  char localArray[CHARSETNAME_SIZE] = {0};
+  char localArray[CHARSETNAME_SIZE + 1] = {0};
 
   /* Make sure last element is 0 */
   if (strlen(charsetName) > CHARSETNAME_SIZE) {
     return -1;
   }
 # undef CHARSETNAME_SIZE
-
-  strncpy( localArray, charsetName, sizeof (localArray) -1);
+  strcpy( localArray, charsetName);
   strupcase (localArray);
 
   if ((!strcmp(localArray, "ISO-8859-1"))  ||

--- a/c/charsets.c
+++ b/c/charsets.c
@@ -203,6 +203,11 @@ int convertCharset(char *input,
 int getCharsetCode(const char *charsetName) {
   char localArray[CHARSETNAME_SIZE + 1] = {0};
 
+  /* Check for null pointer */
+  if (charsetName == NULL) {
+    return -1;
+  }
+
   /* Make sure last element is 0 */
   if (strlen(charsetName) > CHARSETNAME_SIZE) {
     return -1;

--- a/c/charsets.c
+++ b/c/charsets.c
@@ -199,25 +199,37 @@ int convertCharset(char *input,
   }
 }
 
-int getCharsetCode(char *charsetName) {
-  if ((!strcmp(strupcase(charsetName), "ISO-8859-1"))  ||
-      (!strcmp(strupcase(charsetName), "ISO8859-1")))
+#define CHARSETNAME_SIZE 15
+int getCharsetCode(const char *charsetName) {
+  char localArray[CHARSETNAME_SIZE] = {0};
+
+  /* Make sure last element is 0 */
+  if (strlen(charsetName) > CHARSETNAME_SIZE) {
+    return -1;
+  }
+# undef CHARSETNAME_SIZE
+
+  strncpy( localArray, charsetName, sizeof (localArray) -1);
+  strupcase (localArray);
+
+  if ((!strcmp(localArray, "ISO-8859-1"))  ||
+      (!strcmp(localArray, "ISO8859-1")))
      {
     return CCSID_ISO_8859_1;
   }
-  else if (!strcmp(strupcase(charsetName), "IBM-1047")) {
+  else if (!strcmp(localArray, "IBM-1047")) {
     return CCSID_IBM1047;
   }
-  else if (!strcmp(strupcase(charsetName), "UTF-8")) {
+  else if (!strcmp(localArray, "UTF-8")) {
     return CCSID_UTF_8;
   }
-  else if (!strcmp(strupcase(charsetName), "UTF-16")) {
+  else if (!strcmp(localArray, "UTF-16")) {
     return CCSID_UTF_16;
   }
-  else if (!strcmp(strupcase(charsetName), "UTF-16BE")) {
+  else if (!strcmp(localArray, "UTF-16BE")) {
     return CCSID_UTF_16_BE;
   }
-  else if (!strcmp(strupcase(charsetName), "UTF-16LE")) {
+  else if (!strcmp(localArray, "UTF-16LE")) {
     return CCSID_UTF_16_LE;
   }
   else {

--- a/c/httpfileservice.c
+++ b/c/httpfileservice.c
@@ -191,7 +191,7 @@ void directoryChangeModeAndRespond(HttpResponse *response, char *file,
     zowelog(NULL, LOG_COMP_RESTFILE, ZOWE_LOG_WARNING,
        "Failed to chnmod file %s: illegal mode %s\n", file, cmode);
     respondWithJsonError(response, "failed to chmod: mode not octol", 400, "Bad Request");
-    return -1;
+    return;
     }
   sscanf (first, "%o", &mode); 
 
@@ -205,7 +205,7 @@ void directoryChangeModeAndRespond(HttpResponse *response, char *file,
             file, returnCode, reasonCode);
     respondWithJsonError(response, "failed to modify file modes", 500, "Bad Request");
   }
-  return 0;
+  return;
 }
 
 /* Deletes a unix file at the specified absolute

--- a/c/zosfile.c
+++ b/c/zosfile.c
@@ -212,7 +212,7 @@ int fileRead(UnixFile *file, char *buffer, int desiredBytes,
              int *returnCode, int *reasonCode) {
   if (file == NULL) {
     if (fileTrace) {
-      printf("File is null\n");
+      printf("fileRead: File is null\n");
     }
 #ifdef METTLE
     *returnCode = -1;
@@ -277,7 +277,7 @@ int fileWrite(UnixFile *file, const char *buffer, int desiredBytes,
               int *returnCode, int *reasonCode) {
   if (file == NULL) {
     if (fileTrace) {
-      printf("File is null\n");
+      printf("fileWrite: File is null\n");
     }
 #ifdef METTLE
     *returnCode = -1;
@@ -380,7 +380,7 @@ int fileGetChar(UnixFile *file, int *returnCode, int *reasonCode) {
 int fileClose(UnixFile *file, int *returnCode, int *reasonCode) {
   if (file == NULL) {
     if (fileTrace) {
-      printf("File is null\n");
+      printf("fileClose: File is null\n");
     }
 #ifdef METTLE
     *returnCode = -1;
@@ -450,6 +450,7 @@ int fileChangeTagPure(const char *fileName, int *returnCode, int *reasonCode,
 
 int fileChangeTag(const char *fileName, int *returnCode, int *reasonCode, int ccsid) {
   bool pure = true;
+
   fileChangeTagPure(fileName, returnCode, reasonCode, ccsid, pure);
   }
 


### PR DESCRIPTION
Signed-off-by: Steven Bollinger <sbollinger@rocketsoftware.com>
Allow ISO8859-1 along with ISO-8859-1.
Make all file encoding case insensitive. 