### PR TITLE
Using a temporary buffer pointer to avoid pointer corruption

### DIFF
--- a/c/httpfileservice.c
+++ b/c/httpfileservice.c
@@ -935,11 +935,12 @@ int writeAsciiDataFromBase64(UnixFile *file, char *fileContents, int contentLeng
                              &reasonCode);
      if (status == 0) {
        int writtenLength = 0;
+       char *dataToWriteToFile = dataToWrite;
        while (dataSize != 0) {
-         writtenLength = fileWrite(file, dataToWrite, dataSize, &returnCode, &reasonCode);
+         writtenLength = fileWrite(file, dataToWriteToFile, dataSize, &returnCode, &reasonCode);
          if (writtenLength >= 0) {
            dataSize -= writtenLength;
-           dataToWrite -= writtenLength;
+           dataToWriteToFile += writtenLength;
          }
          else {
            zowelog(NULL, LOG_COMP_RESTFILE, ZOWE_LOG_DEBUG, "Error writing to file: return: %d, rsn: %d.\n", returnCode, reasonCode);


### PR DESCRIPTION
<!-- Thank you for submitting a PR to Zowe! To help us understand, test, and give feedback on your code, please fill in the details below. -->

## Proposed changes
The original pointer used for malloc() was getting corrupted while data write was happening, now we use a copy/temporary pointer. Thereby safeguarding the original pointer and hence we avoid the wrong free() which was causing the abend.

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Change in a documentation
- [ ] Refactor the code 
- [ ] Chore, repository cleanup, updates the dependencies.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zss/blob/v2.x/master/CONTRIBUTING.md))
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [ ] video or image is included if visual changes are made
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works, or describe a test method below

## Testing
This issue happens randomly so trying to upload continuously will cause an abend at some point.
