### PR TITLE
Updates for feature/zss64_2021

### DIFF
--- a/c/crossmemory.c
+++ b/c/crossmemory.c
@@ -1889,11 +1889,18 @@ static int handleUnsafeProgramCall(PCHandlerParmList *parmList,
 
   int returnCode = RC_CMS_OK;
 
+#ifdef CMS_ABEND_DIAG
   int pushRC = recoveryPush("CMS service function call",
-                            RCVR_FLAG_RETRY | RCVR_FLAG_DELETE_ON_RETRY | RCVR_FLAG_SDWA_TO_LOGREC,
-                            "RCMS", 
-			    extractServiceFunctionAbendInfo, &abendInfo,
-			    NULL, NULL);
+                            RCVR_FLAG_RETRY | RCVR_FLAG_DELETE_ON_RETRY |
+                            RCVR_FLAG_SDWA_TO_LOGREC,
+                            "RCMS",
+                            extractServiceFunctionAbendInfo, &abendInfo,
+                            NULL, NULL);
+#else
+  int pushRC = recoveryPush("CMS service function call",
+                            RCVR_FLAG_RETRY | RCVR_FLAG_DELETE_ON_RETRY | RCVR_FLAG_PRODUCE_DUMP,
+                            "RCMS", NULL, NULL, NULL, NULL);
+#endif
 
   if (pushRC == RC_RCV_OK) {
 
@@ -1947,9 +1954,15 @@ static int handleProgramCall(PCHandlerParmList *parmList, bool isSpaceSwitchPC) 
 
   int returnCode = RC_CMS_OK;
 
+#ifdef CMS_ABEND_DIAG
   int pushRC = recoveryPush("CMS PC handler",
                             RCVR_FLAG_RETRY | RCVR_FLAG_DELETE_ON_RETRY | RCVR_FLAG_SDWA_TO_LOGREC,
                             "RCMS", NULL, NULL, NULL, NULL);
+#else
+  int pushRC = recoveryPush("CMS PC handler",
+                            RCVR_FLAG_RETRY | RCVR_FLAG_DELETE_ON_RETRY,
+                            "RCMS", NULL, NULL, NULL, NULL);
+#endif
 
   if (pushRC == RC_RCV_OK) {
 

--- a/c/recovery.c
+++ b/c/recovery.c
@@ -106,8 +106,6 @@ static void resetESPIE(int token) {
     supervisorMode(TRUE);
   }
 
-  
-
 }
 
 static int setDummyESPIE() {
@@ -135,6 +133,7 @@ static int setDummyESPIE() {
       :
       : "r2"
   );
+
 
   ALLOC_STRUCT31(
     STRUCT31_NAME(parms31),
@@ -1166,6 +1165,7 @@ static int establishRouterInternal(RecoveryContext *userContext,
       :
   );
 
+
   if (!frrRequired) {
 
     /* ESTAEX */
@@ -1556,10 +1556,12 @@ int recoveryRemoveRouter() {
 static RecoveryStateEntry *addRecoveryStateEntry(RecoveryContext *context, char *name, int flags, char *dumpTitle,
                                                  AnalysisFunction *userAnalysisFunction, void * __ptr32 analysisFunctionUserData,
                                                  CleanupFunction *userCleanupFunction, void * __ptr32 cleanupFunctionUserData) {
+
   RecoveryStateEntry *newEntry = allocRecoveryStateEntry(context);
   if (newEntry == NULL) {
     return NULL;
   }
+
 #if !defined(METTLE) && defined(_LP64)
   if (userAnalysisFunction != NULL) {
     newEntry->analysisFunctionEnvironment = ((uint64 *)userAnalysisFunction)[0];
@@ -1573,8 +1575,10 @@ static RecoveryStateEntry *addRecoveryStateEntry(RecoveryContext *context, char 
   newEntry->analysisFunction = (void * __ptr32 )userAnalysisFunction;
   newEntry->cleanupFunctionEntryPoint = (void * __ptr32 )userCleanupFunction;
 #endif
+
   newEntry->analysisFunctionUserData = analysisFunctionUserData;
   newEntry->cleanupFunctionUserData = cleanupFunctionUserData;
+
   if (name != NULL) {
     int stateNameLength = strlen(name);
     if (stateNameLength > sizeof(newEntry->serviceInfo.stateName)) {
@@ -1583,6 +1587,7 @@ static RecoveryStateEntry *addRecoveryStateEntry(RecoveryContext *context, char 
     newEntry->serviceInfo.stateNameLength = stateNameLength;
     memcpy(newEntry->serviceInfo.stateName, name, stateNameLength);
   }
+
   newEntry->flags |= flags;
   newEntry->state = (flags & RCVR_FLAG_DISABLE) ? RECOVERY_STATE_DISABLED : RECOVERY_STATE_ENABLED;
   memset(newEntry->dumpTitle.title, ' ', sizeof(newEntry->dumpTitle.title));
@@ -1600,12 +1605,14 @@ static RecoveryStateEntry *addRecoveryStateEntry(RecoveryContext *context, char 
 }
 
 static void removeRecoveryStateEntry(RecoveryContext *context) {
+
   RecoveryStateEntry *entryToRemove = context->recoveryStateChain;
   if (entryToRemove != NULL) {
     context->recoveryStateChain = entryToRemove->next;
   } else {
     return;
   }
+
   freeRecoveryStateEntry(context, entryToRemove);
   entryToRemove = NULL;
 }
@@ -1651,14 +1658,15 @@ RecoveryStateEntry *addRecoveryStateEntry(RecoveryContext *context, char *name, 
 }
 
 static void removeRecoveryStateEntry(RecoveryContext *context) {
+
   RecoveryStateEntry *entryToRemove = context->recoveryStateChain;
   if (entryToRemove != NULL) {
     context->recoveryStateChain = entryToRemove->next;
   }
+
   safeFree((char *)entryToRemove, sizeof(RecoveryStateEntry));
   entryToRemove = NULL;
 }
-
 
 #endif /* __ZOWE_OS_ZOS */
 
@@ -1715,6 +1723,7 @@ int recoveryPush2(char *name, int flags, char *dumpTitle,
   if (newEntry == NULL) {
     return RC_RCV_ALLOC_FAILED;
   }
+
   newEntry->linkageStackToken = linkageStackToken;
 
   /* Extract key from the newly created stacked state. IPK cannot be used
@@ -2026,6 +2035,7 @@ void recoveryUpdateStateServiceInfo(char *loadModuleName, char *csect, char *rec
                     componentID, subcomponentName,
                     buildDate, version, componentIDBaseNumber,
                     stateName);
+
 }
 
 void recoveryGetABENDCode(SDWA *sdwa, int *completionCode, int *reasonCode) {

--- a/h/crossmemory.h
+++ b/h/crossmemory.h
@@ -359,20 +359,6 @@ typedef struct CrossMemoryServerStatus_tag {
   char descriptionNullTerm[64];
 } CrossMemoryServerStatus;
 
-typedef struct SAFEnityName_tag {
-  short bufferLength;
-  short entityLength;
-  char entityName[255];
-  char padding[7];
-} SAFEnityName;
-
-typedef enum SAFAccessAttribute_tag {
-  SAF_ACCESS_ATTRIBUTE_READ = 0x02,
-  SAF_ACCESS_ATTRIBUTE_UPDATE = 0x04,
-  SAF_ACCESS_ATTRIBUTE_CONTROL = 0x08,
-  SAF_ACCESS_ATTRIBUTE_ALTER = 0x08,
-} SAFAccessAttribute;
-
 ZOWE_PRAGMA_PACK_RESET
 
 #define LOG_COMP_ID_CMS       0x008F0001000C0001LLU
@@ -441,9 +427,19 @@ int cmsAddConfigParm(CrossMemoryServer *server,
                      const char *name, const void *value,
                      CrossMemoryServerParmType type);
 
+/**
+ * Checks if the cross-memory caller has read access to the provided class
+ * and entity.
+ *
+ * @param globalArea The global area of the server.
+ * @param className The class to be checked.
+ * @param entityName The entity to be checked.
+ * @return True if the caller has read access to the class/entity, otherwise
+ * false.
+ */
 bool cmsTestAuth(CrossMemoryServerGlobalArea *globalArea,
-		 char *className,
-		 char *entityName);
+                 const char *className,
+                 const char *entityName);
 
 
 /* Use these inside your service functions if they need ECSA.

--- a/h/zowetypes.h
+++ b/h/zowetypes.h
@@ -24,7 +24,7 @@
 
 #ifndef __cplusplus
 #ifndef true
-typedef char bool;  /* this is a char on ZOS */
+typedef int bool;
 #define true 1
 #define false 0
 #endif


### PR DESCRIPTION
Here's my initial adjustments for the ZSS 64 changes.
* Minor changes in cross-memory
* Make the new ABEND diagnostics a compile-time option in recovery.c
* Revert whitespace changes
* Revert `bool` to be `int` to keep compatibility with the existing plugins/structures

More work may be needed in recovery, zos and radmin.