### PR TITLE
maximum of 1000 requests to prevent slh from becoming full

### DIFF
--- a/h/httpserver.h
+++ b/h/httpserver.h
@@ -380,6 +380,8 @@ typedef struct HttpConversation_tag{
   WSSession         *wsSession;
   RLETask           *task;
   int                zeroLengthReadCount;
+  int                requestCount;
+  bool               isKeepAlive;
 } HttpConversation;
 
 typedef struct HttpWorkElement_tag{


### PR DESCRIPTION
The SLH will become full eventually and crash the server. From evidence of testing, 1000 requests should be plenty and won't crash the server. At some point, we should do timeouts, but for now, at least we can do the right thing for Postman, etc.