### PR TITLE
Bugfix for dataset validation

### DIFF
--- a/c/datasetjson.c
+++ b/c/datasetjson.c
@@ -892,7 +892,6 @@ static void updateDatasetWithJSONInternal(HttpResponse* response,
         isFixed = TRUE;
       } else if (recordType == 'U') {
         respondWithError(response, HTTP_STATUS_BAD_REQUEST,"Undefined-length dataset");
-        fclose(outDataset);
         return;
       }
     }
@@ -972,7 +971,7 @@ static void updateDatasetWithJSONInternal(HttpResponse* response,
   /*passed record length check and type check*/
 
   FILE *outDataset = fopen(datasetPath, "wb, recfm=*, type=record");
-  if (datasetRead == NULL) {
+  if (outDataset == NULL) {
     respondWithError(response,HTTP_STATUS_NOT_FOUND,"File could not be opened or does not exist");
     return;
   }


### PR DESCRIPTION
I found that upon dataset write, fopen was called too soon, validation needs to be done first since failing validation would cause fclose.
So, reorganized this logic a bit to prevent a few issues we saw in testing.