### PR TITLE
Support for libraryName31 and libraryName64 keys for dataServices in pluginDefinition.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Zowe Common C Changelog
 
-## `1.26.0`
+## `1.27.0`
 
 - Enhancement: Allow to specify 31-bit and 64-bit version of dataService library using `libraryName64` and `libraryName31` keys in DataService definition.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Zowe Common C Changelog
 
+## `1.26.0`
+
+- Enhancement: Allow to specify 31-bit and 64-bit version of dataService library using `libraryName64` and `libraryName31` keys in DataService definition.
+
 ## `1.25.0`
 
 - Bugfix: `fileCopy` incorrectly processed files tagged as binary and mixed

--- a/c/dataservice.c
+++ b/c/dataservice.c
@@ -143,6 +143,75 @@ static void *lookupDLLEntryPoint(char *libraryName, char *functionName){
   return ep;
 }
 
+#define LIBRARY_NAME_KEY           "libraryName"
+#define INITIALIZER_NAME_KEY       "initializerName"
+#ifdef _LP64
+#define LIBRARY_NAME_WITH_BITS_KEY "libraryName64"
+#else
+#define LIBRARY_NAME_WITH_BITS_KEY "libraryName31"
+#endif
+
+static InitializerAPI *loadDll(DataService *service, JsonObject *serviceJsonObject, const char *pluginLocation) {
+  char *libraryNameWithBits = jsonObjectGetString(serviceJsonObject, LIBRARY_NAME_WITH_BITS_KEY);
+  char *libraryName = jsonObjectGetString(serviceJsonObject, LIBRARY_NAME_KEY);
+  char *initializerName = jsonObjectGetString(serviceJsonObject, INITIALIZER_NAME_KEY);
+  char dllLocation[COMMON_PATH_MAX] = {0};
+  int pluginLocationLen = strlen(pluginLocation);
+  InitializerAPI *initializer = NULL;
+
+  /* "external will load a DLL in LE on the path, and a load module in the STEPLIB in METAL */
+#ifdef METTLE
+  /* do a load of 8 char name.  Pray that the STEPLIB yields something good. */
+  zowelog(NULL, LOG_COMP_DATASERVICE, ZOWE_LOG_DEBUG, "*** PANIC ***  service loading in METTLE not implemented\n");
+#else
+  if (pluginLocationLen > 0 && pluginLocation[pluginLocationLen - 1] == '/') {
+    pluginLocationLen--; /* exclude trailing slash */
+  }
+
+  do {
+    if (!libraryNameWithBits && !libraryName) {
+      zowelog(NULL, LOG_COMP_DATASERVICE, ZOWE_LOG_WARNING, "Dataservice: couldn't find '%s' or '%s' key for dataservice '%s'\n",
+        LIBRARY_NAME_WITH_BITS_KEY, LIBRARY_NAME_KEY, service->identifier);
+      break;
+    }
+    if (!initializerName) {
+      zowelog(NULL, LOG_COMP_DATASERVICE, ZOWE_LOG_WARNING, "Dataservice: couldn't find '%s' key for dataservice '%s'\n",
+        INITIALIZER_NAME_KEY, service->identifier);
+      break;
+    }
+    if (libraryNameWithBits) {
+      snprintf(dllLocation, sizeof(dllLocation), "%.*s/lib/%s", pluginLocationLen, pluginLocation, libraryNameWithBits);
+      zowelog(NULL, LOG_COMP_DATASERVICE, ZOWE_LOG_DEBUG, "going for DLL EP lib=%s epName=%s\n", dllLocation, initializerName);
+      if (initializer = (InitializerAPI*) lookupDLLEntryPoint(dllLocation, initializerName)) {
+        break;
+      }
+    }
+    if (libraryName) {
+      snprintf(dllLocation, sizeof(dllLocation), "%.*s/lib/%s", pluginLocationLen, pluginLocation, libraryName);
+      zowelog(NULL, LOG_COMP_DATASERVICE, ZOWE_LOG_DEBUG, "going for DLL EP lib=%s epName=%s\n", dllLocation, initializerName);
+      if (initializer = (InitializerAPI*) lookupDLLEntryPoint(dllLocation, initializerName)) {
+        break;
+      }
+    }
+    if (libraryNameWithBits) {
+      zowelog(NULL, LOG_COMP_DATASERVICE, ZOWE_LOG_DEBUG, "going for DLL EP lib=%s epName=%s\n", libraryNameWithBits, initializerName);
+      if (initializer = (InitializerAPI*) lookupDLLEntryPoint(libraryNameWithBits, initializerName)) {
+        break;
+      }
+    }
+    if (libraryName) {
+      zowelog(NULL, LOG_COMP_DATASERVICE, ZOWE_LOG_DEBUG, "going for DLL EP lib=%s epName=%s\n", libraryName, initializerName);
+      initializer = (InitializerAPI*) lookupDLLEntryPoint(libraryName, initializerName);
+    }
+    if (!initializer) {
+      zowelog(NULL, LOG_COMP_DATASERVICE, ZOWE_LOG_WARNING, "Dataservice: couldn't load dll for dataservice '%s'\n", service->identifier);
+    }
+  } while(0);
+  zowelog(NULL, LOG_COMP_DATASERVICE, ZOWE_LOG_DEBUG, "DLL EP = 0x%x\n", initializer);
+#endif
+  return initializer;
+}
+
 static DataService *makeDataService(WebPlugin *plugin, JsonObject *serviceJsonObject, char *subURI, InternalAPIMap *namedAPIMap,
                                     unsigned int *idMultiplier, int pluginLogLevel, Storage *remoteStorage) {
   zowelog(NULL, LOG_COMP_DATASERVICE, ZOWE_LOG_DEBUG, "%s begin data service:\n", __FUNCTION__);
@@ -184,33 +253,7 @@ static DataService *makeDataService(WebPlugin *plugin, JsonObject *serviceJsonOb
     zowelog(NULL, LOG_COMP_DATASERVICE, ZOWE_LOG_DEBUG, "Service=%s initializer set internal method=0x%p\n",
             service->identifier, service->name, service->initializer);
   } else if (!strcmp(initializerLookupMethod,"external")){
-    char *libraryName = jsonObjectGetString(serviceJsonObject, "libraryName");
-    /* "external will load a DLL in LE on the path, and a load module in the STEPLIB in METAL */
-#ifdef METTLE
-    /* do a load of 8 char name.  Pray that the STEPLIB yields something good. */
-    service->initializer = NULL;
-    zowelog(NULL, LOG_COMP_DATASERVICE, ZOWE_LOG_DEBUG, "*** PANIC ***  service loading in METTLE not implemented\n");
-#else
-    char dllLocation[1023] = {0}; /* USS max path length */
-    int pluginLocationLen = strlen(plugin->pluginLocation);
-    
-    if (plugin->pluginLocation[pluginLocationLen - 1] == '/') {
-      snprintf(dllLocation, sizeof(dllLocation), "%.*s/lib/%s", strlen(plugin->pluginLocation) - 1, plugin->pluginLocation, libraryName);
-    }
-    else {
-      snprintf(dllLocation, sizeof(dllLocation), "%s/lib/%s", plugin->pluginLocation, libraryName);
-    }
-
-    zowelog(NULL, LOG_COMP_DATASERVICE, ZOWE_LOG_DEBUG, "going for DLL EP lib=%s epName=%s\n", dllLocation, initializerName);
-    service->initializer = (InitializerAPI*) lookupDLLEntryPoint(dllLocation,initializerName);
-    if (service->initializer == NULL) {
-      zowelog(NULL, LOG_COMP_DATASERVICE, ZOWE_LOG_DEBUG, "going for DLL EP lib=%s epName=%s\n", libraryName, initializerName);
-      service->initializer = (InitializerAPI*) lookupDLLEntryPoint(libraryName,initializerName);
-    }
-    zowelog(NULL, LOG_COMP_DATASERVICE, ZOWE_LOG_DEBUG, "DLL EP = 0x%x\n", service->initializer);
-    fflush(stdout);
-    fflush(stderr);
-#endif
+    service->initializer = loadDll(service, serviceJsonObject, plugin->pluginLocation);
   } else {
     zowelog(NULL, LOG_COMP_DATASERVICE, ZOWE_LOG_DEBUG, "unknown plugin initialize lookup method %s\n", initializerLookupMethod);
   }

--- a/c/dataservice.c
+++ b/c/dataservice.c
@@ -162,7 +162,7 @@ static InitializerAPI *loadDll(DataService *service, JsonObject *serviceJsonObje
   /* "external will load a DLL in LE on the path, and a load module in the STEPLIB in METAL */
 #ifdef METTLE
   /* do a load of 8 char name.  Pray that the STEPLIB yields something good. */
-  zowelog(NULL, LOG_COMP_DATASERVICE, ZOWE_LOG_DEBUG, "*** PANIC ***  service loading in METTLE not implemented\n");
+  zowelog(NULL, LOG_COMP_DATASERVICE, ZOWE_LOG_SEVERE, "*** PANIC ***  service loading in METTLE not implemented\n");
 #else
   if (pluginLocationLen > 0 && pluginLocation[pluginLocationLen - 1] == '/') {
     pluginLocationLen--; /* exclude trailing slash */


### PR DESCRIPTION
This PR introduces support for `libraryName31` and `libraryName64` keys for dataService. The keys allow to distinguish 31 and 64-bit versions of a plugin. If bits-specific key not found then zss tries to load the dll using `libraryName` key. For example,

```json
{
  "identifier": "org.zowe.my.plugin",
  "apiVersion": "1.0.0",
  "pluginVersion": "1.2.1",
  "pluginType": "application",
  "dataServices": [
    {
      "type": "service",
      "name": "myService",
      "libraryName31": "myService31.so",
      "libraryName64": "myService64.so",
      "dependenciesIncluded": true,
      "methods": [ "GET", "POST", "DELETE" ],
      "initializerName": "myServiceServiceInstaller",
      "initializerLookupMethod": "external",
      "version": "0.0.1"
    }
  ]
}
```
