### PR TITLE
HTTP Client: Handle empty status string

### DIFF
--- a/c/httpclient.c
+++ b/c/httpclient.c
@@ -288,7 +288,9 @@ static int processHttpResponseFragment(HttpResponseParser *parser,
         }
         break;
       case HTTP_STATE_RESP_STATUS_GAP2:
-        if (isCR || isLF) {
+        if (isCR) {
+          parser->state = HTTP_STATE_RESP_STATUS_CR_SEEN;
+        } else if (isLF) {
           return ANSI_FAILED;
         } else if (isWhitespace) {
           /* include whitespace in statusReason string */


### PR DESCRIPTION
## Fix for HTTP Client
This PR allows to handle correctly statuses with empty status message e.g. `HTTP/1.1 404` (compare with `HTTP/1.1 404 Not Found` which has non empty status message)