### PR TITLE
Fix an implicit declaration

### DIFF
--- a/c/stcbase.c
+++ b/c/stcbase.c
@@ -36,6 +36,7 @@
 #include "openprims.h"
 #include "collections.h"
 #include "stcbase.h"
+#include "scheduling.h"
 
 /* handleReadySockets is a highly system-specific way of waking 
    running asynchronous IO work.   Windows and linux are different enought to need some data-hiding 


### PR DESCRIPTION
#### Overview
Function `zosPost` is not properly declared in `c/stcbase.c`, this may lead to unexpected behavior where the compiler assumes that the arguments are all `int`s whereas we need to pass a 64-bit address and an int. This pull-request include `scheduling.h` to ensure the compiler knows the `zosPost` prototype.