### PR TITLE
Use Chunked Transfer Encoding for sending Unix files

### DIFF
--- a/c/httpserver.c
+++ b/c/httpserver.c
@@ -4186,11 +4186,23 @@ static int streamBinaryForFile2(HttpResponse *response, Socket *socket, UnixFile
   int encodedLength;
   ChunkedOutputStream *stream = NULL;
 
-  if (encoding == ENCODING_GZIP || (encoding == ENCODING_CHUNKED && !response)) {
-#ifdef DEBUG	
-    printf("HELP - not implemented\n");	
+  if ((response && socket) || (!response && !socket)) {
+#ifdef DEBUG
+    printf("bad arguments: either response or socket must be not NULL, never both\n");	
 #endif
-    return 0;
+    return 8;
+  }
+  if (encoding == ENCODING_GZIP) {
+#ifdef DEBUG
+    printf("GZIP encoding not implemented\n");	
+#endif
+    return 8;
+  }
+  if (encoding == ENCODING_CHUNKED && !response) {
+#ifdef DEBUG
+    printf("bad arguments: response must be not NULL to use chunked encoding\n");	
+#endif
+    return 8;
   }
   if (encoding == ENCODING_CHUNKED) {
     stream = makeChunkedOutputStreamInternal(response);
@@ -4252,13 +4264,19 @@ static int streamTextForFile2(HttpResponse *response, Socket *socket, UnixFile *
      A: You can't. There is no equivalent of USS character encoding tags on
         other Unix systems. Hence, things like the .htaccess (for Apache).
   */
+  if ((response && socket) || (!response && !socket)) {
+#ifdef DEBUG	
+    printf("bad arguments: either response or socket must be not NULL, never both\n");	
+#endif
+    return 8;
+  }
   switch (encoding){
   case ENCODING_CHUNKED:
     if (!response) {
 #ifdef DEBUG	
-      printf("HELP - not implemented\n");	
+      printf("bad arguments: response must be not NULL to use chunked encoding\n");	
 #endif	
-      break;
+      return 8;
     }
     stream = makeChunkedOutputStreamInternal(response);
     /* fallthrough */

--- a/c/httpserver.c
+++ b/c/httpserver.c
@@ -4234,6 +4234,7 @@ static int streamBinaryForFile2(HttpResponse *response, Socket *socket, UnixFile
     if (NULL != encodedBuffer) safeFree31(encodedBuffer, ENCODE64_SIZE(bytesRead)+1);
   }
   if (encoding == ENCODING_CHUNKED) {
+    /* finish the chunked output here because finishResponse will not flush this stream's data */
     finishChunkedOutput(stream, NO_TRANSLATE);
   }
 
@@ -4363,6 +4364,7 @@ static int streamTextForFile2(HttpResponse *response, Socket *socket, UnixFile *
       bytesSent += encodedLength;
     }
     if (encoding == ENCODING_CHUNKED) {
+      /* finish the chunked output here because finishResponse will not flush this stream's data */
       finishChunkedOutput(stream, NO_TRANSLATE);
     }
     break;

--- a/c/httpserver.c
+++ b/c/httpserver.c
@@ -3937,6 +3937,10 @@ bool isCachedCopyModified(HttpRequest *req, uint64_t etag, time_t mtime) {
   return true;
 }
 
+static int streamBinaryForFile2(HttpResponse *response, Socket *socket, UnixFile *in, int encoding, bool asB64);
+static int streamTextForFile2(HttpResponse *response, Socket *socket, UnixFile *in, int encoding,
+                      int sourceCCSID, int targetCCSID, bool asB64);
+
 // Response must ALWAYS be finished on return
 void respondWithUnixFile2(HttpService* service, HttpResponse* response, char* absolutePath, int jsonMode, int autocvt, bool asB64) {
   FileInfo info;
@@ -4002,7 +4006,7 @@ void respondWithUnixFile2(HttpService* service, HttpResponse* response, char* ab
     addStringHeader(response,"Server","jdmfws");
     addStringHeader(response, "Cache-control", "no-store");
     addStringHeader(response, "Pragma", "no-cache");
-    addIntHeader(response, "Content-Length", asB64 ? 4 * ((fileSize + 2) / 3) : fileSize); /* Is this safe post-conversion??? */
+    addStringHeader(response, "Transfer-Encoding", "chunked");
     setContentType(response, mimeType);
     addCacheRelatedHeaders(response, mtime, etag);
 
@@ -4018,7 +4022,7 @@ void respondWithUnixFile2(HttpService* service, HttpResponse* response, char* ab
       printf("Streaming binary for %s\n", absolutePath);
 #endif
       
-      streamBinaryForFile(response->socket, in, asB64);
+      streamBinaryForFile2(response, NULL, in, ENCODING_CHUNKED, asB64);
     } else {
       writeHeader(response);
 #ifdef DEBUG
@@ -4049,9 +4053,9 @@ void respondWithUnixFile2(HttpService* service, HttpResponse* response, char* ab
 #endif
         ;
       if (ccsid == 0) {
-        streamTextForFile(response->socket, in, ENCODING_SIMPLE, NATIVE_CODEPAGE, webCodePage, asB64);
+        streamTextForFile2(response, NULL, in, ENCODING_CHUNKED, NATIVE_CODEPAGE, webCodePage, asB64);
       } else {
-        streamTextForFile(response->socket, in, ENCODING_SIMPLE, ccsid, webCodePage, asB64);
+        streamTextForFile2(response, NULL, in, ENCODING_CHUNKED, ccsid, webCodePage, asB64);
       }
 
 #ifdef USE_CONTINUE_RESPONSE_HACK
@@ -4170,13 +4174,27 @@ void respondWithJsonError(HttpResponse *response, char *error, int statusCode, c
 
 #define ENCODE64_SIZE(SZ) (2 + 4 * ((SZ + 2) / 3))
 
-int streamBinaryForFile(Socket *socket, UnixFile *in, bool asB64) {
+/*
+  * when encoding is ENCODING_SIMPLE then socket is mandatory
+  * when encoding is ENCODING_CHUNKED then response is mandatory
+*/
+static int streamBinaryForFile2(HttpResponse *response, Socket *socket, UnixFile *in, int encoding, bool asB64) {
   int returnCode = 0;
   int reasonCode = 0;
   int bufferSize = FILE_STREAM_BUFFER_SIZE;
   char buffer[bufferSize+4];
   int encodedLength;
+  ChunkedOutputStream *stream = NULL;
 
+  if (encoding == ENCODING_GZIP || (encoding == ENCODING_CHUNKED && !response)) {
+#ifdef DEBUG	
+    printf("HELP - not implemented\n");	
+#endif
+    return 0;
+  }
+  if (encoding == ENCODING_CHUNKED) {
+    stream = makeChunkedOutputStreamInternal(response);
+  }
   while (!fileEOF(in)) {
     int bytesRead = fileRead(in,buffer,bufferSize,&returnCode,&reasonCode);
     if (bytesRead <= 0) {
@@ -4195,15 +4213,30 @@ int streamBinaryForFile(Socket *socket, UnixFile *in, bool asB64) {
     }
     char *outPtr = asB64 ? encodedBuffer : buffer;
     int outLen = asB64 ? encodedLength : bytesRead;
-    writeFully(socket, outPtr, outLen);
+    if (encoding == ENCODING_CHUNKED) {
+      writeBytes(stream, outPtr, outLen, NO_TRANSLATE);
+    } else {
+      writeFully(socket, outPtr, outLen);
+    }
 
     if (NULL != encodedBuffer) safeFree31(encodedBuffer, ENCODE64_SIZE(bytesRead)+1);
+  }
+  if (encoding == ENCODING_CHUNKED) {
+    finishChunkedOutput(stream, NO_TRANSLATE);
   }
 
   return 0;
 }
-  
-int streamTextForFile(Socket *socket, UnixFile *in, int encoding,
+
+int streamBinaryForFile(Socket *socket, UnixFile *in, bool asB64) {
+  return streamBinaryForFile2(NULL, socket, in, ENCODING_SIMPLE, asB64);
+}
+
+/*
+  * when encoding is ENCODING_SIMPLE then socket is mandatory
+  * when encoding is ENCODING_CHUNKED then response is mandatory
+*/
+static int streamTextForFile2(HttpResponse *response, Socket *socket, UnixFile *in, int encoding,
                       int sourceCCSID, int targetCCSID, bool asB64) {
   int returnCode = 0;
   int reasonCode = 0;
@@ -4212,6 +4245,7 @@ int streamTextForFile(Socket *socket, UnixFile *in, int encoding,
   char buffer[bufferSize+4];
   char translation[(2*bufferSize)+4]; /* UTF inflation tolerance */
   int encodedLength;
+  ChunkedOutputStream *stream = NULL;
 
 
   /* Q: How do we find character encoding for unix file? 
@@ -4219,6 +4253,15 @@ int streamTextForFile(Socket *socket, UnixFile *in, int encoding,
         other Unix systems. Hence, things like the .htaccess (for Apache).
   */
   switch (encoding){
+  case ENCODING_CHUNKED:
+    if (!response) {
+#ifdef DEBUG	
+      printf("HELP - not implemented\n");	
+#endif	
+      break;
+    }
+    stream = makeChunkedOutputStreamInternal(response);
+    /* fallthrough */
   case ENCODING_SIMPLE:
     while (!fileEOF(in)){
 #ifdef DEBUG
@@ -4293,15 +4336,17 @@ int streamTextForFile(Socket *socket, UnixFile *in, int encoding,
         outPtr = encodedBuffer;
         outLen = encodedLength;
       }
-      writeFully(socket,outPtr,(int) outLen);
+      if (encoding == ENCODING_CHUNKED) {
+        writeBytes(stream, outPtr, (int) outLen, NO_TRANSLATE);
+      } else {
+        writeFully(socket,outPtr,(int) outLen);
+      }
       if (NULL != encodedBuffer) safeFree31(encodedBuffer, allocSize);
       bytesSent += encodedLength;
     }
-    break;
-  case ENCODING_CHUNKED:
-#ifdef DEBUG
-    printf("HELP - not implemented\n");
-#endif
+    if (encoding == ENCODING_CHUNKED) {
+      finishChunkedOutput(stream, NO_TRANSLATE);
+    }
     break;
   case ENCODING_GZIP:
 #ifdef DEBUG
@@ -4316,6 +4361,11 @@ int streamTextForFile(Socket *socket, UnixFile *in, int encoding,
            encoding, sourceCCSID, targetCCSID, asB64, bytesSent);
   }
   return 1;
+}
+
+int streamTextForFile(Socket *socket, UnixFile *in, int encoding,
+                      int sourceCCSID, int targetCCSID, bool asB64) {
+  return streamTextForFile2(NULL, socket, in, encoding, sourceCCSID, targetCCSID, asB64);
 }
 
 int runServiceThread(Socket *socket){


### PR DESCRIPTION
The purpose of this PR is to fix various issues when the number in `Content-length` response header mismatches with actual content length. Chunked Transfer Encoding is supposed to solve all the issues.