### PR TITLE
symbol resolution library for C and QJS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Zowe Common C Changelog
 
+## `2.9.0`
+
+- Feature: configmgr's zos module now has a "resolveSymbol" function which takes a string starting with & which can be used to resolve static and dynamic zos symbols
+
 ## `2.8.0`
 
 - Bugfix: `fileCopy` would not work when convert encoding was not requested. The destination file would be created, but without the requested content.

--- a/c/zos.c
+++ b/c/zos.c
@@ -323,7 +323,7 @@ TCB *getNextSiblingTCB(TCB *tcb){
   Input: A symbol starting with & and not ending with .
   Output: resolved symbol or NULL
 */
-char *resolveSymbolBySyscall(char *inputSymbol, int *rc, int *rsn) {
+char *resolveSymbolBySyscall(const char *inputSymbol, int *rc, int *rsn) {
   int inputLen = strlen(inputSymbol);
   if (inputLen == 0 || inputSymbol[0] != '&' || inputSymbol[inputLen-1] == '.'){
     *rc=RESOLVESYMBOL_RETURN_BAD_INPUT;
@@ -412,9 +412,9 @@ char *resolveSymbolBySyscall(char *inputSymbol, int *rc, int *rsn) {
   Input: A symbol starting with & and not ending with .
   Output: resolved symbol or NULL
 */
-char *resolveSymbol(char *inputSymbol, int *rc, int *rsn) {
+char *resolveSymbol(const char *inputSymbol, int *rc, int *rsn) {
   ECVT *ecvt = getECVT();
-  SymbTable *symbt = (*SymbTable)ecvt->ecvtsymt;
+  SymbTable *symbt = ecvt->ecvtsymt;
   SymbTable *symbt1;
 //  dumpbuffer((char*)symbt, 0x400);
 

--- a/c/zos.c
+++ b/c/zos.c
@@ -247,6 +247,8 @@ ECVT *getECVT(void) {
   return (ECVT*)(cvt->cvtecvt);
 }
 
+
+
 char *getSysplexName (void) {
   ECVT *ecvt = getECVT();
   return ecvt->ecvtsplx;
@@ -316,6 +318,175 @@ TCB *getParentTCB(TCB *tcb){
 TCB *getNextSiblingTCB(TCB *tcb){
   return (TCB*)tcb->tcbntc;
 }
+
+/*
+  Input: A symbol starting with & and not ending with .
+  Output: resolved symbol or NULL
+*/
+char *resolveSymbolBySyscall(char *inputSymbol, int *rc, int *rsn) {
+  int inputLen = strlen(inputSymbol);
+  if (inputLen == 0 || inputSymbol[0] != '&' || inputSymbol[inputLen-1] == '.'){
+    *rc=RESOLVESYMBOL_RETURN_BAD_INPUT;
+    return NULL;
+  }
+
+
+  ALLOC_STRUCT31(
+    STRUCT31_NAME(below2G),
+    STRUCT31_FIELDS(
+      char input[1024];
+      char output[1024];
+      char workarea[1024];
+      char savearea[72];
+      SymbfpInputArguments symbfArguments;
+      //symboltable;
+      //char timestamp[8];
+      int returnCode;
+      int outputLength;
+    )
+  );
+  
+  snprintf(below2G->input, 1024, "%s", inputSymbol);
+  below2G->symbfArguments.patternAddr = below2G->input;
+  below2G->symbfArguments.patternLength = sizeof(below2G->input);
+  below2G->outputLength = 1024;
+  
+  below2G->symbfArguments.patternAddr = &below2G->input;
+  below2G->symbfArguments.targetAddr = &below2G->output;
+  below2G->symbfArguments.targetLengthAddr = &below2G->outputLength;
+  below2G->symbfArguments.returnCodeAddr = &below2G->returnCode;
+  below2G->symbfArguments.workAreaAddr = &below2G->workarea;
+  
+  int loadStatus = 0;
+  int symbfAddress = (int)loadByName("ASASYMBF",&loadStatus);
+//  printf("symbf address at 0x%x, status=%d\n", symbfAddress, loadStatus);
+
+  if (!loadStatus) {
+    __asm(ASM_PREFIX
+#ifdef __XPLINK__
+         " LA 13,%[savearea] \n"
+#endif
+         " LLGF 15,%[symbfAddress] \n"
+         " LA 1,%[symbfArguments] \n"
+#ifdef _LP64
+         " SAM31 \n"
+         " SYSSTATE AMODE64=NO \n"
+#endif
+         " BASR 14,15 \n"
+#ifdef _LP64
+         " SAM64 \n"
+         " SYSSTATE AMODE64=YES \n"
+#endif
+          :
+          :[savearea]"m"(below2G->savearea),[symbfArguments]"m"(below2G->symbfArguments),[symbfAddress]"m"(symbfAddress)
+          :"r0","r1","r14","r15"
+#ifdef __XPLINK__
+         ,"r13"
+#endif
+         );
+    } else {
+//     printf("Could not locate ASASYMBF, status=%d\n", loadStatus);
+      *rc=loadStatus;
+      FREE_STRUCT31(STRUCT31_NAME(below2G));
+      return NULL;
+
+    }
+
+//    printf("input '%s', output '%s'\n", below2G->input, below2G->output);
+    int outputLen = strlen(below2G->output);
+    if (outputLen != 0){
+      char *result = safeMalloc(sizeof(below2G->output), "output");
+      snprintf(result, outputLen+1, "%s", below2G->output);
+      FREE_STRUCT31(STRUCT31_NAME(below2G));
+      return result;
+    } else{
+      FREE_STRUCT31(STRUCT31_NAME(below2G));
+      return NULL;
+    }
+
+
+}
+
+
+/*
+  Input: A symbol starting with & and not ending with .
+  Output: resolved symbol or NULL
+*/
+char *resolveSymbol(char *inputSymbol, int *rc, int *rsn) {
+  ECVT *ecvt = getECVT();
+  SymbTable *symbt = (*SymbTable)ecvt->ecvtsymt;
+  SymbTable *symbt1;
+//  dumpbuffer((char*)symbt, 0x400);
+
+
+
+  int inputLen = strlen(inputSymbol);
+  if (inputLen == 0 || inputSymbol[0] != '&' || inputSymbol[inputLen-1] == '.'){
+    *rc=RESOLVESYMBOL_RETURN_BAD_INPUT;
+    return NULL;
+  }
+
+  bool useEntryOffsets = (symbt->flag0 & SYMBT_PTRS_ARE_OFFSETS) != 0;
+  bool isType1 = (symbt->flag1 & SYMBT_SYMBT1) != 0;
+  int16_t entryCount;
+  if (isType1) {
+    symbt1 = ecvt->ecvtsymt;
+    entryCount = symbt1->numberOfSymbols;
+  } else {
+    entryCount = symbt->numberOfSymbols;
+  }
+
+//  printf("using offsets? %s\n", useEntryOffsets ? "true" : "false");
+//  printf("is type1? %s\n", isType1 ? "true" : "false");
+//  printf("there are %d (0x%x) entries\n", entryCount, entryCount);
+
+  SymbTableEntry *firstEntry = isType1 ? &symbt1->firstEntry : &symbt->firstEntry;
+  if ((symbt->flag1 & SYMBT_INDIRECT_SYMBOL_AREA) != 0) {
+    firstEntry =  isType1 ? &symbt1->firstEntry : &symbt->firstEntry;
+//    printf("indirect symbol area\n");
+  }
+//  printf("firstEntry is at 0x%p\n", firstEntry);
+//  dumpbuffer((char*)firstEntry, 0x20);
+
+
+  SymbTableEntry *entry = firstEntry;
+
+  for (int i = 0; i < entryCount; i++) {
+    if (useEntryOffsets) {
+      //printf("firstEntry = 0x%p, symbol offset = 0x%x, length=%d, subtext offset = 0x%x, length=%d\n", firstEntry, entry->symbolOffset, entry->symbolLength, entry->subtextOffset, entry->subtextLength);
+      
+      char *currentSymbol = (char*)firstEntry + entry->symbolOffset;
+//      printf("Symbol=%.*s\n", entry->symbolLength, currentSymbol);
+
+      // extra '.' at end to account for
+      if ((inputLen+1 == entry->symbolLength) && (memcmp(currentSymbol, inputSymbol, inputLen) == 0) && currentSymbol[inputLen]=='.'){
+        char *result = (char*) safeMalloc(entry->subtextLength+1, "subtext");
+        snprintf(result, entry->subtextLength+1, "%s", (char*)firstEntry + entry->subtextOffset);
+        return result;
+      }
+
+      entry = entry+1;
+    } else{
+      char *currentSymbol = entry->symbolPtr;
+
+      printf("Symbol=%.*s\n", entry->symbolLength, currentSymbol);
+
+
+      // extra '.' at end to account for
+      if ((inputLen+1 == entry->symbolLength) && (memcmp(currentSymbol, inputSymbol, inputLen) == 0) && currentSymbol[inputLen]=='.'){
+        char *result = (char*) safeMalloc(entry->subtextLength+1, "subtext");
+        snprintf(result, entry->subtextLength+1, "%s", entry->subtextPtr);
+        return result;
+      }
+    }
+ 
+     //printf("next entry at 0x%p\n", entry);
+
+  }
+
+  return resolveSymbolBySyscall(inputSymbol, rc, rsn);
+}
+
 
 
 /* SAF

--- a/h/zos.h
+++ b/h/zos.h
@@ -368,127 +368,6 @@ typedef struct PSA_tag{
   unsigned int psamodew;
 } PSA;
 
-typedef struct ecvt_tag{
-  char  eyecatcher[4];
-  Addr31 ecvtcplx;   /* address IXCCPLX */
-  char  ecvtsplx[8];/* Sysplex name used for debugging */
-  int   ecvtsple;   /* sysplex partitioning ECB */
-  Addr31 ecvtsplq;   /* sysplex partitioning queue */
-  Addr31 ecvtstc1;   /*  V(IEATSTC1) */
-  Addr31 ecvtstc2;   /*  V(IEATSTC2) */
-  /* offset 0x20 here */
-  Addr31 ecvtstc3;   /*  V(IEATSTC3) */
-  Addr31 ecvtstc4;   /*  V(IEATSTC4) */
-
-  Addr31 ecvtappc;   /*  Anchor for APPC structures */
-  Addr31 ecvtsch;    /*  Anchor for APPC scheduler data structures */
-  /* offset 0x30 here */
-  int   ecvtiosf;   /*  IOS Flags  --- offset 0x30*/
-  Addr31 ecvtomda;   /* operations measurement data - console services */
-  short ecvtr038;   /* reserved */
-  char  ecvtcnz;
-  char  ecvtaloc;   /* flags */
-  Addr31 ecvtbpms;   /* BELOW 16M, pageable device support start addr */
-  Addr31 ecvtbpme;   /* BELOW 16M, pageable device support end   addr - offset x40 */
-  Addr31 ecvtapms;   /* ABOVE 16M, pageable device support start addr */
-  Addr31 ecvtapme;   /* ABOVE 16M, pageable device support end   addr  */
-  Addr31 ecvtqucb;   /* XCF data area IXCTQUCB anchor - offset 0x4C */
-  Addr31 ecvtssdf;   /* free SSD queue */
-  int   ecvtssds;   /* sequence number for previous and compare double swap */
-  int   ecvtr058;   /* reserved */
-  Addr31 ecvtsrbt;   /* SSD resource manager */
-  Addr31 ecvtdpqh;   /* Queue of DU-ALpools for PC Auth - offset 0x60 */
-  Addr31 ecvttcre;   /* V(IEAVTCRE) entry */
-  char  ecvtxcfg[16];  /* Sysplex Configuration requirements bitstring */
-  int   ecvtr078;   /* reserved */
-  int   ecvtr07C;   /* reserved */
-  /* Offset 0x80 Here */
-  Addr31 ecvtscha;   /* V(IEAVSCHA) schedule */
-  int   ecvtr084;   /* reserved */
-  Addr31 ecvtdlcb;   /* CSVDLCB DLCB for the Current LNKLST set */
-  Addr31 ecvtnttp;   /* address of system level name/token header */
-  /* Offset 0x90 Here */
-  Addr31 ecvtsrbj;   /* V(IEAVJOIN) - see book */
-  Addr31 ecvtsrbl;   /* V(IEAVLEAV) - see book */
-  Addr31 ecvtmsch;   /* address of SLM (XES) subchannel list */
-  Addr31 ecvtcal;    /* address of Common Area List (CAL) of System Lock Manager (SLM) */
-  /* Offset 0xA0 Here */
-  char ecvtload[8]; /* edited MVS load parameter */
-  char ecvtmlpr[8]; /* load parameter used for this IPL */
-  /* offset 0xB0 Here */
-  Addr31 ecvttcp;    /* Token used by TCPIP */
-  int   ecvtr0B4;   /* reserved */
-  Addr31 ecvtnvdm;   /* Netview DM TCP ID Block Pointer */
-  int   ecvtr0BC;   /* reserved */
-  /* offset 0xC0 Here */
-  Addr31 ecvtgrmp;   /* Graphics Resource Monitor GRM data block */
-  Addr31 ecvtwlm;    /* WLM Vector table */
-  Addr31 ecvtcsm;    /* Communication Storage Manager (VTAM) */
-  Addr31 ecvtctbl;   /* Customer Anchor Table - RVT somewhere in here */
-  /* offset 0xD0 Here */
-  Addr31 ecvtpmcs;   /* V(IEAVPMCS)  process service routine */
-  Addr31 ecvtpmcr;   /* V(IEAVPMCR)  ditto-ish */
-  Addr31 ecvtstx1;   /* V(IEAVAX01) STAX defer yes */
-  Addr31 ecvtstx2;   /* V(IEAVAX02) STAX defer no */
-  /* Offset 0xE0 Here */
-  int   ecvtslid;   /* Slip Trap ID or 0x00000000 */
-  Addr31 ecvtcsvt;   /* CSV Table - Callable Services Vector - Important and Common */
-  Addr31 ecvtasa;    /* ASA Table */
-  Addr31 ecvtexpm;   /* V(IEAVEXPM) GETXSB service routine */
-  /* Offset 0xF0 Here */
-  Addr31 ecvtocvt;   /* OpenMVS Anchor, its CVT */
-  Addr31 ecvtoext;   /* OpenMVS  external data - what is this? */
-  Addr31 ecvtcmps;   /* V(CSRCMPSS) - compression services routine */
-  Addr31 ecvtnucp;   /* nucleus dataset name */
-  /* Offset 0x100 Here */
-  Addr31 ecvtxrat;   /* XES Anchor Table for branch entry routine addresses */
-  Addr31 ecvtpwvt;   /* Processor Workunit Queue Vector Table */
-  char  ecvtclon[2];/* System.within Sysplex 2-char ID */
-  char  ecvtgmod;   /* GRS operation mode, NONE, 1 - Ring , 2 - Star */
-  char  ecvtr10B[5]; /* reserved */
-  /* Offset 0x110 */
-  char  ecvtr110[10]; /* reserved */
-  short ecvtptim;     /* time value for parallel detach (RTM) */
-  Addr31 ecvtjcct;     /* JES Communication Control Table */
-  /* Offset 0x120 */
-  Addr31 ecvtlsab;     /* Logger Services Anchor Block */
-  Addr31 ecvtetpe;     /* V(IEAVETPE) */
-  Addr31 ecvtsymt;     /* System static Symbol table - Mapped by SYMBT withing ASASYMBP */
-  Addr31 ecvtesym;     /* V(IEAVESYM) */
-  char unmapped1[0x20];
-  /* Offset 0x150 */
-  char ecvthdnm[8];
-  char ecvtlpnm[8];
-  char ecvtvmnm[8];
-  /* Offset 0x168 */
-  Addr31 ecvtgrm;    /* V(CRG52GRM) */
-  Addr31 ecvtseif;   /* V(CRG52SEI) */
-  /* Offset 0x170 */
-  Addr31 ecvtaes;    /* V(IEAVEAES) */
-  Addr31 ecvtrsmt;   /* Addr registration services management table */
-  char   ecvtmmem[16];
-  /* Offset 0x188 */
-  Addr31 ecvtipa;    /* Addr of Initzltn Parameter Area - like "D IPLINFO" */
-  char   ecvtmmet[16]; 
-  Addr31 ecvtmmeq;
-  /* Offset 0x1A0 */
-  char unmapped2[0x3C];
-  /* OFFSET 0x1DC */
-  int  ecvtpseq;
-  char ecvtpown[16];
-  char ecvtpnam[16];
-  char ecvtpver[2];
-  char ecvtprel[2];
-  char ecvtpmod[2];
-  char ecvtpdvl;
-  char ecvtttfl;     /* transaction trace flags */
-  /* OFFSET 0x208 */
-  char unmapped208[0x3D0-0x208]; 
-  /* OFFSET 0x3D0 */
-  Addr31 ecvtizugsp;      /* ZOSMF info */
-  /* more unmapped fields here */
-} ECVT;
-
 typedef struct SymbfpInputArguments_tag{
   Addr31 patternAddr;
   int    patternLength;
@@ -584,6 +463,127 @@ typedef struct SymbTable1_tag{
 #define SYMBT_MAXSTATIC_TABLE_SIZE 32512
 
 #define RESOLVESYMBOL_RETURN_BAD_INPUT 1
+
+typedef struct ecvt_tag{
+  char  eyecatcher[4];
+  Addr31 ecvtcplx;   /* address IXCCPLX */
+  char  ecvtsplx[8];/* Sysplex name used for debugging */
+  int   ecvtsple;   /* sysplex partitioning ECB */
+  Addr31 ecvtsplq;   /* sysplex partitioning queue */
+  Addr31 ecvtstc1;   /*  V(IEATSTC1) */
+  Addr31 ecvtstc2;   /*  V(IEATSTC2) */
+  /* offset 0x20 here */
+  Addr31 ecvtstc3;   /*  V(IEATSTC3) */
+  Addr31 ecvtstc4;   /*  V(IEATSTC4) */
+
+  Addr31 ecvtappc;   /*  Anchor for APPC structures */
+  Addr31 ecvtsch;    /*  Anchor for APPC scheduler data structures */
+  /* offset 0x30 here */
+  int   ecvtiosf;   /*  IOS Flags  --- offset 0x30*/
+  Addr31 ecvtomda;   /* operations measurement data - console services */
+  short ecvtr038;   /* reserved */
+  char  ecvtcnz;
+  char  ecvtaloc;   /* flags */
+  Addr31 ecvtbpms;   /* BELOW 16M, pageable device support start addr */
+  Addr31 ecvtbpme;   /* BELOW 16M, pageable device support end   addr - offset x40 */
+  Addr31 ecvtapms;   /* ABOVE 16M, pageable device support start addr */
+  Addr31 ecvtapme;   /* ABOVE 16M, pageable device support end   addr  */
+  Addr31 ecvtqucb;   /* XCF data area IXCTQUCB anchor - offset 0x4C */
+  Addr31 ecvtssdf;   /* free SSD queue */
+  int   ecvtssds;   /* sequence number for previous and compare double swap */
+  int   ecvtr058;   /* reserved */
+  Addr31 ecvtsrbt;   /* SSD resource manager */
+  Addr31 ecvtdpqh;   /* Queue of DU-ALpools for PC Auth - offset 0x60 */
+  Addr31 ecvttcre;   /* V(IEAVTCRE) entry */
+  char  ecvtxcfg[16];  /* Sysplex Configuration requirements bitstring */
+  int   ecvtr078;   /* reserved */
+  int   ecvtr07C;   /* reserved */
+  /* Offset 0x80 Here */
+  Addr31 ecvtscha;   /* V(IEAVSCHA) schedule */
+  int   ecvtr084;   /* reserved */
+  Addr31 ecvtdlcb;   /* CSVDLCB DLCB for the Current LNKLST set */
+  Addr31 ecvtnttp;   /* address of system level name/token header */
+  /* Offset 0x90 Here */
+  Addr31 ecvtsrbj;   /* V(IEAVJOIN) - see book */
+  Addr31 ecvtsrbl;   /* V(IEAVLEAV) - see book */
+  Addr31 ecvtmsch;   /* address of SLM (XES) subchannel list */
+  Addr31 ecvtcal;    /* address of Common Area List (CAL) of System Lock Manager (SLM) */
+  /* Offset 0xA0 Here */
+  char ecvtload[8]; /* edited MVS load parameter */
+  char ecvtmlpr[8]; /* load parameter used for this IPL */
+  /* offset 0xB0 Here */
+  Addr31 ecvttcp;    /* Token used by TCPIP */
+  int   ecvtr0B4;   /* reserved */
+  Addr31 ecvtnvdm;   /* Netview DM TCP ID Block Pointer */
+  int   ecvtr0BC;   /* reserved */
+  /* offset 0xC0 Here */
+  Addr31 ecvtgrmp;   /* Graphics Resource Monitor GRM data block */
+  Addr31 ecvtwlm;    /* WLM Vector table */
+  Addr31 ecvtcsm;    /* Communication Storage Manager (VTAM) */
+  Addr31 ecvtctbl;   /* Customer Anchor Table - RVT somewhere in here */
+  /* offset 0xD0 Here */
+  Addr31 ecvtpmcs;   /* V(IEAVPMCS)  process service routine */
+  Addr31 ecvtpmcr;   /* V(IEAVPMCR)  ditto-ish */
+  Addr31 ecvtstx1;   /* V(IEAVAX01) STAX defer yes */
+  Addr31 ecvtstx2;   /* V(IEAVAX02) STAX defer no */
+  /* Offset 0xE0 Here */
+  int   ecvtslid;   /* Slip Trap ID or 0x00000000 */
+  Addr31 ecvtcsvt;   /* CSV Table - Callable Services Vector - Important and Common */
+  Addr31 ecvtasa;    /* ASA Table */
+  Addr31 ecvtexpm;   /* V(IEAVEXPM) GETXSB service routine */
+  /* Offset 0xF0 Here */
+  Addr31 ecvtocvt;   /* OpenMVS Anchor, its CVT */
+  Addr31 ecvtoext;   /* OpenMVS  external data - what is this? */
+  Addr31 ecvtcmps;   /* V(CSRCMPSS) - compression services routine */
+  Addr31 ecvtnucp;   /* nucleus dataset name */
+  /* Offset 0x100 Here */
+  Addr31 ecvtxrat;   /* XES Anchor Table for branch entry routine addresses */
+  Addr31 ecvtpwvt;   /* Processor Workunit Queue Vector Table */
+  char  ecvtclon[2];/* System.within Sysplex 2-char ID */
+  char  ecvtgmod;   /* GRS operation mode, NONE, 1 - Ring , 2 - Star */
+  char  ecvtr10B[5]; /* reserved */
+  /* Offset 0x110 */
+  char  ecvtr110[10]; /* reserved */
+  short ecvtptim;     /* time value for parallel detach (RTM) */
+  Addr31 ecvtjcct;     /* JES Communication Control Table */
+  /* Offset 0x120 */
+  Addr31 ecvtlsab;     /* Logger Services Anchor Block */
+  Addr31 ecvtetpe;     /* V(IEAVETPE) */
+  SymbTable * __ptr32 ecvtsymt;     /* System static Symbol table - Mapped by SYMBT withing ASASYMBP */
+  Addr31 ecvtesym;     /* V(IEAVESYM) */
+  char unmapped1[0x20];
+  /* Offset 0x150 */
+  char ecvthdnm[8];
+  char ecvtlpnm[8];
+  char ecvtvmnm[8];
+  /* Offset 0x168 */
+  Addr31 ecvtgrm;    /* V(CRG52GRM) */
+  Addr31 ecvtseif;   /* V(CRG52SEI) */
+  /* Offset 0x170 */
+  Addr31 ecvtaes;    /* V(IEAVEAES) */
+  Addr31 ecvtrsmt;   /* Addr registration services management table */
+  char   ecvtmmem[16];
+  /* Offset 0x188 */
+  Addr31 ecvtipa;    /* Addr of Initzltn Parameter Area - like "D IPLINFO" */
+  char   ecvtmmet[16]; 
+  Addr31 ecvtmmeq;
+  /* Offset 0x1A0 */
+  char unmapped2[0x3C];
+  /* OFFSET 0x1DC */
+  int  ecvtpseq;
+  char ecvtpown[16];
+  char ecvtpnam[16];
+  char ecvtpver[2];
+  char ecvtprel[2];
+  char ecvtpmod[2];
+  char ecvtpdvl;
+  char ecvtttfl;     /* transaction trace flags */
+  /* OFFSET 0x208 */
+  char unmapped208[0x3D0-0x208]; 
+  /* OFFSET 0x3D0 */
+  Addr31 ecvtizugsp;      /* ZOSMF info */
+  /* more unmapped fields here */
+} ECVT;
 
 
 typedef struct gda_tag{
@@ -1535,13 +1535,13 @@ int locate(char *dsn, int *volserCount, char *firstVolser);
   Input: A symbol starting with & and not ending with .
   Output: resolved symbol or NULL
 */
-char *resolveSymbolBySyscall(char *inputSymbol, int *rc, int *rsn);
+char *resolveSymbolBySyscall(const char *inputSymbol, int *rc, int *rsn);
 
 /*
   Input: A symbol starting with & and not ending with .
   Output: resolved symbol or NULL
 */
-char *resolveSymbol(char *inputSymbol, int *rc, int *rsn);
+char *resolveSymbol(const char *inputSymbol, int *rc, int *rsn);
 
 #define VERIFY_GENERATE_IDT        0x800
 #define VERIFY_WITHOUT_LOG         0x400

--- a/tests/js/symbol.js
+++ b/tests/js/symbol.js
@@ -1,0 +1,5 @@
+import * as zos from 'zos';
+
+console.log(`Resolved static symbol &SYSNAME to "${zos.resolveSymbol('&SYSNAME')}"`);
+console.log(`Resolved dynamic symbol &DAY to "${zos.resolveSymbol('&DAY')}"`);
+console.log('done');


### PR DESCRIPTION
This feature can be tested via configmgr and a builtin test.

```
> ./configmgr -script ../tests/js/symbol.js
Resolved static symbol &SYSNAME to "RS28"
Resolved dynamic symbol &DAY to "24"
done
```

It adds a function, `resolveSymbol`, available both as a C function and as a QJS zos module function.
It takes in a string starting with `&` and not ending with `.`, and will lookup the string to find the dynamic or static symbol value that corresponds to it.

This is done with a combination of techniques.
At first, it will read through the symbol table off the ecvt to see if it's a static symbol.
If it isn't there, it may be a dynamic symbol, and that can be checked through a bit of assembly code that runs next. If still not found, null is returned.