### PR TITLE
Allow bypassing zos version check with env var ZWE_zowe_launcher_unsafeDisableZosVersionCheck

### DIFF
--- a/c/le.c
+++ b/c/le.c
@@ -120,9 +120,15 @@ void abortIfUnsupportedCAA() {
   unsigned int zosVersion = ecvt->ecvtpseq;
 #ifndef METTLE
   if (zosVersion > LE_MAX_SUPPORTED_ZOS) {
-    printf("error: z/OS version = 0x%08X, max supported version = 0x%08X - "
-           "CAA fields require verification\n", zosVersion, LE_MAX_SUPPORTED_ZOS);
-    abort();
+    const char *continueWithWarning = getenv("ZWE_zowe_launcher_unsafeDisableZosVersionCheck");
+    if (!strcmp(continueWithWarning, "true")) {
+      printf("warning: z/OS version = 0x%08X, max supported version = 0x%08X - "
+             "CAA fields require verification\n", zosVersion, LE_MAX_SUPPORTED_ZOS);
+    } else {
+      printf("error: z/OS version = 0x%08X, max supported version = 0x%08X - "
+             "CAA fields require verification\n", zosVersion, LE_MAX_SUPPORTED_ZOS);
+      abort();
+    }
   }
 #else
   /* Metal uses its own copy of CAA, reserved fields will always be available */


### PR DESCRIPTION
This PR changes the zOS version check from an error to a warning in the presence of the env var ZWE_zowe_launcher_unsafeDisableZosVersionCheck
It must be an env var because of the early execution of this code. Putting it into the yaml will not work.