### PR TITLE
Always close TLS socket

### DIFF
--- a/c/tls.c
+++ b/c/tls.c
@@ -137,8 +137,7 @@ int tlsWrite(TlsSocket *socket, const char *buf, int size, int *outLength) {
 
 int tlsSocketClose(TlsSocket *socket) {
   int rc = 0;
-  rc = rc || gsk_secure_socket_shutdown(socket->socketHandle);
-  rc = rc || gsk_secure_socket_close(&socket->socketHandle);
+  rc = gsk_secure_socket_close(&socket->socketHandle);
   safeFree((char*)socket, sizeof(*socket));
   return rc;
 }


### PR DESCRIPTION
This PR fixes a bug when TLS socket wasn't closed. For example, if connection was closed by peer then `gsk_secure_socket_shutdown()` retuned non zero, therefore a call to `gsk_secure_socket_close()` didn't happen. This fix removes unnecessary call to  `gsk_secure_socket_shutdown()`