### PR TITLE
A 31/64 bit tested version of Rusermap

### DIFF
--- a/c/rusermap.c
+++ b/c/rusermap.c
@@ -1,0 +1,165 @@
+
+/*
+  This program and the accompanying materials are
+  made available under the terms of the Eclipse Public License v2.0 which accompanies
+  this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+  
+  SPDX-License-Identifier: EPL-2.0
+  
+  Copyright Contributors to the Zowe Project.
+*/
+
+#ifdef METTLE 
+
+#include <metal/metal.h>
+#include <metal/stddef.h>
+#include <metal/stdio.h>
+#include <metal/stdlib.h>
+#include <metal/stdbool.h>
+#include <metal/string.h>
+#include <metal/stdarg.h>
+#include <metal/ctype.h>  
+#include <metal/stdbool.h>  
+#include "metalio.h"
+#include "qsam.h"
+
+#else
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <fcntl.h>
+#include <string.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <ctype.h>  
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <stdint.h>
+#include <errno.h>
+
+#endif
+
+#include "zowetypes.h"
+#include "alloc.h"
+#include "utils.h"
+#include "rusermap.h"
+
+#define MAP_USERID_TO_LOTUS_NOTES_ID 0x0001  /* Lotus Notes, hahahahahahaha */
+#define MAP_LOTUS_NOTES_ID_TO_USERID 0x0002
+
+#define MAP_CERTIFICATE_TO_USERID 0x0006
+
+#define MAX_CERT_SIZE 4096
+
+#define IRRSIM00_WORKAREA_LENGTH 1024
+
+
+/* last arg must be at least 9 chars in length */
+int getUseridByCertificate(char *certificate, int certificateLength, char *useridBuffer,
+                           int *racfRC, int *racfReason){
+
+#pragma pack(packed)
+  ALLOC_STRUCT31(
+    STRUCT31_NAME(parms31),
+    STRUCT31_FIELDS
+    (
+     Addr31   parmlistStorage[15];
+     uint32_t zero; /* must be initted to zero, used for all the ALET's and NULL pointers */
+     uint32_t highbitZero;
+     uint32_t safRC;
+     uint32_t racfRC;
+     uint32_t racfReason;
+     uint16_t functionCode;
+     uint8_t  reserved;
+     uint8_t  useridLength;
+     char     userid[8];
+     char     workArea[IRRSIM00_WORKAREA_LENGTH];
+     uint32_t certificateLength;
+     char     certificate[MAX_CERT_SIZE];
+     )
+    );
+#pragma pack(reset)
+  
+  memset(parms31,0,sizeof(*parms31));
+  parms31->functionCode = MAP_CERTIFICATE_TO_USERID;
+  parms31->highbitZero = 0x80000000;
+  parms31->useridLength = 0;
+  if (certificateLength > MAX_CERT_SIZE){
+    return 12;
+  } else{
+    memcpy(parms31->certificate, certificate, certificateLength);
+    parms31->certificateLength = certificateLength;
+  }
+
+  int rc = 0;
+  /*
+  printf(" before call parms31Len=0x%x\n",(int)sizeof(*parms31));fflush(stdout);
+  dumpbuffer((char*)parms31,sizeof(*parms31));
+  */
+  __asm(ASM_PREFIX
+        " LLGT 15,X'10'(,0) \n"   /* Get the CVT */
+        " LLGT 15,X'220'(,15) \n" /* CSRTABLE */
+        " LLGT 15,X'28'(,15) \n"  /* Some RACF Routin Vector */
+        " LLGT 15,X'A0'(,15) \n"  /* IRRSIM00 itself */
+#ifdef _LP64
+        " SAM31 \n"
+        " SYSSTATE AMODE64=NO \n"
+#endif
+        " CALL (15),(%[wa]"
+        ",%[z],%[safRC]"
+        ",%[z],%[racfRC]"
+        ",%[z],%[racfRSN]"
+        ",%[z],%[fc]"
+        ",%[z]"   /* options */
+        ",%[userid]"
+        ",%[cert]"
+        ",%[z]"   /* appl userid */
+        ",%[z]"   /* Distinguished name */
+        ",%[z])" /* registry name, which is NULL with high bit set */
+        ",VL,MF=(E,%[parmlist]) \n"
+
+#ifdef _LP64
+        " SAM64 \n"
+        " SYSSTATE AMODE64=YES \n"
+#endif
+        " ST 15,%[rc]"
+        : [rc]"=m"(rc)
+        : [wa]"m"(parms31->workArea),
+          [z]"m"(parms31->zero),
+          [highbit]"m"(parms31->highbitZero),
+          [fc]"m"(parms31->functionCode),
+          [safRC]"m"(parms31->safRC),
+          [racfRC]"m"(parms31->racfRC),
+          [racfRSN]"m"(parms31->racfReason),
+          [userid]"m"(parms31->useridLength),   /* must point at pre-pended length */
+          [cert]"m"(parms31->certificateLength),
+          [parmlist]"m"(parms31->parmlistStorage)
+        :"r14","r15");
+  
+
+  int safRC = parms31->safRC;
+  *racfRC = parms31->racfRC;
+  *racfReason = parms31->racfReason;
+
+  if (safRC == 0){
+    memcpy(useridBuffer,parms31->userid,parms31->useridLength);
+  }
+
+  FREE_STRUCT31(
+    STRUCT31_NAME(parms31)
+  );
+  
+  return safRC;
+}
+
+
+
+/*
+  This program and the accompanying materials are
+  made available under the terms of the Eclipse Public License v2.0 which accompanies
+  this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+  
+  SPDX-License-Identifier: EPL-2.0
+  
+  Copyright Contributors to the Zowe Project.
+*/

--- a/h/rusermap.h
+++ b/h/rusermap.h
@@ -1,0 +1,51 @@
+
+/*
+  This program and the accompanying materials are
+  made available under the terms of the Eclipse Public License v2.0 which accompanies
+  this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+  
+  SPDX-License-Identifier: EPL-2.0
+  
+  Copyright Contributors to the Zowe Project.
+*/
+
+#ifndef __ZOWE_RUSERMAP__
+#define __ZOWE_RUSERMAP__ 1
+
+#define RUSERMAP_SAF_SUCCESS 0
+#define RUSERMAP_RACF_FAILURE 8
+#define RUSERMAP_RACF_REASON_NOAUTH 0x14
+#define RUSERMAP_RACF_REASON_NOUSERID 0x18
+#define RUSERMAP_RACF_REASON_BADCERT 0x1C
+#define RUSERMAP_RACF_REASON_NOUSER_FOR_CERT 0x20
+
+/** 
+  getUseridByCertificate() gets the SAF Userid for a certificate, if one had been previously
+  defined for that user.
+
+  The certificate is a standard DER format certificate and must have the proper length passed
+  in the second argument.  The useridBuffer must be at least 9 bytes or bad thing will happen.
+
+  The saf return code is returned and must be 0 for success.  Non-Zero returns are further explained
+  in the racfRC and racfReason values
+
+  Please consult the following IBM doc for a full explanation of return codes:
+ 
+  https://www.ibm.com/docs/en/zos/2.5.0?topic=descriptions-r-usermap-irrsim00-map-application-user
+ */
+
+int getUseridByCertificate(char *certificate, int certificateLength, char *useridBuffer,
+                           int *racfRC, int *racfReason);
+
+
+#endif
+
+/*
+  This program and the accompanying materials are
+  made available under the terms of the Eclipse Public License v2.0 which accompanies
+  this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+  
+  SPDX-License-Identifier: EPL-2.0
+  
+  Copyright Contributors to the Zowe Project.
+*/

--- a/tests/rusermaptest.c
+++ b/tests/rusermaptest.c
@@ -1,0 +1,87 @@
+/*
+  This program and the accompanying materials are
+  made available under the terms of the Eclipse Public License v2.0 which accompanies
+  this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+  
+  SPDX-License-Identifier: EPL-2.0
+  
+  Copyright Contributors to the Zowe Project.
+*/
+
+#ifdef METTLE 
+#include <metal/metal.h>
+#include <metal/stddef.h>
+#include <metal/stdio.h>
+#include <metal/stdlib.h>
+#include <metal/string.h>
+#include <metal/stdarg.h>  
+#include "metalio.h"
+
+#else
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdarg.h>
+#include <sys/stat.h>
+
+#endif /* METTLE */
+
+#include "zowetypes.h"
+#include "alloc.h"
+#include "utils.h"
+#include "charsets.h"
+#include "unixfile.h"
+#include "rusermap.h"
+
+
+/*
+
+  Testing on ZOS:  (This program can *ONLY* run on ZOS).
+
+  64-bit build
+
+  xlclang -q64 -I ../h -D_OPEN_SYS_FILE_EXT=1 -D_XOPEN_SOURCE=600 -D_OPEN_THREADS=1 -DSUBPOOL=132 "-Wc,float(ieee),longname,langlvl(extc99),gonum,goff,ASM,asmlib('CEE.SCEEMAC','SYS1.MACLIB','SYS1.MODGEN')" -o rusermaptest rusermaptest.c ../c/rusermap.c ../c/charsets.c ../c/zosfile.c  ../c/timeutls.c ../c/utils.c ../c/alloc.c ../c/logging.c ../c/collections.c ../c/le.c ../c/recovery.c ../c/zos.c ../c/scheduling.c
+
+  31-bit build
+
+  xlc -I ../h -D_OPEN_SYS_FILE_EXT=1 -D_XOPEN_SOURCE=600 -D_OPEN_THREADS=1 -DSUBPOOL=132 "-Wc,float(ieee),longname,langlvl(extc99),gonum,goff,ASM,asmlib('CEE.SCEEMAC','SYS1.MACLIB','SYS1.MODGEN')" -o rusermaptest31 rusermaptest.c ../c/rusermap.c ../c/charsets.c ../c/zosfile.c  ../c/timeutls.c ../c/utils.c ../c/alloc.c ../c/logging.c ../c/collections.c ../c/le.c ../c/recovery.c ../c/zos.c ../c/scheduling.c
+
+
+  Configuring the user to have a certificate:
+
+  Note for the following call the cert should be B64:
+
+  tsocmd "racdcert add('{{ zowe_dataset_prefix }}.CERT.{{ dataset }}') id({{ zowe_runtime_user }}) withlabel('{{ label }}') trust" 
+  tsocmd "SETROPTS RACLIST(DIGTCERT, DIGTRING) REFRESH"
+
+*/
+
+int main(int argc, char **argv){
+  char *command = argv[1];
+  char *fakecert = "HUM-DE-DUM, I AM A CERTIFICATE";
+  char userid[9];
+
+
+  FILE *ptr;
+  ptr = fopen("apimtst.der","rb");
+  printf("pointer=%p\n",ptr);
+  fflush(stdout);
+  char buffer[4096];
+  memset(buffer,0,4096);
+  int bytesRead = fread(buffer,1,4096,ptr);
+  printf("bytesRead=%d\n",bytesRead);
+  fflush(stdout);
+  fclose( ptr );
+  dumpbuffer(buffer,bytesRead);
+  int retCode = 0;
+  int reason = 0;
+  int rc = getUseridByCertificate(buffer, bytesRead, userid, &retCode, &reason);
+
+  if (rc){
+    printf("Could not get userid, racfFC=0x%x, reason=0x%x\n",retCode,reason);
+  } else {
+    printf("Userid: %s\n",userid);
+  }
+
+  return 0;
+}


### PR DESCRIPTION
Signed-off-by: Joe Devlin <joe.devlin@gmail.com>


## Proposed changes
An implementation of Rusermap that can be used from all Zowe C code, 31 or 64 bit.



This PR depends upon the following PRs:

## Type of change
Please delete options that are not relevant.

- [ x] New feature (non-breaking change which adds functionality)

## PR Checklist
Please delete options that are not relevant.
- [ x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [ x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zss/blob/v2.x/master/CONTRIBUTING.md))
- [x] I have commented my code, particularly in hard-to-understand areas

- [ x] I have added tests that prove my fix is effective or that my feature works, or describe a test method below

## Testing
There's a unit test in zowe-common-c/tests/rusermaptest.c

