### PR TITLE
Fix no uid/gid shown in respondWithUnixFileMetadata 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,9 @@
 # Zowe Common C Changelog
 
-## `2.9.0`
-
-- Feature: `fileCopy` now copies with the target having the permissions of the source, as opposed to the previous 700 permissions.
-
 ## `2.8.0`
 
 - Bugfix: `fileCopy` would not work when convert encoding was not requested. The destination file would be created, but without the requested content.
+- Feature: `fileCopy` now copies with the target having the permissions of the source, as opposed to the previous 700 permissions.
 - Bugfix: respondWithUnixFileMetadata would not return UID or GID of a file if the id-to-name mapping failed, which is possible when an account is removed.
 
 ## `2.5.0`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## `2.8.0`
 
 - Bugfix: `fileCopy` would not work when convert encoding was not requested. The destination file would be created, but without the requested content.
+- Bugfix: respondWithUnixFileMetadata would not return UID or GID of a file if the id-to-name mapping failed, which is possible when an account is removed.
 
 ## `2.5.0`
 

--- a/c/httpfileservice.c
+++ b/c/httpfileservice.c
@@ -741,7 +741,7 @@ void respondWithUnixFileMetadata(HttpResponse *response, char *absolutePath) {
       zowelog(NULL, LOG_COMP_HTTPSERVER, ZOWE_LOG_DEBUG, 
              "failed to obtain group name for gid=%d, returnCode: %d, reasonCode: 0x%08x\n",
              info.ownerGID, returnCode, reasonCode);
-      snprintf(owner, USER_NAME_LEN+1, "%d", info.ownerGID);
+      snprintf(owner, GROUP_NAME_LEN+1, "%d", info.ownerGID);
     }
     trimRight(group, GROUP_NAME_LEN);
 

--- a/c/httpfileservice.c
+++ b/c/httpfileservice.c
@@ -731,6 +731,7 @@ void respondWithUnixFileMetadata(HttpResponse *response, char *absolutePath) {
       zowelog(NULL, LOG_COMP_HTTPSERVER, ZOWE_LOG_DEBUG, 
              "failed to obtain user name for uid=%d, returnCode: %d, reasonCode: 0x%08x\n",
              info.ownerUID, returnCode, reasonCode);
+      snprintf(owner, USER_NAME_LEN+1, "%d", info.ownerUID);
     }
     trimRight(owner, USER_NAME_LEN);
 
@@ -740,6 +741,7 @@ void respondWithUnixFileMetadata(HttpResponse *response, char *absolutePath) {
       zowelog(NULL, LOG_COMP_HTTPSERVER, ZOWE_LOG_DEBUG, 
              "failed to obtain group name for gid=%d, returnCode: %d, reasonCode: 0x%08x\n",
              info.ownerGID, returnCode, reasonCode);
+      snprintf(owner, USER_NAME_LEN+1, "%d", info.ownerGID);
     }
     trimRight(group, GROUP_NAME_LEN);
 

--- a/c/httpserver.c
+++ b/c/httpserver.c
@@ -4929,7 +4929,7 @@ int makeJSONForDirectory(HttpResponse *response, char *dirname, int includeDotte
             zowelog(NULL, LOG_COMP_HTTPSERVER, ZOWE_LOG_DEBUG, 
                     "failed to obtain group name for gid=%d, returnCode: %d, reasonCode: 0x%08x\n",
                     fileInfoOwnerGID(&info), returnCode, reasonCode);
-            snprintf(owner, USER_NAME_LEN+1, "%d", info.ownerGID);
+            snprintf(owner, GROUP_NAME_LEN+1, "%d", info.ownerGID);
           }
           trimRight(group, GROUP_NAME_LEN);
           

--- a/c/httpserver.c
+++ b/c/httpserver.c
@@ -4919,6 +4919,7 @@ int makeJSONForDirectory(HttpResponse *response, char *dirname, int includeDotte
             zowelog(NULL, LOG_COMP_HTTPSERVER, ZOWE_LOG_DEBUG, 
                     "failed to obtain user name for uid=%d, returnCode: %d, reasonCode: 0x%08x\n",
                     fileInfoOwnerUID(&info), returnCode, reasonCode);
+            snprintf(owner, USER_NAME_LEN+1, "%d", info.ownerUID);
           }
           trimRight(owner, USER_NAME_LEN);
           
@@ -4928,6 +4929,7 @@ int makeJSONForDirectory(HttpResponse *response, char *dirname, int includeDotte
             zowelog(NULL, LOG_COMP_HTTPSERVER, ZOWE_LOG_DEBUG, 
                     "failed to obtain group name for gid=%d, returnCode: %d, reasonCode: 0x%08x\n",
                     fileInfoOwnerGID(&info), returnCode, reasonCode);
+            snprintf(owner, USER_NAME_LEN+1, "%d", info.ownerGID);
           }
           trimRight(group, GROUP_NAME_LEN);
           


### PR DESCRIPTION
respondWithUnixFileMetadata returns the owner / group strings of files when its known.
But, if a user account is removed, there is no mapping between a UID/GID number and a name.
If you `ls` such files, you'll see ls just returns the ID instead of the name when the name no longer exists.
So, we'll do the same in this API.