### PR TITLE
Fix introduced compiler warning from recent merge.

### DIFF
--- a/c/tls.c
+++ b/c/tls.c
@@ -8,6 +8,7 @@
   Copyright Contributors to the Zowe Project.
 */
 #include <stdlib.h>
+#include <string.h>
 #include <sys/socket.h>
 #include <errno.h>
 #include "alloc.h"


### PR DESCRIPTION
There is a compiler warning for build_cmgr_xlclang.sh.