### PR TITLE
Min member name length = 1

### DIFF
--- a/c/configmgr.c
+++ b/c/configmgr.c
@@ -773,7 +773,7 @@ int cfgSetParmlibMemberName(ConfigManager *mgr, const char *configName, const ch
   CFGConfig *config = getConfig(mgr,configName);
   if (config){
     int len = strlen(parmlibMemberName);
-    if (len < 3 || len  > PARMLIB_MEMBER_MAX){
+    if (len < 1 || len  > PARMLIB_MEMBER_MAX){
       return ZCFG_BAD_PARMLIB_MEMBER_NAME;
     } else {
       config->parmlibMemberName = substring(mgr,(char*)parmlibMemberName,0,len);


### PR DESCRIPTION
## Proposed changes

This PR addresses Issue: https://github.com/zowe/zowe-common-c/issues/430

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zss/blob/v2.x/master/CONTRIBUTING.md))
- [x] Relevant update to CHANGELOG.md


## Testing
### Before
```
/zowe/runtime/2140/bin: ./zwe config validate -c "PARMLIB(JCONNOR.ZOWE.YAML(A))"
Error: Could not set parmlib member name for A, status=6
```
### After
```
/zowe/runtime/2150/bin: ./zwe config validate -c "PARMLIB(JCONNOR.ZOWE.YAML(A))"
Temporary directory '/skynet/tmp/.zweenv-8066' created.
Zowe will remove it on success, but if zwe exits with a non-zero code manual cleanup would be needed.
2024-03-20 11:54:23 <ZWELS:84282083> JCONNOR INFO (zwe-internal-start-prepare) Zowe version: v2.15.0
2024-03-20 11:54:23 <ZWELS:84282083> JCONNOR INFO (zwe-internal-start-prepare) build and hash: v2.x/master#4702 (3b20609fdb0c600941baf68a8f34f5568c9d71e4)
Validating Zowe core configuration for file(s)=/skynet/tmp/.zweenv-8066/.zowe-merged.yaml
Zowe core configuration is valid
Temporary directory /skynet/tmp/.zweenv-8066 removed successfully.
```

