### PR TITLE
move getesm out of "utils" artifactory location

### DIFF
--- a/.github/workflows/build-getesm.yml
+++ b/.github/workflows/build-getesm.yml
@@ -71,7 +71,7 @@ jobs:
         with:
           artifacts: |
             .pax/getesm/getesm.pax
-          publish-target-path-pattern: libs-snapshot-local/org/zowe/utils/${{ steps.version.outputs.version }}-${{ steps.branch.outputs.branch }}
+          publish-target-path-pattern: libs-snapshot-local/org/zowe/getesm/${{ steps.version.outputs.version }}-${{ steps.branch.outputs.branch }}
           publish-target-file-pattern: getesm-${{ steps.version.outputs.version }}-${{ steps.date.outputs.date }}.pax
           perform-release: ${{ github.event.inputs.PERFORM_RELEASE }}
           


### PR DESCRIPTION
I thought /org/zowe/utils/getesm.pax would be a fine location, but then realized this has limitations in zowe-install-packaging which uses the structure "org.zowe.utils" to refer to only one object, so i cannot make a nice utils folder like that. instead, i will just call it "org.zowe.getesm"