### PR TITLE
Reinstating keep-alive

### DIFF
--- a/c/httpserver.c
+++ b/c/httpserver.c
@@ -1933,9 +1933,6 @@ static void addRequestHeader(HttpRequestParser *parser){
       parser->isWebSocket = TRUE;
     }
   }
-  /* Temporarily disable this while investigating and developing solutions to
-     Out of memory issues around the SLH used by each connection running out of memory
-     Due to connections not closing when they should
   else if (!compareIgnoringCase(newHeader->nativeName, "Connection",
                                   parser->headerNameLength)) {
     if (!compareIgnoringCase(newHeader->nativeValue, "Keep-Alive",
@@ -1943,8 +1940,6 @@ static void addRequestHeader(HttpRequestParser *parser){
       parser->keepAlive = TRUE;
     }
   }
-  */
-  parser->keepAlive = FALSE;
 
   HttpHeader *headerChain = parser->headerChain;
   if (headerChain){


### PR DESCRIPTION
Even though we have logic to close the connection, we aren't using it. I'd like to reinstate the code that was removed temporarily, unless there are any objections.

It goes along with the changes added in this pull request: https://github.com/zowe/zowe-common-c/commit/6cbd244f2147be5e653773ab9bc457cab628c141