### PR TITLE
Make group lookup function for user

### DIFF
--- a/c/zosaccounts.c
+++ b/c/zosaccounts.c
@@ -414,7 +414,7 @@ int groupGetName(int gid, char *groupNameBuffer, int *returnCode, int *reasonCod
   rc = getGroupList(user, NULL, &count, &returnCode, &reasonCode);
   if (rc == -1) {
     printf ("failed to obtain group count for user %s\n", user);
-    exit(0);
+    exit(EXIT_FAILURE);
   }
   printf ("found %d groups\n", count);
   // allocate array for group list
@@ -423,7 +423,7 @@ int groupGetName(int gid, char *groupNameBuffer, int *returnCode, int *reasonCod
   rc = getGroupList(user, groups, &count, &returnCode, &reasonCode);
   if (rc == -1) {
     printf ("unable to get groups for user %s\n", user);
-    exit(0);
+    exit(EXIT_FAILURE);
   }
   for (int i = 0; i < count; i++) {
     printf ("group %d\n", groups[i]);

--- a/h/zosaccounts.h
+++ b/h/zosaccounts.h
@@ -65,6 +65,16 @@ int groupIdGet (char *string, int *returnCode, int *reasonCode);
 int groupGetName(int gid, char *groupNameBuffer, int *returnCode, int *reasonCode);
 int resetZosUserPassword(const char *userName,  const char *password, const char *newPassword,
                          int *returnCode, int *reasonCode);
+/**
+ * @brief Get list of groups to which a user belongs.
+ * @param userName User name.
+ * @param groups Up to *groupCount groups are returned in array groups.
+ * @param groupCount If *groupCount is 0 then on return it contains number of groups found for user.
+ * If *groupCount greater or equal than number of groups then on return it contains actual number of groups for user.
+ * In case of error *groupCount is -1 on return.
+ * @return -1 on failure , 0 on success.
+ */
+int getGroupList(const char *userName, int *groups, int *groupCount, int *returnCode, int *reasonCode);
 
 #endif  /*  __ZOSACCOUNTS__ */
 


### PR DESCRIPTION
The PR adds a new function that gets a list of groups for a user. The function is similar to [getgrouplist](https://man7.org/linux/man-pages/man3/getgrouplist.3.html)

Example of usage:
```C
  int count = 0;
  int rc = 0;
  int returnCode;
  int reasonCode;

  const char *user = "root";
  // obtain group count for user
  rc = getGroupList(user, NULL, &count, &returnCode, &reasonCode);
  if (rc == -1) {
    printf ("failed to obtain group count for user %s\n", user);
    exit(EXIT_FAILURE);
  }
  printf ("found %d groups\n", count);
  // allocate array for group list
  int *groups = (int*)safeMalloc(sizeof(int) * count, "groups");
  // obtain group list
  rc = getGroupList(user, groups, &count, &returnCode, &reasonCode);
  if (rc == -1) {
    printf ("unable to get groups for user %s\n", user);
    exit(EXIT_FAILURE);
  }
  for (int i = 0; i < count; i++) {
    printf ("group %d\n", groups[i]);
  }
}
```
