### PR TITLE
Enable force encoding with provided encoding types.

### DIFF
--- a/c/httpserver.c
+++ b/c/httpserver.c
@@ -4053,11 +4053,23 @@ void respondWithUnixFile2(HttpService* service, HttpResponse* response, char* ab
 #error Unknown OS
 #endif
         ;
-      if (ccsid == 0) {
-        streamTextForFile2(response, NULL, in, ENCODING_CHUNKED, NATIVE_CODEPAGE, webCodePage, asB64);
-      } else {
-        streamTextForFile2(response, NULL, in, ENCODING_CHUNKED, ccsid, webCodePage, asB64);
-      }
+    char *forceEnabled = getQueryParam(response->request, "force");
+    if (ccsid == 0 && strcmp(forceEnabled, "enable")) {
+        char *sourceEncoding = getQueryParam(response->request, "source");
+        char *targetEncoding = getQueryParam(response->request, "target");
+        if(sourceEncoding != NULL && targetEncoding != NULL) {
+           streamTextForFile2(response->socket, in, ENCODING_CHUNKED, sourceEncoding, targetEncoding, asB64);
+        }
+        else {
+           streamTextForFile2(response->socket, in, ENCODING_CHUNKED, NATIVE_CODEPAGE, webCodePage, asB64);
+        }
+    }
+    else if(ccsid == 0 && strcmp(forceEnabled, "disable")) {
+      streamTextForFile2(response->socket, in, ENCODING_CHUNKED, NATIVE_CODEPAGE, webCodePage, asB64);
+    }
+    else {
+      streamTextForFile2(response->socket, in, ENCODING_CHUNKED, ccsid, webCodePage, asB64);
+    }
 
 #ifdef USE_CONTINUE_RESPONSE_HACK
       /* See comments above */

--- a/c/httpserver.c
+++ b/c/httpserver.c
@@ -4064,7 +4064,7 @@ void respondWithUnixFile2(HttpService* service, HttpResponse* response, char* ab
            streamTextForFile2(response->socket, in, ENCODING_CHUNKED, NATIVE_CODEPAGE, webCodePage, asB64);
         }
     }
-    else if(ccsid == 0 && strcmp(forceEnabled, "disable")) {
+    else if(ccsid == 0)) {
       streamTextForFile2(response->socket, in, ENCODING_CHUNKED, NATIVE_CODEPAGE, webCodePage, asB64);
     }
     else {
@@ -4201,19 +4201,19 @@ static int streamBinaryForFile2(HttpResponse *response, Socket *socket, UnixFile
 
   if ((response && socket) || (!response && !socket)) {
 #ifdef DEBUG
-    printf("bad arguments: either response or socket must be not NULL, never both\n");
+    printf("bad arguments: either response or socket must be not NULL, never both\n");	
 #endif
     return 8;
   }
   if (encoding == ENCODING_GZIP) {
 #ifdef DEBUG
-    printf("GZIP encoding not implemented\n");
+    printf("GZIP encoding not implemented\n");	
 #endif
     return 8;
   }
   if (encoding == ENCODING_CHUNKED && !response) {
 #ifdef DEBUG
-    printf("bad arguments: response must be not NULL to use chunked encoding\n");
+    printf("bad arguments: response must be not NULL to use chunked encoding\n");	
 #endif
     return 8;
   }
@@ -4279,17 +4279,17 @@ static int streamTextForFile2(HttpResponse *response, Socket *socket, UnixFile *
         other Unix systems. Hence, things like the .htaccess (for Apache).
   */
   if ((response && socket) || (!response && !socket)) {
-#ifdef DEBUG
-    printf("bad arguments: either response or socket must be not NULL, never both\n");
+#ifdef DEBUG	
+    printf("bad arguments: either response or socket must be not NULL, never both\n");	
 #endif
     return 8;
   }
   switch (encoding){
   case ENCODING_CHUNKED:
     if (!response) {
-#ifdef DEBUG
-      printf("bad arguments: response must be not NULL to use chunked encoding\n");
-#endif
+#ifdef DEBUG	
+      printf("bad arguments: response must be not NULL to use chunked encoding\n");	
+#endif	
       return 8;
     }
     stream = makeChunkedOutputStreamInternal(response);

--- a/c/httpserver.c
+++ b/c/httpserver.c
@@ -4189,19 +4189,19 @@ static int streamBinaryForFile2(HttpResponse *response, Socket *socket, UnixFile
 
   if ((response && socket) || (!response && !socket)) {
 #ifdef DEBUG
-    printf("bad arguments: either response or socket must be not NULL, never both\n");	
+    printf("bad arguments: either response or socket must be not NULL, never both\n");
 #endif
     return 8;
   }
   if (encoding == ENCODING_GZIP) {
 #ifdef DEBUG
-    printf("GZIP encoding not implemented\n");	
+    printf("GZIP encoding not implemented\n");
 #endif
     return 8;
   }
   if (encoding == ENCODING_CHUNKED && !response) {
 #ifdef DEBUG
-    printf("bad arguments: response must be not NULL to use chunked encoding\n");	
+    printf("bad arguments: response must be not NULL to use chunked encoding\n");
 #endif
     return 8;
   }
@@ -4267,17 +4267,17 @@ static int streamTextForFile2(HttpResponse *response, Socket *socket, UnixFile *
         other Unix systems. Hence, things like the .htaccess (for Apache).
   */
   if ((response && socket) || (!response && !socket)) {
-#ifdef DEBUG	
-    printf("bad arguments: either response or socket must be not NULL, never both\n");	
+#ifdef DEBUG
+    printf("bad arguments: either response or socket must be not NULL, never both\n");
 #endif
     return 8;
   }
   switch (encoding){
   case ENCODING_CHUNKED:
     if (!response) {
-#ifdef DEBUG	
-      printf("bad arguments: response must be not NULL to use chunked encoding\n");	
-#endif	
+#ifdef DEBUG
+      printf("bad arguments: response must be not NULL to use chunked encoding\n");
+#endif
       return 8;
     }
     stream = makeChunkedOutputStreamInternal(response);

--- a/c/httpserver.c
+++ b/c/httpserver.c
@@ -4063,13 +4063,14 @@ void respondWithUnixFile2(HttpService* service, HttpResponse* response, char* ab
            int sscanfSource = sscanf(sourceEncoding, "%d", &sEncoding);
            int sscanfTarget = sscanf(targetEncoding, "%d", &tEncoding);
            if (sscanfSource != 1 || sscanfTarget != 1) {
-             respondWithError(response, HTTP_STATUS_BAD_REQUEST, "source/target encoding value parsing error");
+             respondWithError(response, HTTP_STATUS_BAD_REQUEST, "source/target encoding value parsing error.");
              return;
            }
            streamTextForFile2(response, NULL, in, ENCODING_CHUNKED, sEncoding, tEncoding, asB64);
         }
         else {
-           streamTextForFile2(response, NULL, in, ENCODING_CHUNKED, NATIVE_CODEPAGE, webCodePage, asB64);
+          respondWithError(response, HTTP_STATUS_BAD_REQUEST, "force encoding enabled make sure to pass all the requried params");
+          return;
         }
     }
     else if(ccsid == 0) {

--- a/c/httpserver.c
+++ b/c/httpserver.c
@@ -4057,18 +4057,26 @@ void respondWithUnixFile2(HttpService* service, HttpResponse* response, char* ab
     if (ccsid == 0 && strcmp(forceEnabled, "enable")) {
         char *sourceEncoding = getQueryParam(response->request, "source");
         char *targetEncoding = getQueryParam(response->request, "target");
+        int sEncoding;
+        int tEncoding;
         if(sourceEncoding != NULL && targetEncoding != NULL) {
-           streamTextForFile2(response->socket, in, ENCODING_CHUNKED, sourceEncoding, targetEncoding, asB64);
+           int sscanfSource = sscanf(sourceEncoding, "%d", &sEncoding);
+           int sscanfTarget = sscanf(targetEncoding, "%d", &tEncoding);
+           if (sscanfSource != 1 || sscanfTarget != 1) {
+             respondWithError(response, HTTP_STATUS_BAD_REQUEST, "source/target encoding value parsing error");
+             return;
+           }
+           streamTextForFile2(response, NULL, in, ENCODING_CHUNKED, sEncoding, tEncoding, asB64);
         }
         else {
-           streamTextForFile2(response->socket, in, ENCODING_CHUNKED, NATIVE_CODEPAGE, webCodePage, asB64);
+           streamTextForFile2(response, NULL, in, ENCODING_CHUNKED, NATIVE_CODEPAGE, webCodePage, asB64);
         }
     }
-    else if(ccsid == 0)) {
-      streamTextForFile2(response->socket, in, ENCODING_CHUNKED, NATIVE_CODEPAGE, webCodePage, asB64);
+    else if(ccsid == 0) {
+      streamTextForFile2(response, NULL, in, ENCODING_CHUNKED, NATIVE_CODEPAGE, webCodePage, asB64);
     }
     else {
-      streamTextForFile2(response->socket, in, ENCODING_CHUNKED, ccsid, webCodePage, asB64);
+      streamTextForFile2(response, NULL, in, ENCODING_CHUNKED, ccsid, webCodePage, asB64);
     }
 
 #ifdef USE_CONTINUE_RESPONSE_HACK


### PR DESCRIPTION
This PR will enable force encoding for files.

For a text file to be readable on the client computer, it must be ASCII or UTF8. But a text file on the mainframe might be EBCDIC instead. So it must be converted, and the current code converts AUTOMATICALLY, and sometimes it is wrong.
When it's wrong, we want to tell it to do something we ask for, rather than automatic conversion.
So, we need a parameter to /unixfile API to allow us to specify the source and target encoding. Source=what is on the mainframe, target=what should the user download.