### PR TITLE
zwe command: process long strings (length>256) correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Zowe Common C Changelog
 
+## `2.10.0`
+
+- Bugfix: configmgr parsing of yaml to json was limited to 256 characters for strings. This has been updated to 1024 to allow for up to max unix path strings. (#383)
+
 ## `2.9.0`
 
 - Feature: configmgr's zos module now has a "resolveSymbol" function which takes a string starting with & which can be used to resolve static and dynamic zos symbols

--- a/c/yaml2json.c
+++ b/c/yaml2json.c
@@ -925,7 +925,7 @@ static int emitScalar(yaml_emitter_t *emitter, char *scalar, char *tag, int styl
 
 static int writeJsonAsYaml1(yaml_emitter_t *emitter, Json *json){
   yaml_event_t event;
-  char scalarBuffer[256];
+  char scalarBuffer[MAX_ACCESS_PATH];
   if (jsonIsArray(json)){
     JsonArray *array = jsonAsArray(json);
     int elementCount = jsonArrayGetCount(array);


### PR DESCRIPTION
## Proposed changes

This PR addresses Issue: [zowe/zowe-install-packaging/issues/3476]

This PR depends upon the following PRs:

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zss/blob/v2.x/master/CONTRIBUTING.md))
- [x] I have added tests that prove my fix is effective or that my feature works, or describe a test method below

## Testing
`Zowe.yaml` file:
```
zowe:
  setup:
    dataset:
      prefix: USERID.ZOWE
      parmlib: USERID.ZOWE.PARMLIB
      jcllib: USERID.ZOWE.JCLLIB
      authLoadlib:  USERID.ZOWE.TEST1
      authPluginLib:  USERID.ZOWE.TEST2
  useConfigmgr: true
  runtimeDirectory: /u/userid/myyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy/zoweeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee/versionnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn/2.9.0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
```
is processed with e.g. `zwe config get` with no problems.

## Further comments
Technically this is not correct for the unix path, where the maximun length is 1023 (buffer defined as 1024). Later I will add a limit for the unix path in schema validation.
