### PR TITLE
Control LPA dev mode with a run-time option

### DIFF
--- a/c/crossmemory.c
+++ b/c/crossmemory.c
@@ -2641,7 +2641,7 @@ static int allocateGlobalResources(CrossMemoryServer *server) {
       if (server->flags & CROSS_MEMORY_SERVER_FLAG_CLEAN_LPA) {
         /* If the "clean LPA" flag is set or in dev mode, force the server to
          * remove the existing LPA module if the private module doesn't match
-         * it. This will help avoid abandoning too many module in LPA during
+         * it. This will help avoid abandoning too many modules in LPA during
          * development. */
         zowelog(NULL, LOG_COMP_ID_CMS, ZOWE_LOG_INFO, CMS_LOG_DEBUG_MSG_ID
                 " LPA dev mode enabled, issuing CSVDYLPA DELETE\n");

--- a/h/crossmemory.h
+++ b/h/crossmemory.h
@@ -393,7 +393,8 @@ ZOWE_PRAGMA_PACK_RESET
 #define CMS_SERVER_FLAG_COLD_START            0x00000001
 #define CMS_SERVER_FLAG_DEBUG                 0x00000002
 #define CMS_SERVER_FLAG_CHECKAUTH             0x00000004
-#define CMS_SERVER_FLAG_CLEAN_LPA             0x00000008
+#define CMS_SERVER_FLAG_DEV_MODE              0x00000008
+#define CMS_SERVER_FLAG_DEV_MODE_LPA          0x00000010
 
 #define CMS_SERVICE_FLAG_NONE                 0x00000000
 #define CMS_SERVICE_FLAG_SPACE_SWITCH         0x00000001
@@ -850,11 +851,11 @@ CrossMemoryServerName cmsMakeServerName(const char *nameNullTerm);
 #define CMS_LOG_SRVC_ENTRY_OCCUPIED_MSG_TEXT    "Service entry %d is occupied"
 #define CMS_LOG_SRVC_ENTRY_OCCUPIED_MSG         CMS_LOG_SRVC_ENTRY_OCCUPIED_MSG_ID" "CMS_LOG_SRVC_ENTRY_OCCUPIED_MSG_TEXT
 
-#ifndef CMS_LOG_CLEAN_LPA_MSG_ID
-#define CMS_LOG_CLEAN_LPA_MSG_ID                CMS_MSG_PRFX"0247W"
+#ifndef CMS_LOG_DEV_MODE_ON_MSG_ID
+#define CMS_LOG_DEV_MODE_ON_MSG_ID              CMS_MSG_PRFX"0247W"
 #endif
-#define CMS_LOG_CLEAN_LPA_MSG_TEXT              "Unsafe LPA development mode is enabled"
-#define CMS_LOG_CLEAN_LPA_MSG                   CMS_LOG_CLEAN_LPA_MSG_ID" "CMS_LOG_CLEAN_LPA_MSG_TEXT
+#define CMS_LOG_DEV_MODE_ON_MSG_TEXT            "Development mode is enabled"
+#define CMS_LOG_DEV_MODE_ON_MSG                 CMS_LOG_DEV_MODE_ON_MSG_ID" "CMS_LOG_DEV_MODE_ON_MSG_TEXT
 
 #endif /* H_CROSSMEMORY_H_ */
 

--- a/h/crossmemory.h
+++ b/h/crossmemory.h
@@ -293,6 +293,7 @@ typedef struct CrossMemoryServer_tag {
 #define CROSS_MEMORY_SERVER_FLAG_TERM_STARTED 0x00000004
 #define CROSS_MEMORY_SERVER_FLAG_TERM_ENDED   0x00000008
 #define CROSS_MEMORY_SERVER_FLAG_CHECKAUTH    0x00000010
+#define CROSS_MEMORY_SERVER_FLAG_CLEAN_LPA    0x00000020
   STCBase * __ptr32 base;
   CMSStarCallback * __ptr32 startCallback;
   CMSStopCallback * __ptr32 stopCallback;
@@ -392,6 +393,7 @@ ZOWE_PRAGMA_PACK_RESET
 #define CMS_SERVER_FLAG_COLD_START            0x00000001
 #define CMS_SERVER_FLAG_DEBUG                 0x00000002
 #define CMS_SERVER_FLAG_CHECKAUTH             0x00000004
+#define CMS_SERVER_FLAG_CLEAN_LPA             0x00000008
 
 #define CMS_SERVICE_FLAG_NONE                 0x00000000
 #define CMS_SERVICE_FLAG_SPACE_SWITCH         0x00000001
@@ -847,6 +849,12 @@ CrossMemoryServerName cmsMakeServerName(const char *nameNullTerm);
 #endif
 #define CMS_LOG_SRVC_ENTRY_OCCUPIED_MSG_TEXT    "Service entry %d is occupied"
 #define CMS_LOG_SRVC_ENTRY_OCCUPIED_MSG         CMS_LOG_SRVC_ENTRY_OCCUPIED_MSG_ID" "CMS_LOG_SRVC_ENTRY_OCCUPIED_MSG_TEXT
+
+#ifndef CMS_LOG_CLEAN_LPA_MSG_ID
+#define CMS_LOG_CLEAN_LPA_MSG_ID                CMS_MSG_PRFX"0247W"
+#endif
+#define CMS_LOG_CLEAN_LPA_MSG_TEXT              "Unsafe LPA development mode is enabled"
+#define CMS_LOG_CLEAN_LPA_MSG                   CMS_LOG_CLEAN_LPA_MSG_ID" "CMS_LOG_CLEAN_LPA_MSG_TEXT
 
 #endif /* H_CROSSMEMORY_H_ */
 


### PR DESCRIPTION
**Overview**

This pull-request adds a new control flag. The flag allows users to enable the LPA dev mode without recompiling the module. In the LPA dev mode, the ZWESIS01 module will always be refreshed at start up and removed from LPA upon termination. This latter should make the memory footprint smaller in a development environment.

Since removing modules from LPA is considered dangerous, a new warning message will be issued to the SYSLOG and SYSPRINT if the new mode is enabled:
```
ZWES0247W Development mode is enabled
```

