### PR TITLE
Take into account leap seconds in cross-memory messages' timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 ## `2.16.0`
 - For correct base64 encoding scheme the buffer size is made to be divisble by 3 (#431). 
+- Take into account leap seconds in xmem log messages' timestamps (#432, #433)
 
 ## `2.15.0`
 - Remove obsolete building script build_configmgr.sh (#410). (#423)
+- Add flags to avoid linkage-stack queries in the recovery facility (#404, #412)
 
 ## `2.13.0`
 - Added support for using "zowe.network" and "components.zss.zowe.network" to set TLS version properties. (#411)

--- a/c/crossmemory.c
+++ b/c/crossmemory.c
@@ -510,11 +510,18 @@ static void getSTCK(uint64 *stckValue) {
   __asm(" STCK 0(%0)" : : "r"(stckValue));
 }
 
-int64 getLocalTimeOffset() {
+static int64 getLocalTimeOffset(void) {
   CVT * __ptr32 cvt = *(void * __ptr32 * __ptr32)0x10;
   void * __ptr32 cvtext2 = cvt->cvtext2;
   int64 *cvtldto = (int64 * __ptr32)(cvtext2 + 0x38);
   return *cvtldto;
+}
+
+static int64 getLeapSecondsOffset(void) {
+  CVT * __ptr32 cvt = *(void * __ptr32 * __ptr32)0x10;
+  void * __ptr32 cvtext2 = cvt->cvtext2;
+  int64 *cvtlso = (int64 * __ptr32)(cvtext2 + 0x50);
+  return *cvtlso;
 }
 
 static void getCurrentLogTimestamp(LogTimestamp *timestamp) {
@@ -523,6 +530,7 @@ static void getCurrentLogTimestamp(LogTimestamp *timestamp) {
   getSTCK(&stck);
 
   stck += getLocalTimeOffset();
+  stck -= getLeapSecondsOffset();
 
   stckToLogTimestamp(stck, timestamp);
 


### PR DESCRIPTION
<!-- Thank you for submitting a PR to Zowe! To help us understand, test, and give feedback on your code, please fill in the details below. -->

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->


The PR adds code to get the current amount of leap seconds and subtract that from the STCK value which goes into the timestamps.

### Additional changes:
* Update the changelog with these changes
* Update the changelog with the missing changes for v2.15

This PR addresses Issue: #432

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zss/blob/v2.x/master/CONTRIBUTING.md))
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings

## Testing
<!-- Describe how this code should be tested. I've you've added an automated or unit test, then describe how to run it. Otherwise, describe how you have tested it and how others should test it. -->

* Start ZIS;
* Compare the timestamps from the beginning of the JES and SYSPRINT logs; the timestamps should match.
