### PR TITLE
Updated unixfile/copy return status

### DIFF
--- a/c/httpfileservice.c
+++ b/c/httpfileservice.c
@@ -23,9 +23,9 @@
 #include <stdio.h>
 #include <string.h>
 #include <limits.h>
+#include <errno.h>
 #endif
 
-#include <errno.h>
 #include <limits.h>
 #include "zowetypes.h"
 #include "utils.h"
@@ -35,6 +35,11 @@
 #include "charsets.h"
 #include "unixfile.h"
 #include "httpfileservice.h"
+
+#ifdef METTLE
+#define EACCES 111
+#define ENOENT 129   
+#endif
 
 #ifndef PATH_MAX
 # ifdef _POSIX_PATH_MAX

--- a/c/httpfileservice.c
+++ b/c/httpfileservice.c
@@ -378,7 +378,14 @@ static int copyUnixDirectory(char *oldAbsolutePath, char *newAbsolutePath, int f
   int returnCode = 0, reasonCode = 0, status = 0;
   FileInfo info = {0};
 
-  if(!strcmp(oldAbsolutePath,newAbsolutePath)){
+  if (newAbsolutePath[0] != '/') {
+    zowelog(NULL, LOG_COMP_RESTFILE, ZOWE_LOG_DEBUG,
+            "Invalid input, not absolute path %s\n",
+            newAbsolutePath);
+    return RC_HTTP_FILE_SERVICE_NOT_ABSOLUTE_PATH;    
+  }
+
+  if (!strcmp(oldAbsolutePath,newAbsolutePath)) {
     zowelog(NULL, LOG_COMP_RESTFILE, ZOWE_LOG_DEBUG,
             "Invalid input, same directory path (source=%s, destination=%s)\n",
             oldAbsolutePath, newAbsolutePath);
@@ -397,7 +404,8 @@ static int copyUnixDirectory(char *oldAbsolutePath, char *newAbsolutePath, int f
   if (status == 0 && !forceCopy) {
     zowelog(NULL, LOG_COMP_RESTFILE, ZOWE_LOG_DEBUG,
             "Directory already exists %s\n", newAbsolutePath);    
-    return RC_HTTP_FILE_SERVICE_ALREADY_EXISTS;  }
+    return RC_HTTP_FILE_SERVICE_ALREADY_EXISTS;  
+  }
 
   status = directoryCopy(oldAbsolutePath, newAbsolutePath, &returnCode, &reasonCode);
   if (status == -1) {
@@ -428,6 +436,9 @@ void copyUnixDirectoryAndRespond(HttpResponse *response, char *oldAbsolutePath, 
     case RC_HTTP_FILE_SERVICE_INVALID_INPUT:
       respondWithJsonError(response, "Invalid input, Same directory", 400, "Bad Request");
       break;
+    case RC_HTTP_FILE_SERVICE_NOT_ABSOLUTE_PATH:
+      respondWithJsonError(response, "Invalid input, Not absolute path", 400, "Bad Request");
+      break;      
     case RC_HTTP_FILE_SERVICE_PERMISION_DENIED:
       respondWithJsonError(response, "Permission denied", 403, "Forbidden");
       break;
@@ -452,8 +463,15 @@ void copyUnixDirectoryAndRespond(HttpResponse *response, char *oldAbsolutePath, 
 static int copyUnixFile(char *oldAbsolutePath, char *newAbsolutePath, int forceCopy) {
   int returnCode = 0, reasonCode = 0, status = 0;
   FileInfo info = {0};
-  
-  if(!strcmp(oldAbsolutePath,newAbsolutePath)){
+
+  if (newAbsolutePath[0] != '/') {
+    zowelog(NULL, LOG_COMP_RESTFILE, ZOWE_LOG_DEBUG,
+            "Invalid input, not absolute path %s\n",
+            newAbsolutePath);
+    return RC_HTTP_FILE_SERVICE_NOT_ABSOLUTE_PATH;    
+  }
+
+  if (!strcmp(oldAbsolutePath,newAbsolutePath)) {
     zowelog(NULL, LOG_COMP_RESTFILE, ZOWE_LOG_DEBUG,
             "Invalid input, same file path (source=%s, destination=%s)\n",
             oldAbsolutePath, newAbsolutePath);
@@ -504,6 +522,9 @@ void copyUnixFileAndRespond(HttpResponse *response, char *oldAbsolutePath, char 
     case RC_HTTP_FILE_SERVICE_INVALID_INPUT:
       respondWithJsonError(response, "Invalid input, Same file", 400, "Bad Request");
       break;
+    case RC_HTTP_FILE_SERVICE_NOT_ABSOLUTE_PATH:
+      respondWithJsonError(response, "Invalid input, Not absolute path", 400, "Bad Request");
+      break;      
     case RC_HTTP_FILE_SERVICE_PERMISION_DENIED:
       respondWithJsonError(response, "Permission denied", 403, "Forbidden");
       break;

--- a/c/httpfileservice.c
+++ b/c/httpfileservice.c
@@ -484,7 +484,7 @@ static int copyUnixFile(char *oldAbsolutePath, char *newAbsolutePath, int forceC
     }
   }
 
-  return HTTP_FILE_SERVICE_SUCCESS;
+  return RC_HTTP_FILE_SERVICE_SUCCESS;
 }
 
 void copyUnixFileAndRespond(HttpResponse *response, char *oldAbsolutePath, char *newAbsolutePath, int forceCopy) {

--- a/h/httpfileservice.h
+++ b/h/httpfileservice.h
@@ -15,6 +15,17 @@
 
 #include "httpserver.h"
 
+#define HTTP_FILE_SERVICE_SUCCESS                0 
+#define HTTP_FILE_SERVICE_NOT_FOUND              10 
+#define HTTP_FILE_SERVICE_ALREADY_EXISTS         11 
+#define HTTP_FILE_SERVICE_PERMISION_DENIED       12 
+#define HTTP_FILE_SERVICE_INVALID_PATH           13 
+#define HTTP_FILE_SERVICE_UNDEFINED_ERROR        14
+#define HTTP_FILE_SERVICE_INVALID_INPUT          15 
+
+#define BPX_EACCES     111
+#define BPX_ENOENT     129
+
 void response200WithMessage(HttpResponse *response, char *msg);
 
 bool isDir(char *absolutePath);

--- a/h/httpfileservice.h
+++ b/h/httpfileservice.h
@@ -15,16 +15,13 @@
 
 #include "httpserver.h"
 
-#define HTTP_FILE_SERVICE_SUCCESS                0 
-#define HTTP_FILE_SERVICE_NOT_FOUND              10 
-#define HTTP_FILE_SERVICE_ALREADY_EXISTS         11 
-#define HTTP_FILE_SERVICE_PERMISION_DENIED       12 
-#define HTTP_FILE_SERVICE_INVALID_PATH           13 
-#define HTTP_FILE_SERVICE_UNDEFINED_ERROR        14
-#define HTTP_FILE_SERVICE_INVALID_INPUT          15 
-
-#define BPX_EACCES     111
-#define BPX_ENOENT     129
+#define RC_HTTP_FILE_SERVICE_SUCCESS                0 
+#define RC_HTTP_FILE_SERVICE_NOT_FOUND              10 
+#define RC_HTTP_FILE_SERVICE_ALREADY_EXISTS         11 
+#define RC_HTTP_FILE_SERVICE_PERMISION_DENIED       12 
+#define RC_HTTP_FILE_SERVICE_INVALID_PATH           13 
+#define RC_HTTP_FILE_SERVICE_UNDEFINED_ERROR        14
+#define RC_HTTP_FILE_SERVICE_INVALID_INPUT          15 
 
 void response200WithMessage(HttpResponse *response, char *msg);
 

--- a/h/httpfileservice.h
+++ b/h/httpfileservice.h
@@ -22,6 +22,7 @@
 #define RC_HTTP_FILE_SERVICE_INVALID_PATH           13 
 #define RC_HTTP_FILE_SERVICE_UNDEFINED_ERROR        14
 #define RC_HTTP_FILE_SERVICE_INVALID_INPUT          15 
+#define RC_HTTP_FILE_SERVICE_NOT_ABSOLUTE_PATH      16 
 
 void response200WithMessage(HttpResponse *response, char *msg);
 


### PR DESCRIPTION
Signed-off-by: Aditya Ranshinge <aranshinge@rocketsoftware.com>

This PR fixes a bug to return valid status for POST /unixfile/copy/{directory}/{file} and POST /unixfile/copy/{directory}
Defined new error codes in httpfileservice.h to identify multiple error scenarios like Bad Request, Not Found, Forbidden etc.
Identified errors in copyUnixFile() and copyUnixDirectory().
Added error tracing logic in copyUnixDirectoryAndRespond() and copyUnixFileAndRespond().
Updated error strings accordingly.