### PR TITLE
Use caller's key when making the msg queue cell pool to prevent SC78.

### DIFF
--- a/c/crossmemory.c
+++ b/c/crossmemory.c
@@ -1935,7 +1935,7 @@ static int allocServerResources(CrossMemoryServer *server) {
                       CMS_MSG_QUEUE_MAIN_POOL_SSIZE,
                       msgQueueCellSize,
                       CMS_MSG_QUEUE_SUBPOOL,
-                      CROSS_MEMORY_SERVER_KEY,
+                      getCurrentKey(),
                       &(CPHeader){"ZWESCMSMSGMCELLPOOL     "});
     if (server->messageQueueMainPool == CPID_NULL) {
       status = RC_CMS_MSG_QUEUE_NOT_CREATED;
@@ -1947,7 +1947,7 @@ static int allocServerResources(CrossMemoryServer *server) {
                       0,
                       msgQueueCellSize,
                       CMS_MSG_QUEUE_SUBPOOL,
-                      CROSS_MEMORY_SERVER_KEY,
+                      getCurrentKey(),
                       &(CPHeader){"ZWESCMSMSGFCELLPOOL     "});
     if (server->messageQueueFallbackPool == CPID_NULL) {
       status = RC_CMS_MSG_QUEUE_NOT_CREATED;


### PR DESCRIPTION
In case when the cross memory server has not been started in key 4, for
example, not APF authorized, allocate the cell pools in the current key
to prevent SC78-10.