### PR TITLE
Trim env var for startup check

### DIFF
--- a/c/le.c
+++ b/c/le.c
@@ -123,7 +123,7 @@ void abortIfUnsupportedCAA() {
     const char *continueWithWarning = getenv("ZWE_zowe_launcher_unsafeDisableZosVersionCheck");
     /* using STDENV in JCL can result in env values that need trimming... */
     char *trimmed[strlen(continueWithWarning)+1];
-    strncopy(trimmed, continueWithWarning, strlen(continueWithWarning));
+    strncpy(trimmed, continueWithWarning, strlen(continueWithWarning));
     trimRight(trimmed, strlen(trimmed));
     
     if (!strcmp(trimmed, "true")) {

--- a/c/le.c
+++ b/c/le.c
@@ -121,7 +121,12 @@ void abortIfUnsupportedCAA() {
 #ifndef METTLE
   if (zosVersion > LE_MAX_SUPPORTED_ZOS) {
     const char *continueWithWarning = getenv("ZWE_zowe_launcher_unsafeDisableZosVersionCheck");
-    if (!strcmp(continueWithWarning, "true")) {
+    /* using STDENV in JCL can result in env values that need trimming... */
+    char *trimmed[strlen(continueWithWarning)+1];
+    strncopy(trimmed, continueWithWarning, strlen(continueWithWarning));
+    trimRight(trimmed, strlen(trimmed));
+    
+    if (!strcmp(trimmed, "true")) {
       printf("warning: z/OS version = 0x%08X, max supported version = 0x%08X - "
              "CAA fields require verification\n", zosVersion, LE_MAX_SUPPORTED_ZOS);
     } else {


### PR DESCRIPTION
Like in the launcher, any code that's expected to be run with env vars set from JCL should also expect that env vars can come in with trailing spaces.
This is a little ugly but the version-checking code in this PR is expected to be entirely removed soon, so this is another stop-gap to get people able to use zowe on untested versions of zos.