### PR TITLE
Fix for dataset write when recfm=FB

### DIFF
--- a/c/datasetjson.c
+++ b/c/datasetjson.c
@@ -792,7 +792,7 @@ static void updateDatasetWithJSONInternal(HttpResponse* response,
     }
   }
   /*passed record length check and type check*/
-  int bytesRead = 0;
+  int bytesWritten = 0;
   int recordsWritten = 0;
   char recordBuffer[maxRecordLength+1];
   for (int i = 0; i < recordCount; i++) {
@@ -810,10 +810,10 @@ static void updateDatasetWithJSONInternal(HttpResponse* response,
       // trim if needed
       len = snprintf (recordBuffer, sizeof(recordBuffer), "%s", record);
     }
-    bytesRead = fwrite(recordBuffer,1,len,outDataset);
+    bytesWritten = fwrite(recordBuffer,1,len,outDataset);
     recordsWritten++;
-    if (bytesRead < 0 && ferror(outDataset)){
-      zowelog(NULL, LOG_COMP_RESTDATASET, ZOWE_LOG_DEBUG, "Error writing to dataset, rc=%d\n", bytesRead);
+    if (bytesWritten < 0 && ferror(outDataset)){
+      zowelog(NULL, LOG_COMP_RESTDATASET, ZOWE_LOG_DEBUG, "Error writing to dataset, rc=%d\n", bytesWritten);
       respondWithError(response,HTTP_STATUS_INTERNAL_SERVER_ERROR,"Error writing to dataset");
       fclose(outDataset);
       break;

--- a/c/datasetjson.c
+++ b/c/datasetjson.c
@@ -777,21 +777,8 @@ static void updateDatasetWithJSONInternal(HttpResponse* response,
         }
         recordLength = maxRecordLength;
       }
-      if (isFixed && (recordLength != 0) && (recordLength != maxRecordLength)) {
+      if (isFixed && recordLength < maxRecordLength) {
         zowelog(NULL, LOG_COMP_RESTDATASET, ZOWE_LOG_DEBUG, "UPDATE DATASET: record given for fixed datset less than maxLength=%d, len=%d, data:%s\n",maxRecordLength,recordLength,jsonString);
-        char recordBuffer[maxRecordLength+1];        
-        memcpy(recordBuffer,jsonString,recordLength);
-        memset(recordBuffer+recordLength,' ',maxRecordLength-recordLength);
-        recordBuffer[maxRecordLength] = '\0';
-        safeFree(jsonString,recordLength);
-        safeFree((char*)item,sizeof(Json));
-        Json *largerItem = (Json*)safeMalloc(sizeof(Json),"Padded JSON String");
-        largerItem->type = JSON_TYPE_STRING;
-        largerItem->data.string = recordBuffer;
-        recordArray->elements[i] = largerItem;
-        char *updatedRecord = jsonArrayGetString(recordArray,i);
-        int updatedLength = strlen(updatedRecord);
-        zowelog(NULL, LOG_COMP_RESTDATASET, ZOWE_LOG_DEBUG, "UPDATE DATASET: record updated to have new length of %d which should match max length of %d, content:%s\n",updatedLength,maxRecordLength,updatedRecord);
       }
     }
     else {
@@ -807,6 +794,7 @@ static void updateDatasetWithJSONInternal(HttpResponse* response,
   /*passed record length check and type check*/
   int bytesRead = 0;
   int recordsWritten = 0;
+  char recordBuffer[maxRecordLength+1];
   for (int i = 0; i < recordCount; i++) {
     char *record = jsonArrayGetString(recordArray,i);
     int recordLength = strlen(record);
@@ -814,10 +802,15 @@ static void updateDatasetWithJSONInternal(HttpResponse* response,
       record = " ";
       recordLength = 1;
     }
-    else if (recordLength > maxRecordLength){
-      recordLength = maxRecordLength; //sanitized input above, will cut off extra space/nonprintable here
+    int len;
+    if (isFixed) {
+      // pad with spaces/or trim if needed
+      len = snprintf (recordBuffer, sizeof(recordBuffer), "%-*s", maxRecordLength, record);
+    } else {
+      // trim if needed
+      len = snprintf (recordBuffer, sizeof(recordBuffer), "%s", record);
     }
-    bytesRead = fwrite(record,1,recordLength,outDataset);
+    bytesRead = fwrite(recordBuffer,1,len,outDataset);
     recordsWritten++;
     if (bytesRead < 0 && ferror(outDataset)){
       zowelog(NULL, LOG_COMP_RESTDATASET, ZOWE_LOG_DEBUG, "Error writing to dataset, rc=%d\n", bytesRead);


### PR DESCRIPTION
Fix for dataset write when recfm=FB. The code mistakenly called `safeFree()` for memory allocated in `ShortLivedHeap`.

PR for testing: https://github.com/zowe/zss/pull/276