### PR TITLE
Add .env mime type, reorg mime types, and more zowelog

### DIFF
--- a/c/httpserver.c
+++ b/c/httpserver.c
@@ -3662,25 +3662,17 @@ char *getMimeType(char *extension, int *isBinary) {
 }
 
 static char *getMimeType2(char *extension, int *isBinary, int dotPos){
-  if (!strcmp(extension,"gif")){
-    *isBinary = TRUE;
-    return "image/gif";
-  } else if (!strcmp(extension,"jpg")){
-    *isBinary = TRUE;
-    return "image/jpeg";
-  } else if (!strcmp(extension,"png")){
-    *isBinary = TRUE;
-    return "image/png";
-  } else if (!strcmp(extension,"js")){
+  if (!strcmp(extension,"js")){
     *isBinary = FALSE;
     return "text/javascript";
   } else if (!strcmp(extension,"ts")){
     *isBinary = FALSE;
     return "text/typescript";
-  } else if (!strcmp(extension,"ts") || !strcmp(extension,"txt") ||
+  } else if (!strcmp(extension,"txt") ||
         !strcmp(extension,"c") || !strcmp(extension,"py") || !strcmp(extension,"rexx") ||
         !strcmp(extension,"cbl") || !strcmp(extension,"cpy") || !strcmp(extension,"asm") ||
         !strcmp(extension,"cpp") || !strcmp(extension,"h") || !strcmp(extension,"log") ||
+        !strcmp(extension,"env")
         (dotPos == 0)){
     *isBinary = FALSE;
     return "text/plain";
@@ -3691,6 +3683,36 @@ static char *getMimeType2(char *extension, int *isBinary, int dotPos){
   } else if (!strcmp(extension,"css")){
     *isBinary = FALSE;
     return "text/css";
+  } else if(!strcmp(extension,"md")) {
+    *isBinary = FALSE;
+    return "text/markdown";
+  } else if(!strcmp(extension,"bin")) {
+    *isBinary = TRUE;
+    return "application/octet-stream";
+  } else if(!strcmp(extension,"gz")) {
+    *isBinary = TRUE;
+    return "application/gzip";
+  } else if(!strcmp(extension,"jar")) {
+    *isBinary = TRUE;
+    return "application/java-archive";
+  } else if(!strcmp(extension,"json")) {
+    *isBinary = FALSE;
+    return "application/json";
+  } else if(!strcmp(extension,"sh")) {
+    *isBinary = FALSE;
+    return "application/x-sh";
+  } else if(!strcmp(extension,"tar")) {
+    *isBinary = TRUE;
+    return "application/x-tar";
+  } else if (!strcmp(extension,"gif")){
+    *isBinary = TRUE;
+    return "image/gif";
+  } else if (!strcmp(extension,"jpg")){
+    *isBinary = TRUE;
+    return "image/jpeg";
+  } else if (!strcmp(extension,"png")){
+    *isBinary = TRUE;
+    return "image/png";
   } else if (!strcmp(extension,"mpg")){
     *isBinary = TRUE;
     return "video/mpeg";
@@ -3703,9 +3725,6 @@ static char *getMimeType2(char *extension, int *isBinary, int dotPos){
   } else if(!strcmp(extension,"avi")) {
     *isBinary = TRUE;
     return "video/x-msvideo";
-  } else if(!strcmp(extension,"bin")) {
-    *isBinary = TRUE;
-    return "application/octet-stream";
   } else if(!strcmp(extension,"bmp")) {
     *isBinary = TRUE;
     return "image/bmp";
@@ -3718,30 +3737,15 @@ static char *getMimeType2(char *extension, int *isBinary, int dotPos){
   } else if(!strcmp(extension,"docx")) {
     *isBinary = FALSE;
     return "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
-  } else if(!strcmp(extension,"gz")) {
-    *isBinary = TRUE;
-    return "application/gzip";
   } else if(!strcmp(extension,"mp3")) {
     *isBinary = TRUE;
     return "audio/mpeg";
-  } else if(!strcmp(extension,"jar")) {
-    *isBinary = TRUE;
-    return "application/java-archive";
-  } else if(!strcmp(extension,"json")) {
-    *isBinary = FALSE;
-    return "application/json";
   } else if(!strcmp(extension,"jsonld")) {
     *isBinary = TRUE;
     return "application/ld+json";
   } else if(!strcmp(extension,"pdf")) {
     *isBinary = TRUE;
     return "application/pdf";
-  } else if(!strcmp(extension,"sh")) {
-    *isBinary = FALSE;
-    return "application/x-sh";
-  } else if(!strcmp(extension,"tar")) {
-    *isBinary = TRUE;
-    return "application/x-tar";
   } else if(!strcmp(extension,"xls")) {
     *isBinary = FALSE;
     return "application/vnd.ms-excel";
@@ -3757,9 +3761,6 @@ static char *getMimeType2(char *extension, int *isBinary, int dotPos){
   } else if(!strcmp(extension,"mp4")) {
     *isBinary = TRUE;
     return "video/mp4";
-  } else if(!strcmp(extension,"md")) {
-    *isBinary = FALSE;
-    return "text/markdown";
   } else{
     *isBinary = TRUE;
     return "application/octet-stream";
@@ -4947,7 +4948,7 @@ static int httpTaskMain(RLETask *task){
 
   HttpWorkElement *element = (HttpWorkElement*)task->userPointer;
   HttpConversation *conversation = element->conversation;
-  printf("httpTaskMain element=0x%x elt->convo=0x%x\n",element,conversation);
+  zowelog(NULL, LOG_COMP_HTTPSERVER, ZOWE_LOG_DEBUG, "httpTaskMain element=0x%x elt->convo=0x%x\n",element,conversation);
   if (!conversation->shouldClose) {
     /* Execute only if the conversation is still open */
     serviceResult = handleHttpService(conversation->server,
@@ -5151,8 +5152,9 @@ static void doHttpResponseWork(HttpConversation *conversation)
           workElement->response = response;
           response = NULL; /* transfer the ownership of the response to the subtask */
           conversation->task->userPointer = workElement;
-          printf("about to start RLE Task from main at 0x%x wkElement=0x%x pendingService=0x%x\n",
-                 conversation->task,workElement,conversation->pendingService);
+          zowelog(NULL, LOG_COMP_HTTPSERVER, ZOWE_LOG_DEBUG,
+                  "about to start RLE Task from main at 0x%x wkElement=0x%x pendingService=0x%x\n",
+                  conversation->task,workElement,conversation->pendingService);
 
           /* Keep track of number of running tasks */                                                                                                                                                            
           serializeStartRunning(conversation);                                                                                                                                                                   


### PR DESCRIPTION
Add .env mime type, reorg mime types area to have media type detection come last, and common extensions first. Switch common debug printfs to zowelog

Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>