### PR TITLE
Keep the connection when Keep-Alive is specified.

### DIFF
--- a/h/http.h
+++ b/h/http.h
@@ -153,6 +153,7 @@ typedef struct HttpRequest_tag{
   HttpRequestParam *processedParamList;
   struct HttpRequest_tag *next;
   const void *authToken;   /* a JWT or other */
+  int keepAlive;
 } HttpRequest;
 
 /*************** WebSocket Stuff ********************/

--- a/h/httpserver.h
+++ b/h/httpserver.h
@@ -110,6 +110,7 @@ typedef struct HttpRequestParser{
   int httpReasonCode;
   char *message;
   HttpRequest *requestQHead;
+  int keepAlive;
 } HttpRequestParser;
 
 


### PR DESCRIPTION
This pull-request fixes a bug reported by QA - ZSS must keep the connection if it responses to with 404 to a request with "Connection: Keep-Alive".

The code only handles `Connection: Keep-Alive`, the others "Keep-Alive" properties are ignored.