### PR TITLE
rexx cfgmgr bugfixes and cleanup

### DIFF
--- a/build/build_rexxcmgr.sh
+++ b/build/build_rexxcmgr.sh
@@ -39,9 +39,6 @@ MINOR=2
 PATCH=5
 VERSION="\"${MAJOR}.${MINOR}.${PATCH}\""
 
-GSKDIR=/usr/lpp/gskssl
-GSKINC="${GSKDIR}/include"
-
 xlclang \
   -c \
   -q64 \
@@ -93,16 +90,22 @@ xlclang \
   -D_OPEN_SYS_FILE_EXT=1 \
   -D_XOPEN_SOURCE=600 \
   -D_OPEN_THREADS=1 \
+  -DUSE_ZOWE_TLS=1 \
   -DCONFIG_VERSION=\"2021-03-27\" \
   -I "${DEPS_DESTINATION}/${LIBYAML}/include" \
   -I "${DEPS_DESTINATION}/${QUICKJS}" \
   -I ${COMMON}/h \
-  ${COMMON}/c/embeddedjs.c 
+  ${COMMON}/c/embeddedjs.c \
+  ${COMMON}/c/qjszos.c \
+  ${COMMON}/c/qjsnet.c
 
 # Hacking around weird link issue:
 ar x /usr/lpp/cbclib/lib/libibmcmp.a z_atomic.LIB64R.o
 
-xlclang \
+GSKDIR=/usr/lpp/gskssl
+GSKINC="${GSKDIR}/include"
+
+xlc \
   -q64 \
   "-Wc,float(ieee),longname,langlvl(extc99),gonum,goff,ASM,asmlib('CEE.SCEEMAC','SYS1.MACLIB','SYS1.MODGEN'),list()" \
   -D_OPEN_SYS_FILE_EXT=1 \
@@ -132,47 +135,45 @@ xlclang \
   polyfill.o \
   debugutil.o \
   embeddedjs.o \
+  qjszos.o \
+  qjsnet.o \
   z_atomic.LIB64R.o \
   ${COMMON}/c/alloc.c \
   ${COMMON}/c/bpxskt.c \
   ${COMMON}/c/charsets.c \
   ${COMMON}/c/collections.c \
   ${COMMON}/c/configmgr.c \
-  ${COMMON}/c/embeddedjs.c \
-  ${COMMON}/c/fdpoll.c \
-  ${COMMON}/c/http.c \
-  ${COMMON}/c/httpclient.c \
   ${COMMON}/c/json.c \
-  ${COMMON}/c/jcsi.c \
   ${COMMON}/c/jsonschema.c \
   ${COMMON}/c/le.c \
   ${COMMON}/c/logging.c \
   ${COMMON}/c/microjq.c \
   ${COMMON}/c/parsetools.c \
   ${COMMON}/c/pdsutil.c \
-  ${COMMON}/c/qjsnet.c \
-  ${COMMON}/c/qjszos.c \
   ${COMMON}/platform/posix/psxregex.c \
   ${COMMON}/c/recovery.c \
   ${COMMON}/c/rexxcmgr.c \
   ${COMMON}/c/scheduling.c \
-  ${COMMON}/c/socketmgmt.c \
   ${COMMON}/c/timeutls.c \
-  ${COMMON}/c/tls.c \
   ${COMMON}/c/utils.c \
   ${COMMON}/c/xlate.c \
   ${COMMON}/c/yaml2json.c \
   ${COMMON}/c/zos.c \
   ${COMMON}/c/zosfile.c \
+  ${COMMON}/c/httpclient.c \
+  ${COMMON}/c/http.c \
+  ${COMMON}/c/tls.c \
+  ${COMMON}/c/socketmgmt.c \
+  ${COMMON}/c/fdpoll.c \
+  ${COMMON}/c/jcsi.c \
   ${GSKDIR}/lib/GSKSSL64.x \
   ${GSKDIR}/lib/GSKCMS64.x
-
 #then
 #  echo "Build successful"
 #  ls -l "${COMMON}/bin"
 #  exit 0
 #else
-#  # remove configmgr in case the linker had RC=4 and produced the binary
+  # remove configmgr in case the linker had RC=4 and produced the binary
 #  rm -f "${COMMON}/bin/configmgr"
 #  echo "Build failed"
 #  exit 8
@@ -186,3 +187,4 @@ xlclang \
 # SPDX-License-Identifier: EPL-2.0
 # 
 # Copyright Contributors to the Zowe Project.
+

--- a/build/deploy_rexxcmgr.sh
+++ b/build/deploy_rexxcmgr.sh
@@ -1,9 +1,9 @@
 #! /bin/sh
 if [ "$#" -eq 1 ]
 then
-  cp ../bin/zwecfg31 "//'$1(ZWECFG31)'"
-  cp ../bin/zwecfg64 "//'$1(ZWECFG64)'"
-  cp ../bin/zwecfgle "//'$1(ZWERXCFG)'"
+  cp ../bin/ZWECFG31 "//'$1(ZWECFG31)'"
+  cp ../bin/ZWECFG64 "//'$1(ZWECFG64)'"
+  cp ../bin/ZWECFGLE "//'$1(ZWERXCFG)'"
 else
   echo "Bad arguments"
 fi

--- a/c/zwecfg31.c
+++ b/c/zwecfg31.c
@@ -89,26 +89,33 @@ static REXXEnv *getOrMakeREXXEnv(IRXENVB *envBlock){
       printf("Start making REXX ENV\n");
     }
     int loadStatus = 0;
-    printf("JOE.0\n");
-    int initEP = (int)loadByName("ZWECFG64",&loadStatus);   
-    printf("loadByName ep=0x%x\n",initEP);
+    int initEP = (int)loadByName("ZWECFG64",&loadStatus);
+    if (traceLevel >= 1) {
+      printf("loadByName ep=0x%x\n",initEP);
+    }
     if (initEP == 0 || loadStatus){
       printf("Failed to load 'ZWECFG64', status=%d\n",loadStatus);
       return NULL;
     } else{
-      printf("initEP=0x%p\n",initEP);
+      if (traceLevel >= 1) {
+        printf("initEP=0x%p\n",initEP);
+      }
       initEP &= 0x7FFFFFFE; /* remove DOO-DOO */
     }
     loadStatus = 0;
-    printf("before second load\n");
+    if (traceLevel >= 1) {
+      printf("before second load\n");
+    }
     int irxexcomEP = (int)loadByName("IRXEXCOM",&loadStatus);
-    printf("after second load, status=%d\n");
+    if (traceLevel >= 1) {
+      printf("after second load, status=%d\n",loadStatus);
+    }
     if (irxexcomEP == 0 || loadStatus){
       printf("Failed to load 'IRXEXCOM', status=%d\n",loadStatus);
       return NULL;
     } else{
       if (traceLevel >= 1){
-	printf("irxexcomEP=0x%p\n",irxexcomEP);
+	      printf("irxexcomEP=0x%p\n",irxexcomEP);
       }
       irxexcomEP &= 0x7FFFFFFE; /* remove DOO-DOO */
     }
@@ -256,7 +263,9 @@ int main(int argc, char *argv){
 	:"=m"(r0),"=m"(r1)
 	::"r8");
   Addr31 envBlock = (Addr31)r0;
-  printf("ZWECFG31 REXX Call Start\n");
+  if (traceLevel >= 1) {
+    printf("ZWECFG31 REXX Call Start\n");
+  }
   IRXEFPL *efpl = (IRXEFPL*)INT2PTR(r1);
   if (traceLevel >= 1){
     printf("EFPL at 0x%p, r1 = 0x%x\n",efpl,r1);


### PR DESCRIPTION
hiding printf behind traceLevel; fixing build for cfgmgr-rexx; optioally print validity exceptions