### PR TITLE
Write dataset type validation

### DIFF
--- a/c/datasetjson.c
+++ b/c/datasetjson.c
@@ -1036,9 +1036,6 @@ static void updateDatasetWithJSONInternal(HttpResponse* response,
   }
   /*passed record length check and type check*/
 
-  respondWithError(response, HTTP_STATUS_BAD_REQUEST,"Ending so that i dont wrote");
-  return;
-
   FILE *outDataset = fopen(datasetPath, "wb, recfm=*, type=record");
   if (outDataset == NULL) {
     respondWithError(response,HTTP_STATUS_NOT_FOUND,"File could not be opened or does not exist");


### PR DESCRIPTION
Prevent writing to dataset types that are inappropriate for the /datasetContents API, or have not been properly tested yet.
We may relax these restrictions in the future if we learn it is safe to use this API for writing, but this is just an initial set of preventing things that do not seem safe to do. This logic is largely based on DSORG checks, but also not allowing writes to PDSs instead of their members.