### PR TITLE
Fixed bugs around the value for session timeout

### DIFF
--- a/c/httpserver.c
+++ b/c/httpserver.c
@@ -2834,17 +2834,19 @@ static int getUserSessionValidity(char *username, const HttpServerConfig *config
     int *groups = (int*)safeMalloc(sizeof(int) * groupCount, "groups");
     retVal = getGroupList(username, groups, &groupCount, returnCode, reasonCode);
     if (!retVal) {
-      int currentValiditySec;
+      int currentValiditySec = 0;
       for (int i = 0; i < groupCount; i++) {
         retVal = getGroupSessionValidity(POINTER_FROM_INT(groups[i]), config, &currentValiditySec, returnCode, reasonCode);
-        if (currentValiditySec && *validitySec != -1 && ((currentValiditySec == -1) || (currentValiditySec > *validitySec))) {
-          *validitySec = currentValiditySec;
-          AUTH_TRACE("longer session duration=%d\n",*validitySec);
+        if (!retVal){
+          if (currentValiditySec && *validitySec != -1 && ((currentValiditySec == -1) || (currentValiditySec > *validitySec))) {
+            *validitySec = currentValiditySec;
+            AUTH_TRACE("longer session duration=%d\n",*validitySec);
+          }
         }
       }
       if (!*validitySec){
         //the default
-        *validitySec= config->defaultTimeout ? (uint64)config->defaultTimeout : (uint64)SESSION_VALIDITY_IN_SECONDS;
+        *validitySec= config->defaultTimeout ? config->defaultTimeout : SESSION_VALIDITY_IN_SECONDS;
       }
       retVal = 0;
     }
@@ -2855,7 +2857,7 @@ static int getUserSessionValidity(char *username, const HttpServerConfig *config
   }
 }
 
-static int sessionTokenStillValid(HttpService *service, HttpRequest *request, char *sessionTokenText, int *sessionValiditySec, int *sessionTimeRemaining){
+static int sessionTokenStillValid(HttpService *service, HttpRequest *request, char *sessionTokenText, int *sessionValiditySec, uint64 *sessionTimeRemaining){
   HttpServer *server = service->server;
   ShortLivedHeap *slh = request->slh;
   char *decodedData = SLHAlloc(slh,strlen(sessionTokenText));
@@ -3008,7 +3010,7 @@ static int serviceAuthNativeWithSessionToken(HttpService *service, HttpRequest *
     zowelog(NULL, LOG_COMP_HTTPSERVER, ZOWE_LOG_DEBUG3,
            "serviceAuthNativeWithSessionToken: tokenCookieText: %s\n",
            (tokenCookieText ? tokenCookieText : "<noAuthToken>"));
-    int timeRemainingStck = 0;
+    uint64 timeRemainingStck = 0;
     int sessionLengthSec = 0;
     if (sessionTokenStillValid(service,request,tokenCookieText,&sessionLengthSec,&timeRemainingStck)){
       zowelog(NULL, LOG_COMP_HTTPSERVER, ZOWE_LOG_DEBUG3,


### PR DESCRIPTION
Various problems fixed: int initialization, using int instead of uint64, and not checking retval before acting upon returned values.