### PR TITLE
Use zowelog instead of printf, reduce useless messages

### DIFF
--- a/c/bpxskt.c
+++ b/c/bpxskt.c
@@ -1316,7 +1316,7 @@ void freeSocketAddr(SocketAddress *address){
 }
 
 void freeSocketSet(SocketSet *set){
-  printf("implement me - freeSocketSet\n");
+  printf("freeSocketSet: NYI\n");
   return;
 }
 

--- a/c/dataservice.c
+++ b/c/dataservice.c
@@ -217,7 +217,7 @@ static DataService *makeDataService(WebPlugin *plugin, JsonObject *serviceJsonOb
 void initalizeWebPlugin(WebPlugin *plugin, HttpServer *server) {
   int i = 0;
   int count = plugin->dataServiceCount;
-  printf("%s begin, count=%d\n", __FUNCTION__,count);
+  zowelog(NULL, LOG_COMP_DATASERVICE, ZOWE_LOG_DEBUG2, "%s begin, count=%d\n", __FUNCTION__,count);  
   for (i = 0; i < count; i++) {
     DataService *service = plugin->dataServices[i];
     if (service->initializer){
@@ -226,7 +226,7 @@ void initalizeWebPlugin(WebPlugin *plugin, HttpServer *server) {
       printf("*** PANIC *** service %s has no installer\n",service->identifier);
     }
   }
-  printf("%s end\n", __FUNCTION__);
+  zowelog(NULL, LOG_COMP_DATASERVICE, ZOWE_LOG_DEBUG2, "%s end\n", __FUNCTION__);
 }
 
 static void freeWebPlugin(WebPlugin *plugin) {
@@ -260,7 +260,7 @@ static bool isValidServiceDef(JsonObject *serviceDef) {
 
 WebPlugin *makeWebPlugin(char *pluginLocation, JsonObject *pluginDefintion, InternalAPIMap *internalAPIMap,
                          unsigned int *idMultiplier, int pluginLogLevel) {
-  zowelog(NULL, LOG_COMP_DATASERVICE, ZOWE_LOG_INFO, "%s begin\n", __FUNCTION__);
+  zowelog(NULL, LOG_COMP_DATASERVICE, ZOWE_LOG_DEBUG2, "%s begin\n", __FUNCTION__);
   WebPlugin *plugin = (WebPlugin*)safeMalloc(sizeof(WebPlugin),"WebPlugin");
   memset(plugin, 0, sizeof (WebPlugin));
   plugin->pluginLocation = pluginLocation;
@@ -297,8 +297,10 @@ WebPlugin *makeWebPlugin(char *pluginLocation, JsonObject *pluginDefintion, Inte
       }
     }
 
-    printf("For plugin=%s, found %d data service(s)\n", plugin->identifier, plugin->dataServiceCount);
-    plugin->dataServices = (DataService**)safeMalloc(sizeof(DataService*) * plugin->dataServiceCount,"DataServices");
+    zowelog(NULL, LOG_COMP_DATASERVICE, ZOWE_LOG_INFO, "Plugin=%s, found %d data service(s)\n", plugin->identifier, plugin->dataServiceCount);
+    if (plugin->dataServiceCount > 0) {
+      plugin->dataServices = (DataService**)safeMalloc(sizeof(DataService*) * plugin->dataServiceCount,"DataServices");
+    }
     int k = 0;
     for (int i = 0; i < jsonArrayGetCount(dataServices); i++) {
       JsonObject *serviceDef = jsonArrayGetObject(dataServices, i);
@@ -323,7 +325,7 @@ WebPlugin *makeWebPlugin(char *pluginLocation, JsonObject *pluginDefintion, Inte
       }
     }
   }
-  zowelog(NULL, LOG_COMP_DATASERVICE, ZOWE_LOG_INFO, "%s end\n", __FUNCTION__);
+  zowelog(NULL, LOG_COMP_DATASERVICE, ZOWE_LOG_DEBUG2, "%s end\n", __FUNCTION__);
   return plugin;
 }
 
@@ -333,7 +335,7 @@ HttpService *makeHttpDataService(DataService *dataService, HttpServer *server) {
   HttpService *httpService = NULL;
   result = makeHttpDataServiceUrlMask(dataService, urlMask, sizeof(urlMask), server->defaultProductURLPrefix);
   if (result != -1) {
-    printf("installing service %s at URI %s\n", dataService->identifier, urlMask);
+    zowelog(NULL, LOG_COMP_DATASERVICE, ZOWE_LOG_INFO, "Installing dataservice %s to URI %s\n", dataService->identifier, urlMask);
     httpService = makeGeneratedService(dataService->identifier, urlMask);
     httpService->authType = SERVICE_AUTH_NATIVE_WITH_SESSION_TOKEN; /* The default */
     registerHttpService(server, httpService);

--- a/c/dataservice.c
+++ b/c/dataservice.c
@@ -300,6 +300,8 @@ WebPlugin *makeWebPlugin(char *pluginLocation, JsonObject *pluginDefintion, Inte
     zowelog(NULL, LOG_COMP_DATASERVICE, ZOWE_LOG_INFO, "Plugin=%s, found %d data service(s)\n", plugin->identifier, plugin->dataServiceCount);
     if (plugin->dataServiceCount > 0) {
       plugin->dataServices = (DataService**)safeMalloc(sizeof(DataService*) * plugin->dataServiceCount,"DataServices");
+    } else {
+      plugin->dataServices = NULL;
     }
     int k = 0;
     for (int i = 0; i < jsonArrayGetCount(dataServices); i++) {


### PR DESCRIPTION
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>

Before:
```
reading server settings from /u/tsspg/bt/zlux/zlux-app-server/bin/../deploy/instance/ZLUX/serverConfig/zluxserver.json
productDir is '../deploy/product'
siteDir is '../deploy/site'
instanceDir is '../deploy/instance'
groupsDir is '../deploy/instance/groups'
usersDir is '../deploy/instance/users'
pluginsDir is '../deploy/instance/ZLUX/plugins'
Host name is DNS or non-numeric, 0
*** WARNING: Server doesn't implement HTTPS! ***
*** In production only use localhost or 127.0.0.1! Server using: 0.0.0.0 ***
ZSS server settings: address=0.0.0.0, port=12224
Will not accept JWTs: JWT keystore configuration missing
privilegedServerName or env ZWED_privilegedServerName is not specified, or is NULL.
warning: privileged server name not provided, falling back to default
For plugin=org.zowe.configjs, found 0 data service(s)
MALLOC failed, got NULL for size 0 at site DataServices
initalizeWebPlugin begin, count=0
initalizeWebPlugin end
initalizeWebPlugin begin, count=0
initalizeWebPlugin end
For plugin=org.zowe.terminal.proxy, found 0 data service(s)
MALLOC failed, got NULL for size 0 at site DataServices
initalizeWebPlugin begin, count=0
initalizeWebPlugin end
For plugin=org.zowe.terminal.tn3270, found 1 data service(s)
added identifier for org.zowe.terminal.tn3270/statediscovery
lookup count=1 name=zosDiscoveryServiceInstaller
Service=org.zowe.terminal.tn3270/statediscovery initializer set internal method=0x367FCDAC
initalizeWebPlugin begin, count=1
zosDiscoveryServiceInstaller begin
installing service org.zowe.terminal.tn3270/statediscovery at URI /ZLUX/plugins/org.zowe.terminal.tn3270/services/statediscovery/**
zosDiscoveryServiceInstaller end
initalizeWebPlugin end
initalizeWebPlugin begin, count=0
initalizeWebPlugin end
initalizeWebPlugin begin, count=0
initalizeWebPlugin end
For plugin=org.zowe.zlux.auth.zosmf, found 0 data service(s)
MALLOC failed, got NULL for size 0 at site DataServices
initalizeWebPlugin begin, count=0
initalizeWebPlugin end
initalizeWebPlugin begin, count=0
initalizeWebPlugin end
For plugin=org.zowe.zlux.bootstrap, found 0 data service(s)
MALLOC failed, got NULL for size 0 at site DataServices
initalizeWebPlugin begin, count=0
initalizeWebPlugin end
initalizeWebPlugin begin, count=0
initalizeWebPlugin end
For plugin=org.zowe.zlux.ng2desktop, found 0 data service(s)
MALLOC failed, got NULL for size 0 at site DataServices
initalizeWebPlugin begin, count=0
initalizeWebPlugin end
For plugin=org.zowe.zlux.proxy.zosmf, found 0 data service(s)
MALLOC failed, got NULL for size 0 at site DataServices
initalizeWebPlugin begin, count=0
initalizeWebPlugin end
For plugin=org.zowe.zlux.sample.angular, found 0 data service(s)
MALLOC failed, got NULL for size 0 at site DataServices
initalizeWebPlugin begin, count=0
initalizeWebPlugin end
For plugin=org.zowe.zlux.sample.iframe, found 0 data service(s)
MALLOC failed, got NULL for size 0 at site DataServices
initalizeWebPlugin begin, count=0
initalizeWebPlugin end
For plugin=org.zowe.zlux.sample.react, found 0 data service(s)
MALLOC failed, got NULL for size 0 at site DataServices
initalizeWebPlugin begin, count=0
initalizeWebPlugin end
For plugin=org.zowe.zosmf.workflows, found 0 data service(s)
MALLOC failed, got NULL for size 0 at site DataServices
initalizeWebPlugin begin, count=0
initalizeWebPlugin end
For plugin=org.zowe.zlux.jupyter-app, found 0 data service(s)
MALLOC failed, got NULL for size 0 at site DataServices
initalizeWebPlugin begin, count=0
initalizeWebPlugin end
For plugin=org.zowe.javamissingwar, found 0 data service(s)
MALLOC failed, got NULL for size 0 at site DataServices
initalizeWebPlugin begin, count=0
initalizeWebPlugin end
For plugin=org.zowe.javatestimport, found 0 data service(s)
MALLOC failed, got NULL for size 0 at site DataServices
initalizeWebPlugin begin, count=0
initalizeWebPlugin end
For plugin=org.zowe.javatestwar, found 0 data service(s)
MALLOC failed, got NULL for size 0 at site DataServices
initalizeWebPlugin begin, count=0
initalizeWebPlugin end
Installing VSAM dataset contents service
Installing dataset metadata service
Installing dataset contents service
ZIS status - Ok (name='ZWESIS_STD      ', cmsRC=0, description='Ok', clientVersion=2)
```

After:
```
productDir is '../deploy/product'
siteDir is '../deploy/site'
instanceDir is '../deploy/instance'
groupsDir is '../deploy/instance/groups'
usersDir is '../deploy/instance/users'
pluginsDir is '../deploy/instance/ZLUX/plugins'
Host name is DNS or non-numeric, 0
*** WARNING: Server doesn't implement HTTPS! ***
*** In production only use localhost or 127.0.0.1! Server using: 0.0.0.0 ***
ZSS server settings: address=0.0.0.0, port=12224
Will not accept JWTs: JWT keystore configuration missing
privilegedServerName or env ZWED_privilegedServerName is not specified, or is NULL.
warning: privileged server name not provided, falling back to default
added identifier for org.zowe.terminal.tn3270/statediscovery
lookup count=1 name=zosDiscoveryServiceInstaller
Service=org.zowe.terminal.tn3270/statediscovery initializer set internal method=0x367FCDAC
zosDiscoveryServiceInstaller begin
zosDiscoveryServiceInstaller end
Installing VSAM dataset contents service
Installing dataset metadata service
Installing dataset contents service
ZIS status - Ok (name='ZWESIS_STD      ', cmsRC=0, description='Ok', clientVersion=2)
```