### PR TITLE
Add helper functions to test caller's environment

### DIFF
--- a/c/zos.c
+++ b/c/zos.c
@@ -1532,9 +1532,12 @@ bool isCallerCrossMemory(void) {
       /* assume not cross-memory */
       "         LA    15,0                                                     \n"
       /* get HASN */
-      "         LA    1,0                                                      \n"
-      "         USING PSA,1                                                    \n"
+      "         USING PSA,0                                                    \n"
+#ifdef _LP64
+      "         LLGT  1,PSAAOLD                                                \n"
+#else
       "         L     1,PSAAOLD                                                \n"
+#endif
       "         USING ASCB,1                                                   \n"
       "         LLH   1,ASCBASID                                               \n"
       "         DROP  1                                                        \n"

--- a/c/zos.c
+++ b/c/zos.c
@@ -1539,12 +1539,10 @@ bool isCallerCrossMemory(void) {
       "         LLH   1,ASCBASID                                               \n"
       "         DROP  1                                                        \n"
       /* get PASN and compare with HASN */
-      "         LA    2,0                                                      \n"
       "         EPAR  2                                                        \n"
       "         CLR   1,2                                                      \n"
       "         JNE   &LXMEM                                                   \n"
       /* get SASN and compare with HASN */
-      "         LA    2,0                                                      \n"
       "         ESAR  2                                                        \n"
       "         CLR   1,2                                                      \n"
       "         JNE   &LXMEM                                                   \n"

--- a/h/zos.h
+++ b/h/zos.h
@@ -40,6 +40,10 @@
 #define loadByName LOADBYNAM
 #define loadByNameLocally LOADBNML
 
+#define isCallerLocked        ZOSCLCKD
+#define isCallerSRB           ZOSCSRB
+#define isCallerCrossMemory   ZOSCXMEM
+
 #endif
 
 
@@ -1212,6 +1216,24 @@ void *loadByName(char *moduleName, int *statusPtr);
 void *loadByNameLocally(char *moduleName, int *statusPtr);
 
 char *getASCBJobname(ASCB *ascb);
+
+/**
+ * @brief Determine if the caller is in locked state.
+ * @return True if the caller holds a CPU, CMS, CML or local lock.
+ */
+bool isCallerLocked(void);
+
+/**
+ * @brief Determine if the caller is running in SRB mode.
+ * @return True if the caller is in SRB mode.
+ */
+bool isCallerSRB(void);
+
+/**
+ * @brief Determine if the caller is running in cross-memory mode.
+ * @return False if the caller's HASN=PASN=SASN, otherwise true.
+ */
+bool isCallerCrossMemory(void);
 
 #endif
 


### PR DESCRIPTION
The following new functions has been added:
* A function to test whether the caller is running in SRB
* A function to test whether the caller is in cross-memory mode
* A function to test whether the caller is holding a CPU, CMS, CML or local lock