### PR TITLE
Fix that file copy writing random bytes to destination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Zowe Common C Changelog
 
+## `2.8.0`
+
+- Bugfix: `fileCopy` would not work when convert encoding was not requested. The destination file would be created, but without the requested content.
+
 ## `2.5.0`
 
 - Added embeddedjs command "xplatform.appendFileUTF8" for appending to files rather than writing whole files.

--- a/c/httpfileservice.c
+++ b/c/httpfileservice.c
@@ -508,9 +508,12 @@ void copyUnixDirectoryAndRespond(HttpResponse *response, char *oldAbsolutePath, 
     case RC_HTTP_FILE_SERVICE_NOT_FOUND:
       respondWithJsonError(response, "Directory not found", 404, "Not Found");
       break;
-    default:
-      respondWithJsonError(response, "Failed to copy a directory", 500, "Internal Server Error");
+    default: {
+      char error[64];
+      snprintf(error, 64, "Error copying directory, rc=%d", returnCode);
+      respondWithJsonError(response, error, 500, "Internal Server Error");
       break;
+      }
     }
   }
 }
@@ -593,9 +596,12 @@ void copyUnixFileAndRespond(HttpResponse *response, char *oldAbsolutePath, char 
     case RC_HTTP_FILE_SERVICE_NOT_FOUND:
       respondWithJsonError(response, "File not found", 404, "Not Found");
       break;    
-    default:
-      respondWithJsonError(response, "Failed to copy a file", 500, "Internal Server Error");
+    default: {
+      char error[64];
+      snprintf(error, 64, "Error copying file, rc=%d", returnCode);
+      respondWithJsonError(response, error, 500, "Internal Server Error");
       break;
+      }
     }
   }
 }

--- a/c/zosfile.c
+++ b/c/zosfile.c
@@ -655,7 +655,7 @@ int fileCopyConverted(const char *existingFileName, const char *newFileName,
   char *fileBuffer = safeMalloc(FILE_BUFFER_SIZE,"fileCopyBuffer");
   int conversionBufferLength = FILE_BUFFER_SIZE * MAX_CONVERT_FACTOR;
   char *conversionBuffer = (shouldConvert ? safeMalloc(conversionBufferLength,"fileCopyConvertBuffer"): NULL);
-  char *writeBuffer = (shouldConvert ? conversionBuffer : writeBuffer);
+  char *writeBuffer = (shouldConvert ? conversionBuffer : fileBuffer);
   int writeLength;
   int returnValue = 0;
   
@@ -680,14 +680,15 @@ int fileCopyConverted(const char *existingFileName, const char *newFileName,
     } else {
       writeLength = bytesRead;
     }
-    
-    status = fileWrite(newFile, writeBuffer, writeLength, &returnCode, &reasonCode);
-    if (status == -1) {
-      *retCode = returnCode;
-      *resCode = reasonCode;
-      returnValue = -1;
-      goto cleanup;
-    } 
+    if (bytesRead > 0) {
+      status = fileWrite(newFile, writeBuffer, writeLength, &returnCode, &reasonCode);
+      if (status == -1) {
+        *retCode = returnCode;
+        *resCode = reasonCode;
+        returnValue = -1;
+        goto cleanup;
+      } 
+    }
   } while (bytesRead != 0);
 
   status = fileClose(existingFile, &returnCode, &reasonCode);


### PR DESCRIPTION
The file copy operation, when not doing convert codepage, would initialize the write buffer to itself, so that when we read X bytes, we would write X bytes of random junk to the destination.
I instead initialize the write buffer = read buffer when conversion is not needed, and this solves the issue.