### PR TITLE
Temporarily disable keep-alive parsing to work-around memory issue

### DIFF
--- a/c/httpserver.c
+++ b/c/httpserver.c
@@ -1916,13 +1916,19 @@ static void addRequestHeader(HttpRequestParser *parser){
     if (!compareIgnoringCase(newHeader->nativeValue,"websocket",parser->headerValueLength)){
       parser->isWebSocket = TRUE;
     }
-  } else if (!compareIgnoringCase(newHeader->nativeName, "Connection",
+  }
+  /* Temporarily disable this while investigating and developing solutions to
+     Out of memory issues around the SLH used by each connection running out of memory
+     Due to connections not closing when they should
+  else if (!compareIgnoringCase(newHeader->nativeName, "Connection",
                                   parser->headerNameLength)) {
     if (!compareIgnoringCase(newHeader->nativeValue, "Keep-Alive",
                              parser->headerValueLength)) {
       parser->keepAlive = TRUE;
     }
   }
+  */
+  parser->keepAlive = FALSE;
 
   HttpHeader *headerChain = parser->headerChain;
   if (headerChain){


### PR DESCRIPTION
Disables key behavior of https://github.com/zowe/zowe-common-c/pull/147 while working on a permanent solution.
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>