### PR TITLE
Fix collision with debug ifdef

### DIFF
--- a/c/json.c
+++ b/c/json.c
@@ -62,7 +62,7 @@
 #  define SOURCE_CODE_CHARSET CCSID_UTF_8
 #endif
 
-#define DEBUG(...) /* fprintf(stderr, __VA_ARGS__) */
+#define JSON_DEBUG(...) /* fprintf(stderr, __VA_ARGS__) */
 #define DUMPBUF($b, $l) /* dumpBufferToStream($b, $l, stderr) */
 
 #ifdef METTLE
@@ -158,7 +158,7 @@ void jsonWriteBufferInternal(jsonPrinter *p, char *text, int len) {
   if (jsonShouldStopWriting(p)) {
     return;
   }
-  DEBUG("write buffer internal: text at %p, len %d\n", text, len);
+  JSON_DEBUG("write buffer internal: text at %p, len %d\n", text, len);
   DUMPBUF(text, len);
   if (p->isCustom) {
     p->customWrite(p, text, len);
@@ -294,7 +294,7 @@ writeBufferWithEscaping(jsonPrinter *p, size_t len, char text[len]) {
       ERROR("JSON: invalid UTF-8, rc %d\n", getCharErr);
       return -1;
     }
-    DEBUG("character at %p + %d, len %d, char %x\n", text, i, len, utf8Char);
+    JSON_DEBUG("character at %p + %d, len %d, char %x\n", text, i, len, utf8Char);
     if (((utf8Char >= 0) && (utf8Char <= effectiveControlCharBoundary))
         || (utf8Char == UTF8_BACKSLASH) || (utf8Char == UTF8_QUOTE)) {
 
@@ -358,7 +358,7 @@ void jsonConvertAndWriteBuffer(jsonPrinter *p, char *text, size_t len,
     if (inputCCSID != CCSID_UTF_8) {
       ssize_t newLen;
 
-      DEBUG("before conversion, len %d:\n", len);
+      JSON_DEBUG("before conversion, len %d:\n", len);
       DUMPBUF(text, len);
       newLen = convertToUtf8(p, len, text, inputCCSID);
       if (newLen < 0) {
@@ -366,7 +366,7 @@ void jsonConvertAndWriteBuffer(jsonPrinter *p, char *text, size_t len,
                 newLen);
         return;
       }
-      DEBUG("utf8, len %d:\n", newLen);
+      JSON_DEBUG("utf8, len %d:\n", newLen);
       text = p->_conversionBuffer;
       len = newLen;
       DUMPBUF(text, len);


### PR DESCRIPTION
-DDEBUG=1 could not be used in a compile because json.c defined DEBUG for a different purpose than the rest of the codebase. This fixes it by giving the json DEBUG a new name, JSON_DEBUG
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>