### PR TITLE
Check if cross-memory server runs as a reusable address space

### DIFF
--- a/h/crossmemory.h
+++ b/h/crossmemory.h
@@ -857,6 +857,12 @@ CrossMemoryServerName cmsMakeServerName(const char *nameNullTerm);
 #define CMS_LOG_DEV_MODE_ON_MSG_TEXT            "Development mode is enabled"
 #define CMS_LOG_DEV_MODE_ON_MSG                 CMS_LOG_DEV_MODE_ON_MSG_ID" "CMS_LOG_DEV_MODE_ON_MSG_TEXT
 
+#ifndef CMS_LOG_REUSASID_NO_MSG_ID
+#define CMS_LOG_REUSASID_NO_MSG_ID              CMS_MSG_PRFX"0248W"
+#endif
+#define CMS_LOG_REUSASID_NO_MSG_TEXT            "Address space is not reusable, start with REUSASID=YES to prevent an ASID shortage"
+#define CMS_LOG_REUSASID_NO_MSG                 CMS_LOG_REUSASID_NO_MSG_ID" "CMS_LOG_REUSASID_NO_MSG_TEXT
+
 #endif /* H_CROSSMEMORY_H_ */
 
 


### PR DESCRIPTION
**Overview**

The use of a cross-memory server without REUSASID=YES may result in an ASID shortage. This pull-request adds a check that and prints a warning if the check fails. Additionally, some environment checks have been consolidated into a single function.
