### PR TITLE
Ensure clean up hook is not called when error

### DIFF
--- a/c/crossmemory.c
+++ b/c/crossmemory.c
@@ -4269,7 +4269,7 @@ int cmsStartMainLoop(CrossMemoryServer *srv) {
   int status = RC_CMS_OK;
   bool globalResourcesAllocated = false;
   bool serverStarted = false;
-  bool startCallbackSuccess = true;
+  bool startCallbackSuccess = false;
   bool resourceManagerInstalled = false;
 
   if (status == RC_CMS_OK) {
@@ -4358,6 +4358,7 @@ int cmsStartMainLoop(CrossMemoryServer *srv) {
   }
 
   if (status == RC_CMS_OK) {
+    startCallbackSuccess = true;
     if (srv->startCallback != NULL) {
       int callbackRC = srv->startCallback(srv->globalArea, srv->callbackData);
       if (callbackRC != 0) {


### PR DESCRIPTION
#### Overview

This pull-request fixes the incorrect cross-memory clean up logic when an initialization error occurs.