### PR TITLE
Small bugfixes to reduce printfs

### DIFF
--- a/c/charsets.c
+++ b/c/charsets.c
@@ -258,8 +258,10 @@ int convertCharset(char *input,
 #endif
 
   *conversionOutputLength = (((char*)parms.Targ_Buf_Ptr) - outputBuffer);
-  printf("inputLen=%d reasonCode = %d src=%d targ=%d\n",inputLength,parms.Reason_Code,parms.Src_CCSID,parms.Targ_CCSID);
-  fflush(stdout);
+  if (TRACE_CHARSET_CONVERSION) {
+    printf("inputLen=%d reasonCode = %d src=%d targ=%d\n",inputLength,parms.Reason_Code,parms.Src_CCSID,parms.Targ_CCSID);
+    fflush(stdout);
+  }
 
   if (parms.Return_Code){
     if (outputMode == CHARSET_OUTPUT_SAFE_MALLOC){

--- a/c/json.c
+++ b/c/json.c
@@ -2591,7 +2591,7 @@ static void copyJson(JsonBuilder *builder, Json *parent, char *parentKey, Json *
     char *s = jsonAsString(json);
     jsonBuildString(builder,parent,parentKey,s,strlen(s),&errorCode);
   } else {
-    printf("*** PANIC *** unexpected json type %d\n",json->type);
+    JSONERROR("*** PANIC *** unexpected json type %d\n",json->type);
     return;
   }
 }


### PR DESCRIPTION
We were seeing some excessive printing coming out of charsets.c in our code testing, so simple fix here is to use the same trace conditional as other areas in this file.

Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>