### PR TITLE
Made the bytes to be encoded for base64 scheme to be divisble by 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Zowe Common C Changelog
 
+## `2.16.0`
+- For correct base64 encoding scheme the buffer size is made to be divisble by 3 (#431). 
+
 ## `2.15.0`
 - Remove obsolete building script build_configmgr.sh (#410). (#423)
 

--- a/c/httpserver.c
+++ b/c/httpserver.c
@@ -4637,8 +4637,9 @@ static int streamBinaryForFile2(HttpResponse *response, Socket *socket, UnixFile
   if (encoding == ENCODING_CHUNKED) {
     stream = makeChunkedOutputStreamInternal(response);
   }
-
-  int bufferSize = FILE_STREAM_BUFFER_SIZE;
+  
+  // To make bufferSize divisble by 3 for correct base64 encoding.
+  int bufferSize = FILE_STREAM_BUFFER_SIZE - (FILE_STREAM_BUFFER_SIZE % 3);
   char *buffer = safeMalloc(bufferSize+4, "streamBinaryBuffer");
   int encodedLength;
 
@@ -4710,7 +4711,8 @@ static int streamTextForFile2(HttpResponse *response, Socket *socket, UnixFile *
     stream = makeChunkedOutputStreamInternal(response);
     /* fallthrough */
   case ENCODING_SIMPLE: {
-    int bufferSize = FILE_STREAM_BUFFER_SIZE;
+    // To make bufferSize divisble by 3 for correct base64 encoding.
+    int bufferSize = FILE_STREAM_BUFFER_SIZE - (FILE_STREAM_BUFFER_SIZE % 3);
     char *buffer = safeMalloc(bufferSize+4, "streamTextBuffer");
     char *translation = safeMalloc((2*bufferSize)+4, "streamTextConvertBuffer"); /* UTF inflation tolerance */
     int encodedLength;


### PR DESCRIPTION
…g scheme

<!-- Thank you for submitting a PR to Zowe! To help us understand, test, and give feedback on your code, please fill in the details below. -->

## Proposed changes
When using base64 encoding, the **number bytes encoded**, causes artifacts if its not divisible by 3 for files larger than 1MB. Currently, this is value is FILE_STREAM_BUFFER_SIZE(defined as 1024000). To fix this issue for the base64 condition we decrease it by 1 to make it divisible by 3. 
There is also a comment added to modify this part of code incase there is a change in FILE_STREAM_BUFFER_SIZE value in the future.

This PR addresses Issue: https://github.com/zowe/zss/issues/657

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zss/blob/v2.x/master/CONTRIBUTING.md))
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [ ] video or image is included if visual changes are made
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works, or describe a test method below

## Testing
You can confirm by viewing a file of size greater than 1MB on the zlux-editor or get a file with 'responseType=B64'.

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, or if there are follow-up tasks and TODOs etc... -->
