### PR TITLE
Verify that the STC user has an OMVS segment

### DIFF
--- a/c/crossmemory.c
+++ b/c/crossmemory.c
@@ -4068,7 +4068,7 @@ static bool isDubStatusOk(int *status, int *bpxRC, int *bpxRSN) {
           CMS_LOG_DEBUG_MSG_ID" BPXnQDB RV = %d, RC = %d, RSN = 0x%08X\n",
           *status, *bpxRC, *bpxRSN);
 
-  if (*status == dubFailRC){
+  if (*status == dubFailRC) {
     return false;
   }
 

--- a/h/crossmemory.h
+++ b/h/crossmemory.h
@@ -137,7 +137,8 @@
 #define RC_CMS_NO_STORAGE_FOR_MSG           86
 #define RC_CMS_ALLOC_FAILED                 87
 #define RC_CMS_NON_PRIVATE_MODULE           88
-#define RC_CMS_MAX_RC                       88
+#define RC_CMS_BAD_OMVS_SEGMENT             89
+#define RC_CMS_MAX_RC                       89
 
 extern const char *CMS_RC_DESCRIPTION[];
 
@@ -869,6 +870,12 @@ CrossMemoryServerName cmsMakeServerName(const char *nameNullTerm);
 #endif
 #define CMS_LOG_NON_PRIVATE_MODULE_MSG_TEXT     "Module ZWESIS01 is loaded from common storage, ensure ZWESIS01 is valid in STEPLIB"
 #define CMS_LOG_NON_PRIVATE_MODULE_MSG          CMS_LOG_NON_PRIVATE_MODULE_MSG_ID" "CMS_LOG_NON_PRIVATE_MODULE_MSG_TEXT
+
+#ifndef CMS_LOG_BPX_ERROR_MSG_ID
+#define CMS_LOG_BPX_ERROR_MSG_ID                CMS_MSG_PRFX"0250E"
+#endif
+#define CMS_LOG_BPX_ERROR_MSG_TEXT              "BPX check RC = %d, RSN = 0x%04X, verify that the started task user has an OMVS segment"
+#define CMS_LOG_BPX_ERROR_MSG                   CMS_LOG_BPX_ERROR_MSG_ID" "CMS_LOG_BPX_ERROR_MSG_TEXT
 
 #endif /* H_CROSSMEMORY_H_ */
 

--- a/h/crossmemory.h
+++ b/h/crossmemory.h
@@ -137,7 +137,7 @@
 #define RC_CMS_NO_STORAGE_FOR_MSG           86
 #define RC_CMS_ALLOC_FAILED                 87
 #define RC_CMS_NON_PRIVATE_MODULE           88
-#define RC_CMS_BAD_OMVS_SEGMENT             89
+#define RC_CMS_BAD_DUB_STATUS               89
 #define RC_CMS_MAX_RC                       89
 
 extern const char *CMS_RC_DESCRIPTION[];
@@ -871,11 +871,11 @@ CrossMemoryServerName cmsMakeServerName(const char *nameNullTerm);
 #define CMS_LOG_NON_PRIVATE_MODULE_MSG_TEXT     "Module ZWESIS01 is loaded from common storage, ensure ZWESIS01 is valid in STEPLIB"
 #define CMS_LOG_NON_PRIVATE_MODULE_MSG          CMS_LOG_NON_PRIVATE_MODULE_MSG_ID" "CMS_LOG_NON_PRIVATE_MODULE_MSG_TEXT
 
-#ifndef CMS_LOG_BPX_ERROR_MSG_ID
-#define CMS_LOG_BPX_ERROR_MSG_ID                CMS_MSG_PRFX"0250E"
+#ifndef CMS_LOG_DUB_ERROR_MSG_ID
+#define CMS_LOG_DUB_ERROR_MSG_ID                CMS_MSG_PRFX"0250E"
 #endif
-#define CMS_LOG_BPX_ERROR_MSG_TEXT              "BPX check RC = %d, RSN = 0x%04X, verify that the started task user has an OMVS segment"
-#define CMS_LOG_BPX_ERROR_MSG                   CMS_LOG_BPX_ERROR_MSG_ID" "CMS_LOG_BPX_ERROR_MSG_TEXT
+#define CMS_LOG_DUB_ERROR_MSG_TEXT              "Bad dub status %d (%d,0x%04X), verify that the started task user has an OMVS segment"
+#define CMS_LOG_DUB_ERROR_MSG                   CMS_LOG_DUB_ERROR_MSG_ID" "CMS_LOG_DUB_ERROR_MSG_TEXT
 
 #endif /* H_CROSSMEMORY_H_ */
 


### PR DESCRIPTION
### Overview
There's been a lot of confusion when users would start ZIS under a user without an OMVS segment and ZIS would silently crash. This pull-request adds an explicit BPX call which should verify if the STC user has an OMVS segment ans is able to perform BPX calls later in the program.

Fixes zowe/zss#189
