### PR TITLE
resolved forceOverwrite dir and updated return errors of rename dir

### DIFF
--- a/c/httpfileservice.c
+++ b/c/httpfileservice.c
@@ -295,17 +295,40 @@ static int renameUnixDirectory(char *oldAbsolutePath, char *newAbsolutePath, int
   int returnCode = 0, reasonCode = 0, status = 0;
   FileInfo info = {0};
 
+  if (newAbsolutePath[0] != '/') {
+    zowelog(NULL, LOG_COMP_RESTFILE, ZOWE_LOG_DEBUG,
+            "Invalid input, not absolute path %s\n",
+            newAbsolutePath);
+    return RC_HTTP_FILE_SERVICE_NOT_ABSOLUTE_PATH;    
+  }
+
+  if (!strcmp(oldAbsolutePath,newAbsolutePath)) {
+    zowelog(NULL, LOG_COMP_RESTFILE, ZOWE_LOG_DEBUG,
+            "Invalid input, same directory path (source=%s, destination=%s)\n",
+            oldAbsolutePath, newAbsolutePath);
+    return RC_HTTP_FILE_SERVICE_INVALID_INPUT;    
+  }
+
   status = fileInfo(oldAbsolutePath, &info, &returnCode, &reasonCode);
   if (status == -1) {
     zowelog(NULL, LOG_COMP_RESTFILE, ZOWE_LOG_DEBUG,
     		    "Failed to stat directory %s, (returnCode = 0x%x, reasonCode = 0x%x)\n",
             oldAbsolutePath, returnCode, reasonCode);
-    return -1;
+    return RC_HTTP_FILE_SERVICE_NOT_FOUND;
   }
 
   status = fileInfo(newAbsolutePath, &info, &returnCode, &reasonCode);
-  if (status == 0 && !forceRename) {
-    return -1;
+  if (status == 0) {
+    zowelog(NULL, LOG_COMP_RESTFILE, ZOWE_LOG_DEBUG,
+            "Directory already exists %s\n", newAbsolutePath); 
+
+    if (!forceRename) {          
+      return RC_HTTP_FILE_SERVICE_ALREADY_EXISTS;  
+    }
+    else if (forceRename && deleteUnixDirectory(newAbsolutePath))
+    {
+      return RC_HTTP_FILE_SERVICE_UNDEFINED_ERROR;
+    }
   }
 
   status = directoryRename(oldAbsolutePath, newAbsolutePath, &returnCode, &reasonCode);
@@ -313,18 +336,46 @@ static int renameUnixDirectory(char *oldAbsolutePath, char *newAbsolutePath, int
     zowelog(NULL, LOG_COMP_RESTFILE, ZOWE_LOG_DEBUG,
     		    "Failed to rename directory %s, (returnCode = 0x%x, reasonCode = 0x%x)\n",
             oldAbsolutePath, returnCode, reasonCode);
-    return -1;
+    if (returnCode == EACCES) {
+      return RC_HTTP_FILE_SERVICE_PERMISION_DENIED;
+    } else if (returnCode == ENOENT) {
+      return RC_HTTP_FILE_SERVICE_NOT_FOUND;
+    } else {
+      return RC_HTTP_FILE_SERVICE_UNDEFINED_ERROR;
+    }
   }
 
-  return 0;
+  return RC_HTTP_FILE_SERVICE_SUCCESS;
 }
 
 void renameUnixDirectoryAndRespond(HttpResponse *response, char *oldAbsolutePath, char *newAbsolutePath, int forceRename) {
-  if (!renameUnixDirectory(oldAbsolutePath, newAbsolutePath, forceRename)) {
+  int returnCode = RC_HTTP_FILE_SERVICE_UNDEFINED_ERROR;
+
+  if (!(returnCode = renameUnixDirectory(oldAbsolutePath, newAbsolutePath, forceRename))) {
     response200WithMessage(response, "Successfully renamed a directory");
   }
   else {
-    respondWithJsonError(response, "Failed to rename a directory", 500, "Internal Server Error");
+    switch (returnCode)
+    {
+    case RC_HTTP_FILE_SERVICE_INVALID_INPUT:
+      respondWithJsonError(response, "Invalid input, Same directory", 400, "Bad Request");
+      break;
+    case RC_HTTP_FILE_SERVICE_NOT_ABSOLUTE_PATH:
+      respondWithJsonError(response, "Invalid input, Not absolute path", 400, "Bad Request");
+      break;      
+    case RC_HTTP_FILE_SERVICE_PERMISION_DENIED:
+      respondWithJsonError(response, "Permission denied", 403, "Forbidden");
+      break;
+    case RC_HTTP_FILE_SERVICE_ALREADY_EXISTS:
+      respondWithJsonError(response, "Directory already exists", 403, "Forbidden");
+      break;               
+    case RC_HTTP_FILE_SERVICE_NOT_FOUND:
+      respondWithJsonError(response, "Directory not found", 404, "Not Found");
+      break;    
+    default:
+      respondWithJsonError(response, "Failed to rename a directory", 500, "Internal Server Error");
+      break;
+    }
   }
 }
 
@@ -401,10 +452,17 @@ static int copyUnixDirectory(char *oldAbsolutePath, char *newAbsolutePath, int f
   }
   
   status = fileInfo(newAbsolutePath, &info, &returnCode, &reasonCode);
-  if (status == 0 && !forceCopy) {
+  if (status == 0) {
     zowelog(NULL, LOG_COMP_RESTFILE, ZOWE_LOG_DEBUG,
-            "Directory already exists %s\n", newAbsolutePath);    
-    return RC_HTTP_FILE_SERVICE_ALREADY_EXISTS;  
+            "Directory already exists %s\n", newAbsolutePath); 
+
+    if (!forceCopy) {          
+      return RC_HTTP_FILE_SERVICE_ALREADY_EXISTS;  
+    }
+    else if (forceCopy && deleteUnixDirectory(newAbsolutePath))
+    {
+      return RC_HTTP_FILE_SERVICE_UNDEFINED_ERROR;
+    }
   }
 
   status = directoryCopy(oldAbsolutePath, newAbsolutePath, &returnCode, &reasonCode);

--- a/c/httpfileservice.c
+++ b/c/httpfileservice.c
@@ -325,9 +325,8 @@ static int renameUnixDirectory(char *oldAbsolutePath, char *newAbsolutePath, int
     if (!forceRename) {          
       return RC_HTTP_FILE_SERVICE_ALREADY_EXISTS;  
     }
-    else if (forceRename && deleteUnixDirectory(newAbsolutePath))
-    {
-      return RC_HTTP_FILE_SERVICE_UNDEFINED_ERROR;
+    else if (forceRename && deleteUnixDirectory(newAbsolutePath)) {
+      return RC_HTTP_FILE_SERVICE_CLEANUP_TARGET_DIR_FAILED;
     }
   }
 
@@ -337,7 +336,7 @@ static int renameUnixDirectory(char *oldAbsolutePath, char *newAbsolutePath, int
     		    "Failed to rename directory %s, (returnCode = 0x%x, reasonCode = 0x%x)\n",
             oldAbsolutePath, returnCode, reasonCode);
     if (returnCode == EACCES) {
-      return RC_HTTP_FILE_SERVICE_PERMISION_DENIED;
+      return RC_HTTP_FILE_SERVICE_PERMISSION_DENIED;
     } else if (returnCode == ENOENT) {
       return RC_HTTP_FILE_SERVICE_NOT_FOUND;
     } else {
@@ -355,15 +354,14 @@ void renameUnixDirectoryAndRespond(HttpResponse *response, char *oldAbsolutePath
     response200WithMessage(response, "Successfully renamed a directory");
   }
   else {
-    switch (returnCode)
-    {
+    switch (returnCode) {
     case RC_HTTP_FILE_SERVICE_INVALID_INPUT:
       respondWithJsonError(response, "Invalid input, Same directory", 400, "Bad Request");
       break;
     case RC_HTTP_FILE_SERVICE_NOT_ABSOLUTE_PATH:
       respondWithJsonError(response, "Invalid input, Not absolute path", 400, "Bad Request");
       break;      
-    case RC_HTTP_FILE_SERVICE_PERMISION_DENIED:
+    case RC_HTTP_FILE_SERVICE_PERMISSION_DENIED:
       respondWithJsonError(response, "Permission denied", 403, "Forbidden");
       break;
     case RC_HTTP_FILE_SERVICE_ALREADY_EXISTS:
@@ -459,9 +457,8 @@ static int copyUnixDirectory(char *oldAbsolutePath, char *newAbsolutePath, int f
     if (!forceCopy) {          
       return RC_HTTP_FILE_SERVICE_ALREADY_EXISTS;  
     }
-    else if (forceCopy && deleteUnixDirectory(newAbsolutePath))
-    {
-      return RC_HTTP_FILE_SERVICE_UNDEFINED_ERROR;
+    else if (forceCopy && deleteUnixDirectory(newAbsolutePath)) {
+      return RC_HTTP_FILE_SERVICE_CLEANUP_TARGET_DIR_FAILED;
     }
   }
 
@@ -471,7 +468,7 @@ static int copyUnixDirectory(char *oldAbsolutePath, char *newAbsolutePath, int f
     		    "Failed to copy directory %s, (returnCode = 0x%x, reasonCode = 0x%x)\n",
             oldAbsolutePath, returnCode, reasonCode);
     if (returnCode == EACCES) {
-      return RC_HTTP_FILE_SERVICE_PERMISION_DENIED;
+      return RC_HTTP_FILE_SERVICE_PERMISSION_DENIED;
     } else if (returnCode == ENOENT) {
       return RC_HTTP_FILE_SERVICE_NOT_FOUND;
     } else {
@@ -489,15 +486,14 @@ void copyUnixDirectoryAndRespond(HttpResponse *response, char *oldAbsolutePath, 
     response200WithMessage(response, "Successfully copied a directory");
   }
   else {
-    switch (returnCode)
-    {
+    switch (returnCode) {
     case RC_HTTP_FILE_SERVICE_INVALID_INPUT:
       respondWithJsonError(response, "Invalid input, Same directory", 400, "Bad Request");
       break;
     case RC_HTTP_FILE_SERVICE_NOT_ABSOLUTE_PATH:
       respondWithJsonError(response, "Invalid input, Not absolute path", 400, "Bad Request");
       break;      
-    case RC_HTTP_FILE_SERVICE_PERMISION_DENIED:
+    case RC_HTTP_FILE_SERVICE_PERMISSION_DENIED:
       respondWithJsonError(response, "Permission denied", 403, "Forbidden");
       break;
     case RC_HTTP_FILE_SERVICE_ALREADY_EXISTS:
@@ -557,7 +553,7 @@ static int copyUnixFile(char *oldAbsolutePath, char *newAbsolutePath, int forceC
             "Failed to copy file %s, (returnCode = 0x%x, reasonCode = 0x%x)\n",
             oldAbsolutePath, returnCode, reasonCode);
     if (returnCode == EACCES) {
-      return RC_HTTP_FILE_SERVICE_PERMISION_DENIED;
+      return RC_HTTP_FILE_SERVICE_PERMISSION_DENIED;
     } else if (returnCode == ENOENT) {
       return RC_HTTP_FILE_SERVICE_NOT_FOUND;
     } else {
@@ -575,15 +571,14 @@ void copyUnixFileAndRespond(HttpResponse *response, char *oldAbsolutePath, char 
     response200WithMessage(response, "Successfully copied a file");
   }
   else {
-    switch (returnCode)
-    {
+    switch (returnCode) {
     case RC_HTTP_FILE_SERVICE_INVALID_INPUT:
       respondWithJsonError(response, "Invalid input, Same file", 400, "Bad Request");
       break;
     case RC_HTTP_FILE_SERVICE_NOT_ABSOLUTE_PATH:
       respondWithJsonError(response, "Invalid input, Not absolute path", 400, "Bad Request");
       break;      
-    case RC_HTTP_FILE_SERVICE_PERMISION_DENIED:
+    case RC_HTTP_FILE_SERVICE_PERMISSION_DENIED:
       respondWithJsonError(response, "Permission denied", 403, "Forbidden");
       break;
     case RC_HTTP_FILE_SERVICE_ALREADY_EXISTS:

--- a/c/httpfileservice.c
+++ b/c/httpfileservice.c
@@ -366,10 +366,13 @@ void renameUnixDirectoryAndRespond(HttpResponse *response, char *oldAbsolutePath
       break;
     case RC_HTTP_FILE_SERVICE_ALREADY_EXISTS:
       respondWithJsonError(response, "Directory already exists", 403, "Forbidden");
-      break;               
+      break;
+    case RC_HTTP_FILE_SERVICE_CLEANUP_TARGET_DIR_FAILED:
+      respondWithJsonError(response, "Failed to delete existing directory", 403, "Forbidden");
+      break;                         
     case RC_HTTP_FILE_SERVICE_NOT_FOUND:
       respondWithJsonError(response, "Directory not found", 404, "Not Found");
-      break;    
+      break;   
     default:
       respondWithJsonError(response, "Failed to rename a directory", 500, "Internal Server Error");
       break;
@@ -498,10 +501,13 @@ void copyUnixDirectoryAndRespond(HttpResponse *response, char *oldAbsolutePath, 
       break;
     case RC_HTTP_FILE_SERVICE_ALREADY_EXISTS:
       respondWithJsonError(response, "Directory already exists", 403, "Forbidden");
-      break;               
+      break;
+    case RC_HTTP_FILE_SERVICE_CLEANUP_TARGET_DIR_FAILED:
+      respondWithJsonError(response, "Failed to delete existing directory", 403, "Forbidden");
+      break;                      
     case RC_HTTP_FILE_SERVICE_NOT_FOUND:
       respondWithJsonError(response, "Directory not found", 404, "Not Found");
-      break;    
+      break;
     default:
       respondWithJsonError(response, "Failed to copy a directory", 500, "Internal Server Error");
       break;

--- a/h/httpfileservice.h
+++ b/h/httpfileservice.h
@@ -15,14 +15,15 @@
 
 #include "httpserver.h"
 
-#define RC_HTTP_FILE_SERVICE_SUCCESS                0 
-#define RC_HTTP_FILE_SERVICE_NOT_FOUND              10 
-#define RC_HTTP_FILE_SERVICE_ALREADY_EXISTS         11 
-#define RC_HTTP_FILE_SERVICE_PERMISION_DENIED       12 
-#define RC_HTTP_FILE_SERVICE_INVALID_PATH           13 
-#define RC_HTTP_FILE_SERVICE_UNDEFINED_ERROR        14
-#define RC_HTTP_FILE_SERVICE_INVALID_INPUT          15 
-#define RC_HTTP_FILE_SERVICE_NOT_ABSOLUTE_PATH      16 
+#define RC_HTTP_FILE_SERVICE_SUCCESS                             0 
+#define RC_HTTP_FILE_SERVICE_NOT_FOUND                           10 
+#define RC_HTTP_FILE_SERVICE_ALREADY_EXISTS                      11 
+#define RC_HTTP_FILE_SERVICE_PERMISSION_DENIED                   12 
+#define RC_HTTP_FILE_SERVICE_INVALID_PATH                        13 
+#define RC_HTTP_FILE_SERVICE_UNDEFINED_ERROR                     14
+#define RC_HTTP_FILE_SERVICE_INVALID_INPUT                       15 
+#define RC_HTTP_FILE_SERVICE_NOT_ABSOLUTE_PATH                   16 
+#define RC_HTTP_FILE_SERVICE_CLEANUP_TARGET_DIR_FAILED           17
 
 void response200WithMessage(HttpResponse *response, char *msg);
 


### PR DESCRIPTION
Signed-off-by: Aditya Ranshinge <aranshinge@rocketsoftware.com>

This PR fixes a bug to allow forceOverwrite directories for rename and copy Unixfile API and return valid status for POST /unixfile/rename/{directory}
Used existing error codes defined in httpfileservice.h to identify multiple error scenarios like Bad Request, Not Found, Forbidden etc.
If forceOverwrite query is true and newName already exists then existing dir is deleted.
