### PR TITLE
Fix an incorrect if condition in the http socket write function

### DIFF
--- a/c/http.c
+++ b/c/http.c
@@ -207,7 +207,7 @@ int writeFully(Socket *socket, char *buffer, int len){
       /* Check for both EAGAIN and EWOULDBLOCK on "older" unix systems
        * for portability.
        */
-      if (WRITE_FORCE && returnCode == EAGAIN || returnCode == EWOULDBLOCK) {
+      if (WRITE_FORCE && (returnCode == EAGAIN || returnCode == EWOULDBLOCK)) {
         PollItem item = {0};
         item.fd = socket->sd;
         item.events = POLLEWRNORM;


### PR DESCRIPTION
When an additional check was introduced (EWOULDBLOCK), the WRITE_FORCE
value was not correctly applied - it should be AND'ed with both the
EAGAIN and EWOULDBLOCK values:

`WRITE_FORCE and (EAGAIN or EWOULDBLOCK)`
