### PR TITLE
Add a hex dump core service to the cross-memory server.

### DIFF
--- a/h/crossmemory.h
+++ b/h/crossmemory.h
@@ -446,7 +446,32 @@ int cmsCallService2(CrossMemoryServerGlobalArea *cmsGlobalArea,
                     int serviceID, void *parmList, int *serviceRC);
 int cmsCallService3(CrossMemoryServerGlobalArea *cmsGlobalArea,
                     int serviceID, void *parmList, int flags, int *serviceRC);
+
+/**
+ * @brief Print a message to a cross-memory server's log
+ * @param serverName Cross-memory server to whose log the message is to be
+ * printed
+ * @param formatString Format string of the message
+ * @return RC_CMS_OK in case of success, and one of the RC_CMS_nn values in
+ * case of failure
+ */
 int cmsPrintf(const CrossMemoryServerName *serverName, const char *formatString, ...);
+
+/**
+ * @brief Print the hex dump of the specified storage to a cross-memory server's
+ * log
+ * @param serverName Cross-memory server to whose log the dump is to be printed
+ * @param data Data to be printed
+ * @param size Size of the data (the maximum size is 512 bytes, the rest will
+ * be truncated)
+ * @param description Description of the data (the maximum length is 31
+ * characters, the rest will be truncated)
+ * @return RC_CMS_OK in case of success, and one of the RC_CMS_nn values in
+ * case of failure
+ */
+int cmsHexDump(const CrossMemoryServerName *serverName,
+               const void *data, unsigned size, const char *description);
+
 int cmsGetConfigParm(const CrossMemoryServerName *serverName, const char *name,
                      CrossMemoryServerConfigParm *parm);
 int cmsGetPCLogLevel(const CrossMemoryServerName *serverName);


### PR DESCRIPTION
### Overview
Until now the users of the cross-memory server could only print simple one line messages to the cross-memory server's log and had no ability to print hex dumps. This pull-request adds a new core service and a client wrapper function which allow users to dump private storage inside cross-memory calls.

Limitations:
* The data size is limited to 512 bytes
* The description length is limited to 31 characters

An example of output (the messages with id ZWES0101I, some lines have been removed to keep this block short):
```
DATESTAMP              JOBNAME  ASCB    (ASID) TCB       MSGID     MSGTEXT                                                     
2020/07/23-09:42:34.41 ZWESISIF 00FBBA00(007A) 008F8588  ZWES0001I ZSS Cross-Memory Server starting, version is 1.13.0+20200723
2020/07/23-09:42:34.41 ZWESISIF 00FBBA00(007A) 008F8588  ZWES0002I Input parameters at 0x6FE6:                                 
. . .
2020/07/23-10:17:24.87 SRBTEST  00F93380(002D) 00000000  ZWES0101I Dump of 'very first page' (4096 bytes at 0x0):                  
                                                         ZWES0101I 00000000  000A0000 000130E1 00000000 00000000 |................|
                                                         ZWES0101I 00000010  00FD9350 00000000 7FFFF000 7FFFF000 |..l&....".0.".0.|
                                                         ZWES0101I 00000020  7FFFF000 7FFFF000 7FFFF000 7FFFF000 |".0.".0.".0.".0.|
                                                         ZWES0101I 00000030  00000000 00000000 7FFFF000 7FFFF000 |........".0.".0.|
. . .
                                                         ZWES0101I 000001E0  00000000 80000000 00000000 7E8FD8D8 |............=.QQ|
                                                         ZWES0101I 000001F0  04040000 80000000 00000000 011F8500 |..............e.|
                                                         ZWES0101I . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 
                                                         ZWES0101I 3584 bytes have been truncated                                    
```