### PR TITLE
Add xplatform.appendFileUTF8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Zowe Common C Changelog
 
+## `2.5.0`
+
+- Added embeddedjs command "xplatform.appendFileUTF8" for appending to files rather than writing whole files.
+
 ## `2.3.0`
 
 - Bugfix for lht functions of collections.c to avoid memory issues on negative keys


### PR DESCRIPTION
This adds xplatform.appendFileUTF8 as it was needed by zwe. zwe wants to write log messages to a file and the existing storefile was not an efficient way to accomplish this.
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>