### PR TITLE
Fix Unixfile copy service for files tagged as binary and mixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Zowe Common C Changelog
 
+## `1.25.0`
+
+- Bugfix: `fileCopy` incorrectly processed files tagged as binary and mixed
+
 ## `1.23.0`
 
 - Bugfix: HTTP server did not send empty files correctly.

--- a/c/zosfile.c
+++ b/c/zosfile.c
@@ -581,6 +581,7 @@ int fileCopy(const char *existingFileName, const char *newFileName, int *retCode
   }
 
   short ccsid = info.ccsid;
+  bool isPureText = (info.fileTaggingTags & FILE_PURE_TEXT) == FILE_PURE_TEXT;
   
   UnixFile *existingFile = fileOpen(existingFileName, FILE_OPTION_READ_ONLY, 0, 0, &returnCode, &reasonCode);
   if (existingFile == NULL) {
@@ -602,7 +603,7 @@ int fileCopy(const char *existingFileName, const char *newFileName, int *retCode
   }
 
   if (ccsid != CCSID_UNTAGGED) {
-    status = fileChangeTag(newFileName, &returnCode, &reasonCode, ccsid);
+    status = fileChangeTagPure(newFileName, &returnCode, &reasonCode, ccsid, isPureText);
     if (status == -1) {
       *retCode = returnCode;
       *resCode = reasonCode;


### PR DESCRIPTION
This PR fixes the Unixfile copy service for files tagged as binary and mixed.

The service couldn't copy binary files and incorrectly tagged mixed files as text. Now the service correctly copies such files. 