### PR TITLE
API for Dataset/Dataset Member Allocation

### DIFF
--- a/c/datasetjson.c
+++ b/c/datasetjson.c
@@ -2690,7 +2690,6 @@ void newDataset(HttpResponse* response, char* absolutePath, int jsonMode){
   int ddNumber = 1;
   char buffer[DD_NAME_LEN + 1];
   while (reasonCode==0x4100000 && ddNumber < 100000) {
-    printf("dnumber: %d\n", ddNumber);
     sprintf(buffer, "MVD%05d", ddNumber);
     int ddconfig = 1;
     setTextUnitString(DD_NAME_LEN, buffer, &ddconfig, DALDDNAM, &textUnits[0]);
@@ -2698,31 +2697,11 @@ void newDataset(HttpResponse* response, char* absolutePath, int jsonMode){
     ddNumber++;
   }
   if (returnCode) {
-    printf("Dynalloc RC = %d, reasonCode = %x\n", returnCode, reasonCode);
     respondWithError(response, HTTP_STATUS_INTERNAL_SERVER_ERROR, "Unable to allocate a DD for ACB");
     return;
   }
   else {
-    printf("Dynalloc RC = %d, reasonCode = %x\n", returnCode, reasonCode);
     response200WithMessage(response, "Successfully created dataset");
-    DynallocInputParms inputParms;
-    memcpy(inputParms.ddName, buffer, DD_NAME_LEN);
-    printf("buffer: %s\ninputParms.ddName: %s\n", buffer, inputParms.ddName);
-    unallocDataset(&inputParms, &reasonCode);
-    if(reasonCode != 0) {
-       printf("unallocDataset RC: %d\n", reasonCode);
-    }
-    // daRC = dynallocUnallocDatasetByDDName2(&daDDName, DYNALLOC_UNALLOC_FLAG_NONE,
-                                                 // &daSysReturnCode, &daSysReasonCode,
-                                                 // false /* Delete data set on deallocation */
-                                                 // ); 
-     // if (daRC != RC_DYNALLOC_OK) {
-      // zowelog(NULL, LOG_COMP_DATASERVICE, ZOWE_LOG_DEBUG,
-              // "error: ds unalloc dsn=\'%44.44s\', member=\'%8.8s\', dd=\'%8.8s\',"
-              // " rc=%d sysRC=%d, sysRSN=0x%08X (read)\n",
-              // daDatasetName.name, daMemberName.name, daDDName.name, daRC, daSysReturnCode, daSysReasonCode, "read");
-        // return;
-    // } 
     return;
   }
   #endif

--- a/c/datasetjson.c
+++ b/c/datasetjson.c
@@ -27,6 +27,7 @@
 #include "bpxnet.h"
 #include "logging.h"
 #include "unixfile.h"
+#include "errno.h"
 #ifdef __ZOWE_OS_ZOS
 #include "zos.h"
 #endif 
@@ -58,6 +59,10 @@ static char vsamCSITypes[5] = {'R', 'D', 'G', 'I', 'C'};
 
 static char getRecordLengthType(char *dscb);
 static int getMaxRecordLength(char *dscb);
+static int updateInputParmsProperty(JsonObject *object, int *configsCount, DynallocNewTextUnit *textUnit);
+static void setTextUnitString(int size, char* data, int *configsCount, int key, DynallocNewTextUnit *textUnit);
+static void setTextUnitCharOrInt(int size, int data, int *configsCount, int key, DynallocNewTextUnit *textUnit);
+static void setTextUnitBool(int *configsCount, int key, DynallocNewTextUnit *textUnit);
 
 typedef struct DatasetName_tag {
   char value[44]; /* space-padded */
@@ -346,6 +351,27 @@ static int isPartionedDataset(char *dscb) {
   return FALSE;
 }
 #endif
+
+static bool isVSAM(char* dsPath) {
+  char dscb[INDEXED_DSCB] = {0};
+  Volser volser = {0};
+  DatasetName dsn = {0};
+  memcpy(dsn.value,dsPath+3,strlen(dsPath)-4);
+  padWithSpaces(dsn.value, sizeof(dsn.value), 0, 0);
+
+  int volserSuccess = getVolserForDataset(&dsn, &volser);
+  if(!volserSuccess){
+    obtainDSCB1(dsn.value, sizeof(dsn.value),
+                           volser.value, sizeof(volser.value),
+                           dscb);
+    int posOffset = 44;
+    int dsorgLow = dscb[83-posOffset];
+    if (dsorgLow & 0x08){
+      return TRUE;
+    }
+  }
+  return FALSE;
+}
 
 static int obtainDSCB1(const char *dsname, unsigned int dsnameLength,
                        const char *volser, unsigned int volserLength,
@@ -2241,6 +2267,356 @@ void respondWithHLQNames(HttpResponse *response, MetadataQueryCache *metadataQue
   metadataQueryCache->cachedCSIParmblocks = returnParmsArray;
   finishResponse(response);     
 #endif /* __ZOWE_OS_ZOS */
+}
+
+
+static int updateInputParmsProperty(JsonObject *object, int *configsCount, DynallocNewTextUnit *textUnit) {
+  Json* value = jsonObjectGetPropertyValue(object, "dsorg");
+  if (jsonIsString(value)){
+    if (!strcmp(value->data.string, "PS")) {
+      setTextUnitCharOrInt(sizeof(short), DALDSORG_PS, configsCount, DALDSORG, textUnit);
+    }
+    else if (!strcmp(value->data.string, "PO")) {
+      setTextUnitCharOrInt(sizeof(short), DALDSORG_PO, configsCount, DALDSORG, textUnit);
+    }
+  }
+
+  errno = 0;
+  value = jsonObjectGetPropertyValue(object, "blksz");
+  if (jsonIsString(value)){
+    long toi = strtol(value->data.string, NULL, 0);
+    if(errno != ERANGE){
+      if (toi <= 0x7FF8 && toi >= 0) { //<-- If DASD, if tape, it can be 80000000
+        setTextUnitCharOrInt(sizeof(short), toi, configsCount, DALBLKSZ, textUnit);
+      }
+      else if (toi <= 0x80000000){
+        setTextUnitCharOrInt(sizeof(long long), toi, configsCount, DALBLKSZ, textUnit);
+      }
+    }
+  }
+
+  errno = 0;
+  value = jsonObjectGetPropertyValue(object, "lrecl");
+  if (jsonIsString(value)){
+    long toi = strtol(value->data.string, NULL, 0);
+    if (errno != ERANGE){
+      if (toi == 0x8000) {
+        setTextUnitCharOrInt(sizeof(short), toi, configsCount, DALLRECL, textUnit);
+      }
+      else if (toi <= 0x7FF8 && toi >= 0) {
+        setTextUnitCharOrInt(sizeof(short), toi, configsCount, DALLRECL, textUnit);
+      }
+    }
+  }
+  value = jsonObjectGetPropertyValue(object, "volser");
+  if (jsonIsString(value)){
+    if (strlen(value->data.string) <= VOLSER_SIZE){
+      setTextUnitString(VOLSER_SIZE, &(value->data.string)[0], configsCount, DALVLSER, textUnit);
+    }
+  }
+
+  value = jsonObjectGetPropertyValue(object, "recfm");
+  if (jsonIsString(value)){
+    int setRECFM = 0;
+    if (indexOf(value->data.string, strlen(value->data.string), 'A', 0) != -1){
+      setRECFM = setRECFM | DALRECFM_A;
+    }
+    if (indexOf(value->data.string, strlen(value->data.string), 'B', 0) != -1){
+      setRECFM = setRECFM | DALRECFM_B;
+    }
+    if (indexOf(value->data.string, strlen(value->data.string), 'V', 0) != -1){
+      setRECFM = setRECFM | DALRECFM_V;
+    }
+    if (indexOf(value->data.string, strlen(value->data.string), 'F', 0) != -1){
+      setRECFM = setRECFM | DALRECFM_F;
+    }
+    if (indexOf(value->data.string, strlen(value->data.string), 'U', 0) != -1){
+      setRECFM = setRECFM | DALRECFM_U;
+    }
+    setTextUnitCharOrInt(sizeof(char), setRECFM, configsCount, DALRECFM, textUnit);
+  }
+
+  errno = 0;
+  value = jsonObjectGetPropertyValue(object, "prime");
+  if (jsonIsString(value)){
+    long toi = strtol(value->data.string, NULL, 0);
+    if (toi <= 0xFFFFFF || toi >= 0) {
+      if (errno != ERANGE){
+        setTextUnitCharOrInt(INT24_SIZE, toi, configsCount, DALPRIME, textUnit);
+      }
+    }
+  }
+
+  errno = 0;
+  value = jsonObjectGetPropertyValue(object, "second");
+  if (jsonIsString(value)){
+    long toi = strtol(value->data.string, NULL, 0);
+    if (toi <= 0xFFFFFF || toi >= 0) {
+      if (errno != ERANGE){
+        setTextUnitCharOrInt(INT24_SIZE, toi, configsCount, DALSECND, textUnit);
+      }
+    }
+  }
+
+  value = jsonObjectGetPropertyValue(object, "space");
+  if (jsonIsString(value)){
+    if (!strcmp(value->data.string, "cyl")){
+      setTextUnitBool(configsCount, DALCYL, textUnit);
+    }
+    if (!strcmp(value->data.string, "trk")){
+      setTextUnitBool(configsCount, DALCYL, textUnit);
+    }
+  }
+
+  errno = 0;
+  value = jsonObjectGetPropertyValue(object, "blkln");
+  if (jsonIsString(value)){
+    long toi = strtol(value->data.string, NULL, 0);
+    if (toi <= 0xFFFF || toi >= 0) {
+      if (errno != ERANGE){
+        setTextUnitCharOrInt(INT24_SIZE, toi, configsCount, DALBLKLN, textUnit);
+      }
+    }
+  }
+
+  value = jsonObjectGetPropertyValue(object, "status");
+  if (jsonIsString(value)){
+    if (!strcmp(value->data.string, "OLD")){
+      setTextUnitCharOrInt(sizeof(char), DISP_OLD, configsCount, DALSTATS, textUnit);
+    }
+    else if (!strcmp(value->data.string, "MOD")){
+      setTextUnitCharOrInt(sizeof(char), DISP_MOD, configsCount, DALSTATS, textUnit);
+    }
+    else if (!strcmp(value->data.string, "SHARE")){
+      setTextUnitCharOrInt(sizeof(char), DISP_SHARE, configsCount, DALSTATS, textUnit);
+    }
+    else {
+      setTextUnitCharOrInt(sizeof(char), DISP_NEW, configsCount, DALSTATS, textUnit);
+    }
+  }
+  else {
+    setTextUnitCharOrInt(sizeof(char), DISP_NEW, configsCount, DALSTATS, textUnit);
+  }
+
+  value = jsonObjectGetPropertyValue(object, "ndisp");
+  if (jsonIsString(value)){
+    if (!strcmp(value->data.string, "UNCATLG")){
+      setTextUnitCharOrInt(sizeof(char), DISP_UNCATLG, configsCount, DALNDISP, textUnit);
+    }
+    else if (!strcmp(value->data.string, "DELETE")){
+      setTextUnitCharOrInt(sizeof(char), DISP_DELETE, configsCount, DALNDISP, textUnit);
+    }
+    else if (!strcmp(value->data.string, "KEEP")){
+      setTextUnitCharOrInt(sizeof(char), DISP_KEEP, configsCount, DALNDISP, textUnit);
+    }
+    else {
+      setTextUnitCharOrInt(sizeof(char), DISP_CATLG, configsCount, DALNDISP, textUnit);
+    }
+  }
+  else {
+    setTextUnitCharOrInt(sizeof(char), DISP_CATLG, configsCount, DALNDISP, textUnit);
+  }
+
+  value = jsonObjectGetPropertyValue(object, "unit");
+  if (jsonIsString(value)){
+    setTextUnitString(strlen(value->data.string), &(value->data.string)[0], configsCount, DALUNIT, textUnit);
+  }
+
+  value = jsonObjectGetPropertyValue(object, "sysout");
+  if (jsonIsString(value)){
+    if (!strcmp(value->data.string, "default")){
+      for(int i = 0; i < *configsCount; i++) {
+        if (textUnit[i].key == DALSTATS || textUnit[i].key == DALNDISP) {
+          textUnit[i].type = TEXT_UNIT_NULL;
+        }
+      }
+      setTextUnitBool(configsCount, DALSYSOU, textUnit);
+    }
+    else if (isalnum(value->data.string[0])) {
+      for(int i = 0; i < *configsCount; i++) {
+        if (textUnit[i].key == DALSTATS || textUnit[i].key == DALNDISP) {
+          textUnit[i].type == TEXT_UNIT_NULL;
+        }
+      }
+      setTextUnitCharOrInt(1, value->data.string[0], configsCount, DALSYSOU, textUnit);
+    } 
+  }
+
+  value = jsonObjectGetPropertyValue(object, "spgnm");
+  if (jsonIsString(value)){
+    if (strlen(value->data.string) <= CLASS_WRITER_SIZE){
+      setTextUnitString(strlen(value->data.string), &(value->data.string)[0], configsCount, DALSPGNM, textUnit);
+    }
+  }
+
+  value = jsonObjectGetPropertyValue(object, "close");
+  if (jsonIsString(value)){
+    if (!strcmp(value->data.string, "true")){
+      setTextUnitBool(configsCount, DALCLOSE, textUnit);
+    }
+  }
+
+  value = jsonObjectGetPropertyValue(object, "dummy");
+  if (jsonIsString(value)){
+    if (!strcmp(value->data.string, "true")){
+      setTextUnitBool(configsCount, DALDUMMY, textUnit);
+    }
+  }
+
+  value = jsonObjectGetPropertyValue(object, "dcbdd");
+  if (jsonIsString(value)){
+    if (strlen(value->data.string) <= DD_NAME_LEN){
+      setTextUnitString(DD_NAME_LEN, &(value->data.string)[0], configsCount, DALDCBDD, textUnit);
+    }
+  }
+
+  value = jsonObjectGetPropertyValue(object, "retdd");
+  if (jsonIsString(value)){
+    if (strlen(value->data.string) <= DD_NAME_LEN){
+      setTextUnitString(DD_NAME_LEN, &(value->data.string)[0], configsCount, DALRTDDN, textUnit);
+    }
+  }
+
+  value = jsonObjectGetPropertyValue(object, "spin");
+  if (jsonIsString(value)){
+    if (!strcmp(value->data.string, "UNALLOC")){
+      setTextUnitCharOrInt(1, SPIN_UNALLOC, configsCount, DALSPIN, textUnit);
+    }
+    else if (!strcmp(value->data.string, "ENDJOB")){
+      setTextUnitCharOrInt(1, SPIN_ENDJOB, configsCount, DALSPIN, textUnit);
+    }
+  }
+
+  value = jsonObjectGetPropertyValue(object, "strcls");
+  if (jsonIsString(value)){
+    if (strlen(value->data.string) <= CLASS_WRITER_SIZE){
+      setTextUnitString(8, &(value->data.string)[0], configsCount, DALSTCL, textUnit);
+    }
+  }
+
+  value = jsonObjectGetPropertyValue(object, "mngcls");
+  if (jsonIsString(value)){
+    if (strlen(value->data.string) <= CLASS_WRITER_SIZE){
+     setTextUnitString(CLASS_WRITER_SIZE, &(value->data.string)[0], configsCount, DALMGCL, textUnit);
+    }
+  }
+
+  value = jsonObjectGetPropertyValue(object, "datacls");
+  if (jsonIsString(value)){
+    if (strlen(value->data.string) <= CLASS_WRITER_SIZE){
+      setTextUnitString(CLASS_WRITER_SIZE, &(value->data.string)[0], configsCount, DALDACL, textUnit);
+    }
+  }
+}
+
+static void setTextUnitString(int size, char* data, int *configsCount, int key, DynallocNewTextUnit *textUnit) {
+  textUnit[*configsCount].size = size;
+  textUnit[*configsCount].type = TEXT_UNIT_STRING;
+  textUnit[*configsCount].key = key;
+  textUnit[*configsCount].data.string = data;
+  (*configsCount)++;
+}  
+
+static void setTextUnitCharOrInt(int size, int data, int *configsCount, int key, DynallocNewTextUnit *textUnit) {
+  textUnit[*configsCount].size = size;
+  textUnit[*configsCount].type = TEXT_UNIT_CHARINT;
+  textUnit[*configsCount].key = key;
+  textUnit[*configsCount].data.number = data;
+  (*configsCount)++;
+}  
+
+static void setTextUnitBool(int *configsCount, int key, DynallocNewTextUnit *textUnit) {
+  textUnit[*configsCount].type = TEXT_UNIT_BOOLEAN;
+  textUnit[*configsCount].key = key;
+  (*configsCount)++;
+}
+
+void newDataset(HttpResponse* response, char* datasetName, int jsonMode){
+  #ifdef __ZOWE_OS_ZOS
+
+  DatasetName dsn = {0};
+  memset(dsn.value, ' ', DATASET_NAME_LEN);
+
+  int lParenIndex = indexOf(datasetName, strlen(datasetName),'(',0);
+
+  //String parsing operation, gets rid of of 3 initial unnecessary characters-> //'
+  if (lParenIndex > 0){
+    memcpy(dsn.value,datasetName+3,lParenIndex-3);
+  }
+  //String parsing operation, gets rid of of 3 initial unnecessary characters-> //'
+  else{
+    memcpy(dsn.value,datasetName+3,strlen(datasetName)-4);
+  }
+
+  int configsCount = 0;
+  DynallocNewTextUnit textUnits[TOTAL_TEXT_UNITS];
+  setTextUnitString(DATASET_NAME_LEN, &dsn.value[0], &configsCount, DALDSNAM, &textUnits[0]);
+  setTextUnitString(DD_NAME_LEN, "MVD00000", &configsCount, DALDDNAM, &textUnits[0]);
+
+  if (jsonMode != TRUE) { /*TODO add support for updating files with raw bytes instead of JSON*/
+    respondWithError(response, HTTP_STATUS_BAD_REQUEST,"Cannot update file without JSON formatted record request");
+    return;
+  }
+
+  HttpRequest *request = response->request;
+
+  FileInfo info;
+
+  char *contentBody = request->contentBody;
+  int bodyLength = strlen(contentBody);
+
+  char *convertedBody = safeMalloc(bodyLength*4,"writeDatasetConvert");
+  int conversionBufferLength = bodyLength*4;
+  int translationLength;
+  int outCCSID = NATIVE_CODEPAGE;
+  int reasonCode;
+
+  int returnCode = convertCharset(contentBody,
+                              bodyLength,
+                              CCSID_UTF_8,
+                              CHARSET_OUTPUT_USE_BUFFER,
+                              &convertedBody,
+                              conversionBufferLength,
+                              outCCSID,
+                              NULL,
+                              &translationLength,
+                              &reasonCode);
+
+  if(returnCode == 0) {  
+
+    ShortLivedHeap *slh = makeShortLivedHeap(0x10000,0x10);
+    char errorBuffer[2048];
+    Json *json = jsonParseUnterminatedString(slh,
+                                             convertedBody, translationLength,
+                                             errorBuffer, sizeof(errorBuffer));
+    if (json) {
+      if (jsonIsObject(json)){
+        JsonObject * jsonObject = jsonAsObject(json);
+        updateInputParmsProperty(jsonObject, &configsCount, &textUnits[0]);
+      }     
+    }
+  }
+
+  returnCode = dynallocNewDataset(&reasonCode, &textUnits[0], configsCount);
+  int ddNumber = 1;
+  char buffer[DD_NAME_LEN + 1];
+  while (reasonCode==0x4100000 && ddNumber < 100000) {
+    sprintf(buffer, "MVD%05d", ddNumber);
+    int ddconfig = 1;
+    setTextUnitString(DD_NAME_LEN, buffer, &ddconfig, DALDDNAM, &textUnits[0]);
+    returnCode = dynallocNewDataset(&reasonCode, &textUnits[0], configsCount);
+    ddNumber++;
+  }
+  if (returnCode) {
+    printf("Dynalloc RC = %d, reasonCode = %x\n", returnCode, reasonCode);
+    respondWithError(response, HTTP_STATUS_INTERNAL_SERVER_ERROR, "Unable to allocate a DD for ACB");
+    return;
+  }
+  else {
+    printf("Dynalloc RC = %d, reasonCode = %x\n", returnCode, reasonCode);
+    response200WithMessage(response, "Successfully created dataset");
+  }
+  #endif
 }
 
 

--- a/c/datasetjson.c
+++ b/c/datasetjson.c
@@ -2330,7 +2330,7 @@ static int updateInputParmsProperty(JsonObject *object, int *configsCount, Dynal
         }
         setTextUnitCharOrInt(sizeof(char), setRECFM, configsCount, DALRECFM, textUnit);
       } else if(!strcmp(propString, "space")) {
-        setTextUnitBool(configsCount, !strcmp(valueString, "cyl) ? DALCYL : DALTRK, textUnit);
+        setTextUnitBool(configsCount, !strcmp(valueString, "cyl") ? DALCYL : DALTRK, textUnit);
       } else if(!strcmp(propString, "blkln")) {
         long toi = strtol(valueString, NULL, 0);
         if (toi <= 0xFFFF || toi >= 0) {

--- a/c/datasetjson.c
+++ b/c/datasetjson.c
@@ -2280,9 +2280,9 @@ static int updateInputParmsProperty(JsonObject *object, int *configsCount, Dynal
     printf("currentProperty: %s\n", jsonPropertyGetKey(currentProp));
     value = jsonPropertyGetValue(currentProp);
     char *valueString = jsonAsString(value);
-    errno = 0;
+    
     if(valueString != NULL){
-      printf("value for prop is not null\n");
+      errno = 0;
       int valueStrLen = valueStrLen;
       char *propString = jsonPropertyGetKey(currentProp);
       
@@ -2382,10 +2382,11 @@ static int updateInputParmsProperty(JsonObject *object, int *configsCount, Dynal
         }
       } else if(!strcmp(propString, "close")) {
         if (!strcmp(valueString, "true")){
+          printf("SETTING CLOSE TRUE\n");
           setTextUnitBool(configsCount, DALCLOSE, textUnit);
         }
       } else if(!strcmp(propString, "dummy")) {
-        if (!strcmp(value->data.string, "true")){
+        if (!strcmp(valueString, "true")){
           setTextUnitBool(configsCount, DALDUMMY, textUnit);
         }
       } else if(!strcmp(propString, "dcbdd")) {
@@ -2393,267 +2394,31 @@ static int updateInputParmsProperty(JsonObject *object, int *configsCount, Dynal
           setTextUnitString(DD_NAME_LEN, &(valueString)[0], configsCount, DALDCBDD, textUnit);
         }
       } else if(!strcmp(propString, "retdd")) {
-        if (strlen(value->data.string) <= DD_NAME_LEN){
-          setTextUnitString(DD_NAME_LEN, &(value->data.string)[0], configsCount, DALRTDDN, textUnit);
+        if (strlen(valueString) <= DD_NAME_LEN){
+          setTextUnitString(DD_NAME_LEN, &(valueString)[0], configsCount, DALRTDDN, textUnit);
         }
       } else if(!strcmp(propString, "spin")) {
-        if (!strcmp(value->data.string, "UNALLOC")){
+        if (!strcmp(valueString, "UNALLOC")){
           setTextUnitCharOrInt(1, SPIN_UNALLOC, configsCount, DALSPIN, textUnit);
-        } else if (!strcmp(value->data.string, "ENDJOB")){
+        } else if (!strcmp(valueString, "ENDJOB")){
           setTextUnitCharOrInt(1, SPIN_ENDJOB, configsCount, DALSPIN, textUnit);
         }
       } else if(!strcmp(propString, "strcls")) {
-        if (strlen(value->data.string) <= CLASS_WRITER_SIZE){
-          setTextUnitString(8, &(value->data.string)[0], configsCount, DALSTCL, textUnit);
+        if (strlen(valueString) <= CLASS_WRITER_SIZE){
+          setTextUnitString(8, &(valueString)[0], configsCount, DALSTCL, textUnit);
         }
       } else if(!strcmp(propString, "mngcls")) {
-        if (strlen(value->data.string) <= CLASS_WRITER_SIZE){
-         setTextUnitString(CLASS_WRITER_SIZE, &(value->data.string)[0], configsCount, DALMGCL, textUnit);
+        if (strlen(valueString) <= CLASS_WRITER_SIZE){
+         setTextUnitString(CLASS_WRITER_SIZE, &(valueString)[0], configsCount, DALMGCL, textUnit);
         }
       } else if(!strcmp(propString, "datacls")) {
-        if (strlen(value->data.string) <= CLASS_WRITER_SIZE){
-          setTextUnitString(CLASS_WRITER_SIZE, &(value->data.string)[0], configsCount, DALDACL, textUnit);
+        if (strlen(valueString) <= CLASS_WRITER_SIZE){
+          setTextUnitString(CLASS_WRITER_SIZE, &(valueString)[0], configsCount, DALDACL, textUnit);
         }
       }
     }
     currentProp = jsonObjectGetNextProperty(currentProp);
   }
-/*   Json* value = jsonObjectGetPropertyValue(object, "dsorg");
-  if (jsonIsString(value)){
-    if (!strcmp(value->data.string, "PS")) {
-      setTextUnitCharOrInt(sizeof(short), DALDSORG_PS, configsCount, DALDSORG, textUnit);
-    }
-    else if (!strcmp(value->data.string, "PO")) {
-      setTextUnitCharOrInt(sizeof(short), DALDSORG_PO, configsCount, DALDSORG, textUnit);
-    }
-  } */
-
-/*   errno = 0;
-  value = jsonObjectGetPropertyValue(object, "blksz");
-  if (jsonIsString(value)){
-    long toi = strtol(value->data.string, NULL, 0);
-    if(errno != ERANGE){
-      if (toi <= 0x7FF8 && toi >= 0) { //<-- If DASD, if tape, it can be 80000000
-        setTextUnitCharOrInt(sizeof(short), toi, configsCount, DALBLKSZ, textUnit);
-      }
-      else if (toi <= 0x80000000){
-        setTextUnitCharOrInt(sizeof(long long), toi, configsCount, DALBLKSZ, textUnit);
-      }
-    }
-  } */
-
-  // errno = 0;
-  // value = jsonObjectGetPropertyValue(object, "lrecl");
-  // if (jsonIsString(value)){
-    // long toi = strtol(value->data.string, NULL, 0);
-    // if (errno != ERANGE){
-      // if (toi == 0x8000) {
-        // setTextUnitCharOrInt(sizeof(short), toi, configsCount, DALLRECL, textUnit);
-      // }
-      // else if (toi <= 0x7FF8 && toi >= 0) {
-        // setTextUnitCharOrInt(sizeof(short), toi, configsCount, DALLRECL, textUnit);
-      // }
-    // }
-  // }
-/*   value = jsonObjectGetPropertyValue(object, "volser");
-  if (jsonIsString(value)){
-    if (strlen(value->data.string) <= VOLSER_SIZE){
-      setTextUnitString(VOLSER_SIZE, &(value->data.string)[0], configsCount, DALVLSER, textUnit);
-    }
-  } */
-
-/*   value = jsonObjectGetPropertyValue(object, "recfm");
-  if (jsonIsString(value)){
-    int setRECFM = 0;
-    if (indexOf(value->data.string, strlen(value->data.string), 'A', 0) != -1){
-      setRECFM = setRECFM | DALRECFM_A;
-    }
-    if (indexOf(value->data.string, strlen(value->data.string), 'B', 0) != -1){
-      setRECFM = setRECFM | DALRECFM_B;
-    }
-    if (indexOf(value->data.string, strlen(value->data.string), 'V', 0) != -1){
-      setRECFM = setRECFM | DALRECFM_V;
-    }
-    if (indexOf(value->data.string, strlen(value->data.string), 'F', 0) != -1){
-      setRECFM = setRECFM | DALRECFM_F;
-    }
-    if (indexOf(value->data.string, strlen(value->data.string), 'U', 0) != -1){
-      setRECFM = setRECFM | DALRECFM_U;
-    }
-    setTextUnitCharOrInt(sizeof(char), setRECFM, configsCount, DALRECFM, textUnit);
-  } */
-
-/*   errno = 0;
-  value = jsonObjectGetPropertyValue(object, "prime");
-  if (jsonIsString(value)){
-    long toi = strtol(value->data.string, NULL, 0);
-    if (toi <= 0xFFFFFF || toi >= 0) {
-      if (errno != ERANGE){
-        setTextUnitCharOrInt(INT24_SIZE, toi, configsCount, DALPRIME, textUnit);
-      }
-    }
-  }
-
-  errno = 0;
-  value = jsonObjectGetPropertyValue(object, "second");
-  if (jsonIsString(value)){
-    long toi = strtol(value->data.string, NULL, 0);
-    if (toi <= 0xFFFFFF || toi >= 0) {
-      if (errno != ERANGE){
-        setTextUnitCharOrInt(INT24_SIZE, toi, configsCount, DALSECND, textUnit);
-      }
-    }
-  } */
-
-/*   value = jsonObjectGetPropertyValue(object, "space");
-  if (jsonIsString(value)){
-    if (!strcmp(value->data.string, "cyl")){
-      setTextUnitBool(configsCount, DALCYL, textUnit);
-    }
-    if (!strcmp(value->data.string, "trk")){
-      setTextUnitBool(configsCount, DALCYL, textUnit);
-    }
-  } */
-
-/*   errno = 0;
-  value = jsonObjectGetPropertyValue(object, "blkln");
-  if (jsonIsString(value)){
-    long toi = strtol(value->data.string, NULL, 0);
-    if (toi <= 0xFFFF || toi >= 0) {
-      if (errno != ERANGE){
-        setTextUnitCharOrInt(INT24_SIZE, toi, configsCount, DALBLKLN, textUnit);
-      }
-    }
-  } */
-
-/*   value = jsonObjectGetPropertyValue(object, "status");
-  if (jsonIsString(value)){
-    if (!strcmp(value->data.string, "OLD")){
-      setTextUnitCharOrInt(sizeof(char), DISP_OLD, configsCount, DALSTATS, textUnit);
-    }
-    else if (!strcmp(value->data.string, "MOD")){
-      setTextUnitCharOrInt(sizeof(char), DISP_MOD, configsCount, DALSTATS, textUnit);
-    }
-    else if (!strcmp(value->data.string, "SHARE")){
-      setTextUnitCharOrInt(sizeof(char), DISP_SHARE, configsCount, DALSTATS, textUnit);
-    }
-    else {
-      setTextUnitCharOrInt(sizeof(char), DISP_NEW, configsCount, DALSTATS, textUnit);
-    }
-  }
-  else {
-    setTextUnitCharOrInt(sizeof(char), DISP_NEW, configsCount, DALSTATS, textUnit);
-  } */
-
-  /* value = jsonObjectGetPropertyValue(object, "ndisp");
-  if (jsonIsString(value)){
-    if (!strcmp(value->data.string, "UNCATLG")){
-      setTextUnitCharOrInt(sizeof(char), DISP_UNCATLG, configsCount, DALNDISP, textUnit);
-    }
-    else if (!strcmp(value->data.string, "DELETE")){
-      setTextUnitCharOrInt(sizeof(char), DISP_DELETE, configsCount, DALNDISP, textUnit);
-    }
-    else if (!strcmp(value->data.string, "KEEP")){
-      setTextUnitCharOrInt(sizeof(char), DISP_KEEP, configsCount, DALNDISP, textUnit);
-    }
-    else {
-      setTextUnitCharOrInt(sizeof(char), DISP_CATLG, configsCount, DALNDISP, textUnit);
-    }
-  }
-  else {
-    setTextUnitCharOrInt(sizeof(char), DISP_CATLG, configsCount, DALNDISP, textUnit);
-  } */
-
-/*   value = jsonObjectGetPropertyValue(object, "unit");
-  if (jsonIsString(value)){
-    setTextUnitString(strlen(value->data.string), &(value->data.string)[0], configsCount, DALUNIT, textUnit);
-  } */
-
- /*  value = jsonObjectGetPropertyValue(object, "sysout");
-  if (jsonIsString(value)){
-    if (!strcmp(value->data.string, "default")){
-      for(int i = 0; i < *configsCount; i++) {
-        if (textUnit[i].key == DALSTATS || textUnit[i].key == DALNDISP) {
-          textUnit[i].type = TEXT_UNIT_NULL;
-        }
-      }
-      setTextUnitBool(configsCount, DALSYSOU, textUnit);
-    }
-    else if (isalnum(value->data.string[0])) {
-      for(int i = 0; i < *configsCount; i++) {
-        if (textUnit[i].key == DALSTATS || textUnit[i].key == DALNDISP) {
-          textUnit[i].type == TEXT_UNIT_NULL;
-        }
-      }
-      setTextUnitCharOrInt(1, value->data.string[0], configsCount, DALSYSOU, textUnit);
-    } 
-  } */
-
-/*   value = jsonObjectGetPropertyValue(object, "spgnm");
-  if (jsonIsString(value)){
-    if (strlen(value->data.string) <= CLASS_WRITER_SIZE){
-      setTextUnitString(strlen(value->data.string), &(value->data.string)[0], configsCount, DALSPGNM, textUnit);
-    }
-  } */
-
-  // value = jsonObjectGetPropertyValue(object, "close");
-  // if (jsonIsString(value)){
-    // if (!strcmp(value->data.string, "true")){
-      // setTextUnitBool(configsCount, DALCLOSE, textUnit);
-    // }
-  // }
-
-/*   value = jsonObjectGetPropertyValue(object, "dummy");
-  if (jsonIsString(value)){
-    if (!strcmp(value->data.string, "true")){
-      setTextUnitBool(configsCount, DALDUMMY, textUnit);
-    }
-  }
- */
- /*  value = jsonObjectGetPropertyValue(object, "dcbdd");
-  if (jsonIsString(value)){
-    if (strlen(value->data.string) <= DD_NAME_LEN){
-      setTextUnitString(DD_NAME_LEN, &(value->data.string)[0], configsCount, DALDCBDD, textUnit);
-    }
-  } */
-
-/*   value = jsonObjectGetPropertyValue(object, "retdd");
-  if (jsonIsString(value)){
-    if (strlen(value->data.string) <= DD_NAME_LEN){
-      setTextUnitString(DD_NAME_LEN, &(value->data.string)[0], configsCount, DALRTDDN, textUnit);
-    }
-  } */
-
-/*   value = jsonObjectGetPropertyValue(object, "spin");
-  if (jsonIsString(value)){
-    if (!strcmp(value->data.string, "UNALLOC")){
-      setTextUnitCharOrInt(1, SPIN_UNALLOC, configsCount, DALSPIN, textUnit);
-    }
-    else if (!strcmp(value->data.string, "ENDJOB")){
-      setTextUnitCharOrInt(1, SPIN_ENDJOB, configsCount, DALSPIN, textUnit);
-    }
-  } */
-
-/*   value = jsonObjectGetPropertyValue(object, "strcls");
-  if (jsonIsString(value)){
-    if (strlen(value->data.string) <= CLASS_WRITER_SIZE){
-      setTextUnitString(8, &(value->data.string)[0], configsCount, DALSTCL, textUnit);
-    }
-  } */
-
-/*   value = jsonObjectGetPropertyValue(object, "mngcls");
-  if (jsonIsString(value)){
-    if (strlen(value->data.string) <= CLASS_WRITER_SIZE){
-     setTextUnitString(CLASS_WRITER_SIZE, &(value->data.string)[0], configsCount, DALMGCL, textUnit);
-    }
-  } */
-
-/*   value = jsonObjectGetPropertyValue(object, "datacls");
-  if (jsonIsString(value)){
-    if (strlen(value->data.string) <= CLASS_WRITER_SIZE){
-      setTextUnitString(CLASS_WRITER_SIZE, &(value->data.string)[0], configsCount, DALDACL, textUnit);
-    }
-  } */
 }
 
 static void setTextUnitString(int size, char* data, int *configsCount, int key, DynallocNewTextUnit *textUnit) {

--- a/c/datasetjson.c
+++ b/c/datasetjson.c
@@ -2275,9 +2275,7 @@ static int updateInputParmsProperty(JsonObject *object, int *configsCount, Dynal
   JsonProperty *currentProp = jsonObjectGetFirstProperty(object);
   //printf("Updating input parms");
   Json *value;
-  printf("updateInptuParmsProperty called\n");
   while(currentProp != NULL){
-    printf("currentProperty: %s\n", jsonPropertyGetKey(currentProp));
     value = jsonPropertyGetValue(currentProp);
     char *valueString = jsonAsString(value);
     
@@ -2382,7 +2380,6 @@ static int updateInputParmsProperty(JsonObject *object, int *configsCount, Dynal
         }
       } else if(!strcmp(propString, "close")) {
         if (!strcmp(valueString, "true")){
-          printf("SETTING CLOSE TRUE\n");
           setTextUnitBool(configsCount, DALCLOSE, textUnit);
         }
       } else if(!strcmp(propString, "dummy")) {

--- a/c/dynalloc.c
+++ b/c/dynalloc.c
@@ -863,7 +863,7 @@ int dynallocNewDataset(int *reasonCode, DynallocNewTextUnit *setTextUnits, int T
     )
   );
 
-  below2G->textUnits = (TextUnit **)safeMalloc(sizeof(TextUnit*) * TextUnitsSize, "Text units array");
+  below2G->textUnits = (TextUnit **)safeMalloc31(sizeof(TextUnit*) * TextUnitsSize, "Text units array");
 
   DynallocParms *parms = &below2G->parms;
   dynallocParmsInit(parms);
@@ -904,7 +904,7 @@ int dynallocNewDataset(int *reasonCode, DynallocNewTextUnit *setTextUnits, int T
         (dynallocParmsGetErrorCode(parms) << 16);
   } while (0);
   freeTextUnitArray(below2G->textUnits, TextUnitsSize);
-  safeFree((char*)below2G->textUnits, sizeof(TextUnit*) * TextUnitsSize);
+  safeFree31((char*)below2G->textUnits, sizeof(TextUnit*) * TextUnitsSize);
   dynallocParmsTerm(parms);
   parms = NULL;
   FREE_STRUCT31(

--- a/c/dynalloc.c
+++ b/c/dynalloc.c
@@ -60,6 +60,10 @@ TextUnit *createIntTextUnit(int key, int value) {
   return createSimpleTextUnit2(key, (char*)&value, sizeof(value));
 }
 
+TextUnit *createIntTextUnitLength(int key, int value, int length) {
+  return createSimpleTextUnit2(key, (char*)&value, length);
+}
+
 TextUnit *createInt8TextUnit(int key, int8_t value) {
   return createSimpleTextUnit2(key, (char*)&value, sizeof(value));
 }
@@ -68,11 +72,27 @@ TextUnit *createInt16TextUnit(int key, int16_t value) {
   return createSimpleTextUnit2(key, (char*)&value, sizeof(value));
 }
 
+TextUnit *createInt24TextUnit(int key, int value) {
+  return createSimpleTextUnit2(key, (char*)&value + 1, INT24_SIZE);
+}
+
+TextUnit *createLongIntTextUnit(int key, long long value) {
+  return createSimpleTextUnit2(key, (char*)&value, sizeof(value));
+}
+
 TextUnit *createCharTextUnit(int key, char value) {
   char valueArray[2];
   valueArray[0] = value;
   valueArray[1] = 0;
   return createSimpleTextUnit2(key, valueArray, 1);
+}
+
+TextUnit *createCharTextUnit2(int key, short value) {
+  char valueArray[3];
+  valueArray[0] = value >> BYTE_LENGTH & BYTE_FULL_MASK;
+  valueArray[1] = value & BYTE_FULL_MASK;
+  valueArray[2] = 0;
+  return createSimpleTextUnit2(key, valueArray, 2);
 }
 
 TextUnit *createCompoundTextUnit(int key, char **values, int valueCount) {
@@ -832,6 +852,65 @@ int dynallocDataset(DynallocInputParms *inputParms, int *reasonCode) {
 
   return rc;
 
+}
+
+int dynallocNewDataset(int *reasonCode, DynallocNewTextUnit *setTextUnits, int TextUnitsSize) {
+  ALLOC_STRUCT31(
+    STRUCT31_NAME(below2G),
+    STRUCT31_FIELDS(
+      DynallocParms parms;
+      TextUnit ** __ptr32 textUnits;
+    )
+  );
+
+  below2G->textUnits = (TextUnit **)safeMalloc(sizeof(TextUnit*) * TextUnitsSize, "Text units array");
+
+  DynallocParms *parms = &below2G->parms;
+  dynallocParmsInit(parms);
+
+  dynallocParmsSetTextUnits(parms, below2G->textUnits, TextUnitsSize);
+
+  int rc;
+
+  do {
+    rc = -1;
+    for (int i = 0; i < TextUnitsSize; i++) { 
+      if (setTextUnits[i].type == TEXT_UNIT_STRING) {
+        below2G->textUnits[i] = createSimpleTextUnit2(setTextUnits[i].key, setTextUnits[i].data.string, setTextUnits[i].size);
+      }
+      else if (setTextUnits[i].type == TEXT_UNIT_CHARINT) {
+        if (setTextUnits[i].size == sizeof(char)) {
+          below2G->textUnits[i] = createCharTextUnit(setTextUnits[i].key, setTextUnits[i].data.number);   
+        }  
+        else if (setTextUnits[i].size == sizeof(short)) {
+          below2G->textUnits[i] = createInt16TextUnit(setTextUnits[i].key, setTextUnits[i].data.number);   
+        } 
+        else if (setTextUnits[i].size == INT24_SIZE) {
+          below2G->textUnits[i] = createInt24TextUnit(setTextUnits[i].key, setTextUnits[i].data.number);   
+        }
+        else if (setTextUnits[i].size == sizeof(long long)) {
+          long number = setTextUnits[i].data.number;
+          below2G->textUnits[i] = createLongIntTextUnit(setTextUnits[i].key, (long long)setTextUnits[i].data.number);   
+        }
+      } 
+      else if (setTextUnits[i].type == TEXT_UNIT_BOOLEAN) {
+        below2G->textUnits[i] = createSimpleTextUnit2(setTextUnits[i].key, NULL, 0);
+      }
+    }
+
+    turn_on_HOB(below2G->textUnits[TextUnitsSize - 1]);
+    rc = invokeDynalloc(parms);
+    *reasonCode = dynallocParmsGetInfoCode(parms) +
+        (dynallocParmsGetErrorCode(parms) << 16);
+  } while (0);
+  freeTextUnitArray(below2G->textUnits, TextUnitsSize);
+  safeFree((char*)below2G->textUnits, sizeof(TextUnit*) * TextUnitsSize);
+  dynallocParmsTerm(parms);
+  parms = NULL;
+  FREE_STRUCT31(
+    STRUCT31_NAME(below2G)
+  );
+  return rc;
 }
 
 int dynallocDatasetMember(DynallocInputParms *inputParms, int *reasonCode,

--- a/h/datasetjson.h
+++ b/h/datasetjson.h
@@ -23,6 +23,9 @@
 
 #define SAF_AUTHORIZATION_READ 0x04
 #define SAF_AUTHORIZATION_UPDATE 0x08
+#define MEMBER_MAX 8
+#define DATASET_PATH_MAX 44
+#define DATASET_MEMBER_MAXLEN DATASET_PATH_MAX + MEMBER_MAX + 6 /* 6 is for extra characters in filepath -- //, '', () */
 
 typedef struct MetadataQueryCache_tag{
   EntryDataSet *cachedHLQSet;
@@ -62,6 +65,7 @@ void respondWithDataset(HttpResponse* response, char* absolutePath, int jsonMode
 void respondWithVSAMDataset(HttpResponse* response, char* absolutePath, hashtable *acbTable, int jsonMode);
 void respondWithDatasetMetadata(HttpResponse *response);
 void respondWithHLQNames(HttpResponse *response, MetadataQueryCache *metadataQueryCache);
+void newDataset(HttpResponse* response, char* absolutePath, int jsonMode);
 void updateDataset(HttpResponse* response, char* absolutePath, int jsonMode);
 void updateVSAMDataset(HttpResponse* response, char* absolutePath, hashtable *acbTable, int jsonMode);
 void deleteVSAMDataset(HttpResponse* response, char* absolutePath);

--- a/h/dynalloc.h
+++ b/h/dynalloc.h
@@ -209,7 +209,17 @@ X'40' Data set available for printing at the end of the job.
 #define DALVSER  0x0010
 #define DALVSEQ  0x0012
 #define DALDSORG 0x003C
+#define DALDSORG_VSAM 0x0008
+#define DALDSORG_GRAPHICS 0x0080
+#define DALDSORG_PO 0x0200
+#define DALDSORG_POU 0x0300
+#define DALDSORG_MQ 0x0400
+#define DALDSORG_CQ 0x0800
+#define DALDSORG_CX 0x1000
+#define DALDSORG_DA 0x2000
+#define DALDSORG_DAU 0x2100
 #define DALDSORG_PS 0x4000
+#define DALDSORG_PSU 0x4100
 #define DALBLKSZ 0x0030
 #define DALLRECL 0x0042 
 #define DALBUFNO 0x0034
@@ -252,8 +262,11 @@ TextUnit *createSimpleTextUnit2(int key, char *value, int firstParameterLength);
 TextUnit *createCharTextUnit(int key, char value);
 TextUnit *createCompoundTextUnit(int key, char **values, int valueCount);
 TextUnit *createIntTextUnit(int key, int value);
+TextUnit *createCharTextUnit2(int key, short value);
 TextUnit *createInt8TextUnit(int key, int8_t value);
+TextUnit *createIntTextUnitLength(int key, int value, int length);
 TextUnit *createInt16TextUnit(int key, int16_t value);
+TextUnit *createInt24TextUnit(int key, int value);
 void freeTextUnit(TextUnit * text_unit);
 
 /* open a stream to the internal reader */
@@ -681,8 +694,28 @@ int DeallocDDName(char *ddname);
 // Values for disposition field
 #define DISP_OLD 0x01
 #define DISP_MOD 0x02
+#define DISP_NEW 0x04
 #define DISP_SHARE 0x08
 #define DISP_DELETE 0x04
+
+// Values for normal disposition field
+#define DISP_UNCATLG 0x01
+#define DISP_CATLG 0x02
+#define DISP_DELETE 0x04
+#define DISP_KEEP 0x08
+
+#define DALSYSOU_DEFAULT 0x08
+
+#define SPIN_UNALLOC 0x80
+#define SPIN_ENDJOB 0x40
+
+#define BYTE_LENGTH 8
+#define BYTE_FULL_MASK 0xff
+
+#define INT24_SIZE 3
+#define VOLSER_SIZE 6
+#define CLASS_WRITER_SIZE 8
+#define TOTAL_TEXT_UNITS 23
 
 /* Use this structure to pass parameters to DYNALLOC functions.
  * Dsname should be padded by spaces. */
@@ -696,11 +729,28 @@ typedef struct DynallocInputParms_tag {
   char reserved[3];
 } DynallocInputParms;
 
+typedef struct DynallocNewTextUnit_tag {
+#define TEXT_UNIT_STRING 1
+#define TEXT_UNIT_BOOLEAN 2
+#define TEXT_UNIT_CHARINT 3
+#define TEXT_UNIT_NULL 4
+#define JSON_TYPE_ERROR 666
+  int type;
+  int size;
+  int key;
+  union {
+    int number;
+    char *string;
+    int boolean;
+  } data;
+} DynallocNewTextUnit;
+
 #pragma map(dynallocDataset, "DYNAUALC")
 #pragma map(dynallocDatasetMember, "DYNAUALM")
 #pragma map(unallocDataset, "DYNADALC")
 
 int dynallocDataset(DynallocInputParms *inputParms, int *reasonCode);
+int dynallocNewDataset(int *reasonCode, DynallocNewTextUnit *setTextUnits, int TextUnitsSize);
 int dynallocDatasetMember(DynallocInputParms *inputParms, int *reasonCode,
                           char *member);
 int unallocDataset(DynallocInputParms *inputParms, int *reasonCode);

--- a/h/dynalloc.h
+++ b/h/dynalloc.h
@@ -315,7 +315,7 @@ int DeallocDDName(char *ddname);
 
 #define DOBURST 0x0001
 /* BURST FieldCount: 1 FieldLength 1
-   X02 for YES X04 for NO
+   XDc12dc2for YES Xdc104dc2 for NO
    Directs output to a stacker on a 3800 Printing Subsystem. */
 
 #define DOCHARS 0x0002
@@ -360,7 +360,7 @@ int DeallocDDName(char *ddname);
 
 #define DOCONTRO 0x0008
 /* CONTROL FieldCount: 1 FieldLength 1
-   X80 for SINGLE X40 for DOUBLE X20 for TRIPLE X10 for PROGRAM
+   XDC180' for SINGLE X'40' for DOUBLE X'20' for TRIPLE X'10' for PROGRAM
    Specifies that all the data records begin with carriage control characters or specifies line spacing. */
 
 #define DOCOPIE9 0x0009
@@ -375,12 +375,12 @@ int DeallocDDName(char *ddname);
 
 #define DODATACK 0x2022
 /* DATACK FieldCount: 1 FieldLength 1
-   X00 for BLOCK X80 for UNBLOCK X81 for BLKCHAR X82 for BLKPOS
+   X'00' for BLOCK X'80' for UNBLOCK X'81' for BLKCHAR X'82' for BLKPOS
    Specifies how errors in printers accessed through the functional subsystem Print Services Facility (PSF) are to be reported.  */
 
 #define DODEFAUL 0x000B
 /* DEFAULT FieldCount: 1 FieldLength 1
-   X40 for YES X80 for NO
+   X'40' for YES X'80' for NO
    Specifies that this is a default output descriptor. */
 
 #define DODEPT 0x0029
@@ -395,12 +395,12 @@ int DeallocDDName(char *ddname);
 
 #define DODPAGEL 0x0023
 /* DPAGELBL FieldCount: 1 FieldLength 1
-   X40 for YES X80 for NO
+   X'40' for YES X'80' for NO
    Indicates whether the system should place a security label on each output page. YES means the system should place a label on each page. NO means the system should not place a label on each page. */
 
 #define DODUPLEX 0x003D
 /* DUPLEX FieldCount: 1 FieldLength 1
-   X80 for NO X40 for NORMAL X20 for TUMBLE
+   X'80' for NO X'40' for NORMAL X'20' for TUMBLE
    Specifies whether the job is to be printed on one or both sides of the paper. Overrides comparable FORMDEF specification. */
 
 #define DOFCB 0x000D
@@ -565,7 +565,7 @@ int DeallocDDName(char *ddname);
 
 #define DOPIMSG 0x0021
 /* PIMSG FieldCount: 2 FieldLength 1
-   X80 for NO X40 for YES The second value field is a two-byte number from 0 through 999 decimal, having a length field of 2.
+   X'80' for NO X'40' for YES The second value field is a two-byte number from 0 through 999 decimal, having a length field of 2.
    Indicates that messages from a functional subsystem should or should not be printed in the listing following the SYSOUT data set. Printing terminates if the number of printing errors exceeds the second value field.  */
 
 #define DOPORTNO 0x0045
@@ -581,7 +581,7 @@ int DeallocDDName(char *ddname);
 #define DOPRTATT 0x0050
 /* PRTATTRS FieldCount: 1 FieldLength 1-127
    EBCDIC text characters
-   Specifies an Infoprint Server job attribute. The z/OS Infoprint Server Users Guide documents job attribute names and syntax for acceptable values. */
+   Specifies an Infoprint Server job attribute. The z/OS Infoprint Server User's Guide documents job attribute names and syntax for acceptable values. */
 
 #define DOPROPTN 0x0039
 /* PRTOPTNS FieldCount: 1 FieldLength 1-16
@@ -640,7 +640,7 @@ int DeallocDDName(char *ddname);
 
 #define DOSYSARE 0x0024
 /* SYSAREA FieldCount: 1 FieldLength 1
-   X40 for YES X80 for NO
+   X'40' for YES X'80' for NO
    Indicates whether you want to use the system printable area of each output page. YES means you want to use the area. NO means you do not want to use the area. */
 
 #define DOTHRESH 0x0022
@@ -655,8 +655,8 @@ int DeallocDDName(char *ddname);
 
 #define DOTRC 0x001A
 /* TRC FieldCount: 1 FieldLength 1
-   X80 for NO X40 for YES
-   Specifies whether or not the SYSOUT data sets records contain table reference codes (TRC) as the second character. */
+   X'80' for NO X'40' for YES
+   Specifies whether or not the SYSOUT data set's records contain table reference codes (TRC) as the second character. */
 
 #define DOUCS 0x001B
 /* UCS FieldCount: 1 FieldLength 1-4
@@ -674,7 +674,7 @@ int DeallocDDName(char *ddname);
    Specifies the names of libraries containing AFP resources. */
 
 #define DOUSERPAT 0x004F
-/* USERPATH FieldCount: 8 FieldLength 1255
+/* USERPATH FieldCount: 8 FieldLength 1-255
    SPECIAL text. See z/OS MVS JCL Reference.
    Specifies up to eight HFS or ZFS system paths containing resources to be used by PSF when processing SYSOUT data sets. */
 


### PR DESCRIPTION
This pull request implements the following feature:
- API which enables the allocation of datasets and dataset members.
- Add 'PUT' method to /datasetContents, accepts JSON body to specify dataset parameters
- Sample request body:
 ```
{
    "ndisp": "CATALOG",
    "status": "NEW",
    "dsorg": "PS",
    "blksz": "27998",
    "lrecl": "84",
    "recfm": "V",
    "close": "true"
}
```