### PR TITLE
ZIS custom module name

### DIFF
--- a/c/crossmemory.c
+++ b/c/crossmemory.c
@@ -2343,6 +2343,12 @@ CrossMemoryServer *makeCrossMemoryServer2(
     *reasonCode = envCheckRC;
     return NULL;
   }
+
+  if (flags & CMS_SERVER_FLAG_DEBUG) {
+    logSetLevel(NULL, LOG_COMP_ID_CMS, ZOWE_LOG_DEBUG);
+    logSetLevel(NULL, LOG_COMP_ID_CMSPC, ZOWE_LOG_DEBUG);
+  }
+
   EightCharString cmsModule = {0};
   if (getCurrentModuleName(&cmsModule)) {
     *reasonCode = RC_CMS_MODULE_QUERY_FAILED;
@@ -2366,10 +2372,6 @@ CrossMemoryServer *makeCrossMemoryServer2(
   server->pcssStackPoolSize = CMS_MAIN_PCSS_STACK_POOL_SIZE;
   server->pcssRecoveryPoolSize = CMS_MAIN_PCSS_RECOVERY_POOL_SIZE;
 
-  if (flags & CMS_SERVER_FLAG_DEBUG) {
-    logSetLevel(NULL, LOG_COMP_ID_CMS, ZOWE_LOG_DEBUG);
-    logSetLevel(NULL, LOG_COMP_ID_CMSPC, ZOWE_LOG_DEBUG);
-  }
   if (flags & CMS_SERVER_FLAG_COLD_START) {
     server->flags |= CROSS_MEMORY_SERVER_FLAG_COLD_START;
   }
@@ -4337,7 +4339,6 @@ __asm("CSVQRGLB CSVQUERY PLISTVER=0,MF=(L,CSVQRGLB)" : "DS"(CSVQRGLB));
 
 static int getCurrentModuleName(EightCharString * __ptr32 result) {
 
-  unsigned char attr = 0;
   int queryRC = 0;
 
   __asm("CSVQRGLB CSVQUERY PLISTVER=0,MF=L" : "DS"(parmList));
@@ -4355,8 +4356,8 @@ static int getCurrentModuleName(EightCharString * __ptr32 result) {
   );
 
   zowelog(NULL, LOG_COMP_ID_CMS, ZOWE_LOG_DEBUG,
-          "CSVQUERY of 0x%08X - module name = \'%8.8s\', RC = %d",
-          moduleAddress, attr, queryRC);
+          CMS_LOG_DEBUG_MSG_ID" CSVQUERY of 0x%08X - module = \'%8.8s\', RC = %d",
+          moduleAddress, result->text, queryRC);
 
   if (queryRC != 0) {
     return -1;
@@ -4385,7 +4386,7 @@ static bool isModulePrivate(void) {
   );
 
   zowelog(NULL, LOG_COMP_ID_CMS, ZOWE_LOG_DEBUG,
-          "CSVQUERY of 0x%08X - attr = 0x%02X, RC = %d",
+          CMS_LOG_DEBUG_MSG_ID" CSVQUERY of 0x%08X - attr = 0x%02X, RC = %d",
           moduleAddress, attr, queryRC);
 
   if (queryRC != 0) {

--- a/c/crossmemory.c
+++ b/c/crossmemory.c
@@ -2142,6 +2142,11 @@ static void *getMyModuleAddressAndSize(unsigned int *size) {
 
   IHACDE *cde = (IHACDE *)(*(int *)((char *)rb + 0x0C) & 0x00FFFFFF);
 
+  if (cde->cdattr & IHACDE_ATTR_MINOR_CDE) {
+    // CDXLMJP is the major CDE and not the extent list if this CDE is minor
+    cde = (IHACDE *)cde->cdxlmjp;
+  }
+
   void *xtlst = cde->cdxlmjp;
 
   void *moduleAddress = *(void * __ptr32 *)((char *)xtlst + 0x0C);

--- a/h/crossmemory.h
+++ b/h/crossmemory.h
@@ -935,7 +935,7 @@ CrossMemoryServerName cmsMakeServerName(const char *nameNullTerm);
 #ifndef CMS_LOG_NON_PRIVATE_MODULE_MSG_ID
 #define CMS_LOG_NON_PRIVATE_MODULE_MSG_ID       CMS_MSG_PRFX"0249E"
 #endif
-#define CMS_LOG_NON_PRIVATE_MODULE_MSG_TEXT     "Module %8.8s is loaded from common storage, ensure %8.8s is valid in STEPLIB"
+#define CMS_LOG_NON_PRIVATE_MODULE_MSG_TEXT     "Module %8.8s is loaded from common storage, ensure %8.8s is valid in the STEPLIB"
 #define CMS_LOG_NON_PRIVATE_MODULE_MSG          CMS_LOG_NON_PRIVATE_MODULE_MSG_ID" "CMS_LOG_NON_PRIVATE_MODULE_MSG_TEXT
 
 #ifndef CMS_LOG_DUB_ERROR_MSG_ID

--- a/h/crossmemory.h
+++ b/h/crossmemory.h
@@ -86,7 +86,7 @@
 #define RC_CMS_PC_ENV_NOT_TERMINATED        35
 #define RC_CMS_PC_SERVICE_ABEND_DETECTED    36
 #define RC_CMS_PC_RECOVERY_ENV_FAILED       37
-#define RC_CMS_MODULE_QUERY_FAILED          38
+#define RC_CMS_PC_NOT_IMPLEMENTED           38
 #define RC_CMS_SERVER_ABENDED               39
 #define RC_CMS_VSNPRINTF_FAILED             40
 #define RC_CMS_MESSAGE_TOO_LONG             41
@@ -138,7 +138,8 @@
 #define RC_CMS_ALLOC_FAILED                 87
 #define RC_CMS_NON_PRIVATE_MODULE           88
 #define RC_CMS_BAD_DUB_STATUS               89
-#define RC_CMS_MAX_RC                       89
+#define RC_CMS_MODULE_QUERY_FAILED          90
+#define RC_CMS_MAX_RC                       90
 
 extern const char *CMS_RC_DESCRIPTION[];
 

--- a/h/crossmemory.h
+++ b/h/crossmemory.h
@@ -86,7 +86,7 @@
 #define RC_CMS_PC_ENV_NOT_TERMINATED        35
 #define RC_CMS_PC_SERVICE_ABEND_DETECTED    36
 #define RC_CMS_PC_RECOVERY_ENV_FAILED       37
-#define RC_CMS_PC_NOT_IMPLEMENTED           38
+#define RC_CMS_MODULE_QUERY_FAILED          38
 #define RC_CMS_SERVER_ABENDED               39
 #define RC_CMS_VSNPRINTF_FAILED             40
 #define RC_CMS_MESSAGE_TOO_LONG             41
@@ -935,7 +935,7 @@ CrossMemoryServerName cmsMakeServerName(const char *nameNullTerm);
 #ifndef CMS_LOG_NON_PRIVATE_MODULE_MSG_ID
 #define CMS_LOG_NON_PRIVATE_MODULE_MSG_ID       CMS_MSG_PRFX"0249E"
 #endif
-#define CMS_LOG_NON_PRIVATE_MODULE_MSG_TEXT     "Module ZWESIS01 is loaded from common storage, ensure ZWESIS01 is valid in STEPLIB"
+#define CMS_LOG_NON_PRIVATE_MODULE_MSG_TEXT     "Module %8.8s is loaded from common storage, ensure %8.8s is valid in STEPLIB"
 #define CMS_LOG_NON_PRIVATE_MODULE_MSG          CMS_LOG_NON_PRIVATE_MODULE_MSG_ID" "CMS_LOG_NON_PRIVATE_MODULE_MSG_TEXT
 
 #ifndef CMS_LOG_DUB_ERROR_MSG_ID

--- a/h/zos.h
+++ b/h/zos.h
@@ -887,7 +887,15 @@ typedef struct IHACDE_tag{
   char                       cdattrb;   /* flags */
   char                       cdsp;      /* Module subpoolID */
   char                       cdattr;    /* flag byte */
-  char                       cdattr2; 
+#define IHACDE_ATTR_NIP               0x80
+#define IHACDE_ATTR_NIC               0x40
+#define IHACDE_ATTR_REENTERABLE       0x20
+#define IHACDE_ATTR_SERIALLY_REUSABLE 0x10
+#define IHACDE_ATTR_NOT_REUSABLE      0x08
+#define IHACDE_ATTR_MINOR_CDE         0x04
+#define IHACDE_ATTR_MODULE_IN_JPA     0x02
+#define IHACDE_ATTR_NOT_LOADABLE_ONLY 0x01
+  char                       cdattr2;
   char                       cdattr3; 
   char                       cdattr4;   /* reserved for future flags */
 } IHACDE;


### PR DESCRIPTION
#### Overview
The main purpose of this PR is to the ability to run ZIS using any module name. Right now, ZIS makes some assumptions about its module name. Additionally, the PR fixes a bug in the service address check function when ZIS is run using an alias.

##### Notes
* `RC_CMS_PC_NOT_IMPLEMENTED` was not used, so its number got recycled
* The log level initialization has been moved to be done earlier so that we can print debug info in the `getCurrentModuleName` function