### PR TITLE
Unix-file contents: Properly handle empty files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Zowe Common C Changelog
 
+## `1.23.0`
+
+- Bugfix: HTTP server did not send empty files correctly.
+
 ## `1.22.0`
 
 - Enhancement: Add "remoteStorage" pointer to dataservice struct, for accessing high availability remote storage in addition to or alternatively to local storage.

--- a/c/httpserver.c
+++ b/c/httpserver.c
@@ -4419,7 +4419,7 @@ static int streamBinaryForFile2(HttpResponse *response, Socket *socket, UnixFile
       zowelog(NULL, LOG_COMP_HTTPSERVER, ZOWE_LOG_DEBUG2,
               "Binary streaming has ended. (return = 0x%x, reason = 0x%x)\n",
               returnCode, reasonCode);
-      return 0;
+      break;
     }
 
     char *encodedBuffer = NULL;
@@ -4493,7 +4493,12 @@ static int streamTextForFile2(HttpResponse *response, Socket *socket, UnixFile *
       printf("WARNING: UTF8 might not be aligned properly: preserve 3 bytes for the next read cycle to fix UTF boundaries\n");
 #endif
       int bytesRead = fileRead(in,buffer,bufferSize,&returnCode,&reasonCode);
-
+      if (bytesRead <= 0) {
+        zowelog(NULL, LOG_COMP_HTTPSERVER, ZOWE_LOG_DEBUG2,
+                "Text streaming has ended. (return = 0x%x, reason = 0x%x)\n",
+                returnCode, reasonCode);
+        break;
+      }
       unsigned int inLen, outLen;
       int rc;
       char *inPtr, *outPtr;


### PR DESCRIPTION
This PR fixes a bug when downloading hangs for empty file with binary tag or without tags.