### PR TITLE
Optional authentication for services

### DIFF
--- a/c/httpserver.c
+++ b/c/httpserver.c
@@ -3258,8 +3258,12 @@ static int handleHttpService(HttpServer *server,
   printf("service=%s authenticated=%d\n",service->name,request->authenticated);
 #endif
   if (request->authenticated == FALSE){
-    /* could make this parameterizable */
-    respondWithAuthError(response, &authResponse);
+    if (service->authFlags & SERVICE_AUTH_FLAG_OPTIONAL == SERVICE_AUTH_FLAG_OPTIONAL) {
+      // Allow the service to decide when to respond with HTTP 401
+      serveRequest(service, response, request);
+    } else {
+      respondWithAuthError(response, &authResponse);
+    }
     // Response is finished on return
   } else {
 

--- a/c/httpserver.c
+++ b/c/httpserver.c
@@ -3258,7 +3258,7 @@ static int handleHttpService(HttpServer *server,
   printf("service=%s authenticated=%d\n",service->name,request->authenticated);
 #endif
   if (request->authenticated == FALSE){
-    if (service->authFlags & SERVICE_AUTH_FLAG_OPTIONAL == SERVICE_AUTH_FLAG_OPTIONAL) {
+    if (service->authFlags & SERVICE_AUTH_FLAG_OPTIONAL) {
       // Allow the service to decide when to respond with HTTP 401
       serveRequest(service, response, request);
     } else {

--- a/h/httpserver.h
+++ b/h/httpserver.h
@@ -180,6 +180,8 @@ typedef struct HttpService_tag{
   int    matchFlags;
   int    serviceType; 
   int    authType;
+#define SERVICE_AUTH_FLAG_OPTIONAL 1
+  int    authFlags;
   int    runInSubtask;
   void  *authority; /* NULL unless AUTH_CUSTOM */
   AuthExtract                    *authExtractionFunction;


### PR DESCRIPTION
This PR allows the service to decide how to handle HTTP requests if the user is not authenticated. Example:

```c
void installServerStatusService(HttpServer *server) {
  HttpService *httpService = makeGeneratedService("Simple service", "/simple/service/**");
  httpService->authType = SERVICE_AUTH_NATIVE_WITH_SESSION_TOKEN;
  httpService->authFlags |= SERVICE_AUTH_FLAG_OPTIONAL;
  httpService->serviceFunction = serve;
  registerHttpService(server, httpService);
}

int serve(HttpService *service, HttpResponse *response) {
  int isAuthenticated = response->request->authenticated;
  // check if the user is authenticated
  //...
}
```

