### PR TITLE
Fix for untagged and dotfiles not being properly sent over rest api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Zowe Common C Changelog
 
+## `1.16.0`
+
+- Fixed mimetype lookup for dotfiles
+
 ## `1.13.0`
 
 - Initialized http server log earlier, a bugfix to show error messages that were hidden before.


### PR DESCRIPTION
I was seeing failure to send files over unixfile api when they are dotfiles or untagged. Appears to have been two mistakes: flipped boolean on checking for forced encoding request, and dotPos detection being from the absolute path rather than filename.

Here's my testing that got it working properly again.
```
Processing file=~/zowe-setup-certificates.env
getMimeType2 extension=env, isDotFile=0
Mimetype=text/plain
ccsid=0
Force encoding=
Sending with default conversion between 1047 and 819
completed send
Processing file=~/.Xauthority
getMimeType2 extension=Xauthority, isDotFile=1
Mimetype=text/plain
ccsid=0
Force encoding=
Sending with default conversion between 1047 and 819
completed send
Processing file=~/.tcshrc
getMimeType2 extension=tcshrc, isDotFile=1
Mimetype=text/plain
ccsid=1047
Force encoding=
Sending with tagged conversion between 1047 and 819
completed send

```

Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>