### PR TITLE
Set cookie path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Zowe Common C Changelog
 
+## `1.21.0`
+
+- Set cookie path to root in order to avoid multiple cookies when browser tries to set path automatically
+
 ## `1.16.0`
 
 - Fixed mimetype lookup for dotfiles

--- a/c/httpserver.c
+++ b/c/httpserver.c
@@ -2958,16 +2958,11 @@ static char *generateSessionTokenKeyValue(HttpService *service, HttpRequest *req
 
   int encodedLength = 0;
   char *base64Output = encodeBase64(slh,tokenCiphertext,tokenPlaintextLength,&encodedLength,TRUE);
-  char *keyValueBuffer = SLHAlloc(slh,520); //512 + trailing "; Path=/"
-  memset(keyValueBuffer,0,520);
-  int keyLength = strlen(SESSION_TOKEN_COOKIE_NAME);
-  memcpy(keyValueBuffer,SESSION_TOKEN_COOKIE_NAME,keyLength);
-  int offset = keyLength;
-  keyValueBuffer[keyLength] = '=';
-  int outputLength = strlen(base64Output);
-  int keyOffset = keyLength+1;
-  memcpy(keyValueBuffer+keyOffset,base64Output,outputLength);
-  sprintf(keyValueBuffer+keyOffset+outputLength,"; Path=/");
+
+  int keyValueBufferSize = encodedLength + strlen(SESSION_TOKEN_COOKIE_NAME) + 16; //16 for trailing ; Path=/ inclusion
+  char *keyValueBuffer = SLHAlloc(slh, keyValueBufferSize);
+
+  snprintf(keyValueBuffer, keyValueBufferSize, "%s=%s; Path=/", SESSION_TOKEN_COOKIE_NAME, base64Output);
   return keyValueBuffer;
 }
 

--- a/c/httpserver.c
+++ b/c/httpserver.c
@@ -2958,14 +2958,16 @@ static char *generateSessionTokenKeyValue(HttpService *service, HttpRequest *req
 
   int encodedLength = 0;
   char *base64Output = encodeBase64(slh,tokenCiphertext,tokenPlaintextLength,&encodedLength,TRUE);
-  char *keyValueBuffer = SLHAlloc(slh,512);
-  memset(keyValueBuffer,0,512);
+  char *keyValueBuffer = SLHAlloc(slh,520); //512 + trailing "; Path=/"
+  memset(keyValueBuffer,0,520);
   int keyLength = strlen(SESSION_TOKEN_COOKIE_NAME);
   memcpy(keyValueBuffer,SESSION_TOKEN_COOKIE_NAME,keyLength);
   int offset = keyLength;
   keyValueBuffer[keyLength] = '=';
-  memcpy(keyValueBuffer+keyLength+1,base64Output,strlen(base64Output));
-
+  int outputLength = strlen(base64Output);
+  int keyOffset = keyLength+1;
+  memcpy(keyValueBuffer+keyOffset,base64Output,outputLength);
+  sprintf(keyValueBuffer+keyOffset+outputLength,"; Path=/");
   return keyValueBuffer;
 }
 


### PR DESCRIPTION
ZSS never set options on its cookies, and app-server would to some extent add options or hide the cookie from the browser, such that any potential issues of the zss cookie was hidden.
But, with HA/FT work, it's important to get the cookie up to the browser, and here is where I see an issue:
If a server doesnt set a path property for a cookie, browsers will add one relative to the path of the request. But, because zss will give you a new cookie every time you call (refreshing the cookie), it means the browser may end up holding 10 different zss cookies because it tracks by paths it made up.
The solution is just to explicitly set path to root, so that the browser just has 1 cookie, which is what we want.

Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>