### PR TITLE
Fix JWT for 64-bit mode

### DIFF
--- a/jwt/rscrypto/rs_icsfp11.c
+++ b/jwt/rscrypto/rs_icsfp11.c
@@ -321,7 +321,7 @@ int rs_icsfp11_hmacTokenKeyCreateFromRaw(
 int rs_icsfp11_findObjectsByLabelAndClass(
                     ICSFP11_HANDLE_T *in_token_handle,
                     char* in_label,
-                    CK_ULONG in_objectClass,
+                    unsigned int in_objectClass,
                     char* in_appname,
                     ICSFP11_HANDLE_T **out_handles,
                     int *out_numfound,
@@ -330,7 +330,7 @@ int rs_icsfp11_findObjectsByLabelAndClass(
   int status = RS_SUCCESS;
 
   CK_ATTRIBUTE object_attrs[3] = {
-      { CKA_CLASS, &in_objectClass, sizeof(CK_OBJECT_CLASS) },
+      { CKA_CLASS, &in_objectClass, sizeof(unsigned int) },
       { CKA_LABEL, NULL, 0 },
       { CKA_APPLICATION, NULL, 0 }
   };

--- a/jwt/rscrypto/rs_icsfp11.h
+++ b/jwt/rscrypto/rs_icsfp11.h
@@ -158,7 +158,7 @@ int rs_icsfp11_findObjectsByLabel(
 int rs_icsfp11_findObjectsByLabelAndClass(
                     const ICSFP11_HANDLE_T *in_token_handle,
                     const char *in_label,
-                    CK_ULONG in_objectClass,
+                    unsigned int in_objectClass,
                     const char *in_appname,
                     ICSFP11_HANDLE_T **out_handles,
                     int *out_numfound,


### PR DESCRIPTION
This PR fixes JWT for 64-bit mode. CK_ULONG is 8 bytes in 64 bit mode, but we needed only 4 bytes so I replaced it with `unsigned int` as in other places.