### PR TITLE
Check and return variable session timeout info

### DIFF
--- a/c/collections.c
+++ b/c/collections.c
@@ -495,12 +495,13 @@ int htRemove(hashtable *ht, void *key){
 
 int stringHash(void *key){
   char *s = (char*)key;
-  int hash = 0;
+  //See: http://www.cse.yorku.ca/~oz/hash.html
+  int hash = 5381;
   int i;
   int len = strlen(s);
 
   for (i=0; i<len; i++){
-    hash = (hash << 4) + s[i];
+    hash = ((hash << 5) + hash) + s[i];
   }
   return hash&0x7fffffff;
 }

--- a/c/httpserver.c
+++ b/c/httpserver.c
@@ -1071,7 +1071,7 @@ void writeHeader(HttpResponse *response){
     if (response->sessionTimeout) {
       addIntHeader(response, "Session-Expires-Seconds", response->sessionTimeout);
     } else {
-      printf("\ncouldnt set expiration during writeheader\n");
+      AUTH_TRACE("\ncouldnt set expiration during writeheader\n");
     }
   }
   if (response->conversation->isKeepAlive) {

--- a/c/httpserver.c
+++ b/c/httpserver.c
@@ -2918,7 +2918,7 @@ static int sessionTokenStillValid(HttpService *service, HttpRequest *request, ch
     return FALSE;
   }
 
-  if (interval > 0) {
+  if (*sessionValiditySec > 0) {
     uint64 difference = now-decodedTimestamp;
     *sessionTimeRemaining = difference;
 

--- a/c/httpserver.c
+++ b/c/httpserver.c
@@ -2845,11 +2845,11 @@ static int getUserSessionValidity(char *username, const HttpServerConfig *config
           AUTH_TRACE("longer session duration=%d\n",*validitySec);
         }
       }
-      if (*validitySec){
-        retVal = 0; 
-      } else{
-        retVal = -1;
+      if (!*validitySec){
+        //the default
+        *validitySec=(uint64)SESSION_VALIDITY_IN_SECONDS;
       }
+      retVal = 0;
     }
     safeFree((char*)groups, sizeof(int) * groupCount);
     return retVal;
@@ -2910,7 +2910,6 @@ static int sessionTokenStillValid(HttpService *service, HttpRequest *request, ch
     zowelog(NULL, LOG_COMP_HTTPSERVER, ZOWE_LOG_WARNING, "Error when getting session duration for user '%s'. rc=%d, rsn=%d\n",
             username, returnCode, reasonCode);
   }
-  if (*sessionValiditySec == 0) { *sessionValiditySec = (uint64)SESSION_VALIDITY_IN_SECONDS; }
   AUTH_TRACE("session validity sec = %d\n",*sessionValiditySec);
   uint64 interval = ((uint64)(*sessionValiditySec))*ONE_SECOND;
 

--- a/h/httpserver.h
+++ b/h/httpserver.h
@@ -131,6 +131,7 @@ typedef struct HttpResponse_tag{
   jsonPrinter    *jp;
   char           *sessionCookie;
   int             standaloneTestMode;
+  int             sessionTimeout;
 } HttpResponse;
 
 

--- a/h/httpserver.h
+++ b/h/httpserver.h
@@ -217,6 +217,7 @@ typedef struct HTTPServerConfig_tag {
   int authTokenType; /* SERVICE_AUTH_TOKEN_TYPE_... */
   hashtable *userTimeouts;
   hashtable *groupTimeouts;
+  int defaultTimeout;
 } HttpServerConfig;
 
 typedef struct HttpServer_tag{

--- a/h/zosaccounts.h
+++ b/h/zosaccounts.h
@@ -48,6 +48,9 @@ typedef BPXYGIDN UserInfo;
 #define USER_NAME_LEN 8
 #define GROUP_NAME_LEN 8
 
+#define MAX_GID 2147483647
+#define GID_MAX_CHAR_LENGTH 10
+
 /* Function Prototype */
 int gidGetUserInfo(const char *userName,  UserInfo * info,
                          int *returnCode, int *reasonCode);


### PR DESCRIPTION
This makes use of recent PRs https://github.com/zowe/zowe-common-c/pull/192 and https://github.com/zowe/zowe-common-c/pull/190 in order to set cookie timeout according to the user or group the user is in. In the case that a user is specified in the list, that value is chosen. In the case the user is not found in the list, groups are checked. If a user is in multiple groups found, the longest session duration value is chosen. If the value is -1, that means there is no expiration. 0 is considered not found, and when not found, the default value (1 hour) will be chosen.

Because the cookie doesnt and shouldnt contain info such as expiration, and because the cookie is given during any call, a header is needed for sending expiration information.

I did not find any standard or non-standard header for sending session expiration info the way we are trying to do. The closest thing I saw was expiration info for SIP, which just seemed too unrelated to use.

So, I made a new header. Current recommendation of standards community is to NOT prefix such as "X-", so instead I chose a name that is generic and maybe will become used by others some day.

How I tested:

I made a JSON,
```
{
users: {myself: 1000},
groups: {
  one: 2000,
  two: 3000,
  three: -1
  four: 4000,
  five: 500
}

}
```

When groups is not defined, the number returned should be derived from 1000.
When groups is defined, and I'm in all the groups, I expect -1, not 4000 and not 500.