### PR TITLE
Using a temporary buffer pointer to avoid pointer corruption.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## `2.16.0`
 - For correct base64 encoding scheme the buffer size is made to be divisble by 3 (#431). 
 - Take into account leap seconds in xmem log messages' timestamps (#432, #433)
+- Using a temporary buffer pointer to avoid pointer corruption during file write (#437).
 
 ## `2.15.0`
 - Remove obsolete building script build_configmgr.sh (#410). (#423)

--- a/c/httpfileservice.c
+++ b/c/httpfileservice.c
@@ -935,12 +935,12 @@ int writeAsciiDataFromBase64(UnixFile *file, char *fileContents, int contentLeng
                              &reasonCode);
      if (status == 0) {
        int writtenLength = 0;
-       char *dataToWriteToFile = dataToWrite;
+       char *currentBufferStart = dataToWrite;
        while (dataSize != 0) {
-         writtenLength = fileWrite(file, dataToWriteToFile, dataSize, &returnCode, &reasonCode);
+         writtenLength = fileWrite(file, currentBufferStart, dataSize, &returnCode, &reasonCode);
          if (writtenLength >= 0) {
            dataSize -= writtenLength;
-           dataToWriteToFile += writtenLength;
+           currentBufferStart += writtenLength;
          }
          else {
            zowelog(NULL, LOG_COMP_RESTFILE, ZOWE_LOG_DEBUG, "Error writing to file: return: %d, rsn: %d.\n", returnCode, reasonCode);

--- a/c/httpfileservice.c
+++ b/c/httpfileservice.c
@@ -935,11 +935,12 @@ int writeAsciiDataFromBase64(UnixFile *file, char *fileContents, int contentLeng
                              &reasonCode);
      if (status == 0) {
        int writtenLength = 0;
+       char *dataToWriteToFile = dataToWrite;
        while (dataSize != 0) {
-         writtenLength = fileWrite(file, dataToWrite, dataSize, &returnCode, &reasonCode);
+         writtenLength = fileWrite(file, dataToWriteToFile, dataSize, &returnCode, &reasonCode);
          if (writtenLength >= 0) {
            dataSize -= writtenLength;
-           dataToWrite -= writtenLength;
+           dataToWriteToFile += writtenLength;
          }
          else {
            zowelog(NULL, LOG_COMP_RESTFILE, ZOWE_LOG_DEBUG, "Error writing to file: return: %d, rsn: %d.\n", returnCode, reasonCode);


### PR DESCRIPTION

## Proposed changes
The original pointer used for malloc() was getting corrupted while data write was happening, now we use a copy/temporary pointer. Thereby safeguarding the original pointer and avoiding the wrong free(), which was causing the abend.

This PR addresses Issue: https://github.com/zowe/zss/issues/693

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Change in a documentation
- [ ] Refactor the code 
- [ ] Chore, repository cleanup, updates the dependencies.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zss/blob/v2.x/master/CONTRIBUTING.md))
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [ ] video or image is included if visual changes are made
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works, or describe a test method below

## Testing
You can create a script to upload chunks of data continuously using the PUT method.
