### PR TITLE
isSyntacticallyNull checking empty string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Zowe Common C Changelog
 
+## `2.15.1`
+- No yaml value converted to null (#442)
+
 ## `2.16.0`
 - For correct base64 encoding scheme the buffer size is made to be divisble by 3 (#431). 
 - Take into account leap seconds in xmem log messages' timestamps (#432, #433)

--- a/c/yaml2json.c
+++ b/c/yaml2json.c
@@ -380,7 +380,9 @@ static bool isSyntacticallyInteger(yaml_char_t *data, int length){
 }
 
 static bool isSyntacticallyBool(yaml_char_t *data, int length){
-  if ((length == 4) &&
+  if (length == 0) {
+    return true
+  } else if ((length == 4) &&
       (!memcmp(data,"true",4) ||
        !memcmp(data,"True",4) ||
        !memcmp(data,"TRUE",4))){

--- a/c/yaml2json.c
+++ b/c/yaml2json.c
@@ -380,9 +380,7 @@ static bool isSyntacticallyInteger(yaml_char_t *data, int length){
 }
 
 static bool isSyntacticallyBool(yaml_char_t *data, int length){
-  if (length == 0) {
-    return true
-  } else if ((length == 4) &&
+  if ((length == 4) &&
       (!memcmp(data,"true",4) ||
        !memcmp(data,"True",4) ||
        !memcmp(data,"TRUE",4))){
@@ -398,7 +396,9 @@ static bool isSyntacticallyBool(yaml_char_t *data, int length){
 }
 
 static bool isSyntacticallyNull(yaml_char_t *data, int length){
-  if ((length == 1) &&
+  if (length == 0 ) {
+    return true;
+  } else if ((length == 1) &&
       !memcmp(data,"~",1)){
     return true;
   } else if ((length == 4) &&


### PR DESCRIPTION
https://github.com/zowe/zowe-common-c/issues/435

According to [definition](https://yaml.org/type/null.html):
```
 ~ # (canonical)
|null|Null|NULL # (English)
| # (Empty)
```

The last option (Empty) is missing in the function `isSyntacticallyNull`

* `isSyntacticallyNull` is called only for `YAML_PLAIN_SCALAR_STYLE`
  *  `nullValue: ` gets resolved as `"nullValue": null` 
  * And `emptyValue: ""` remains as `"emptyValue": ""`
* `YAML_NULL_TAG` is probably never set, this might be a problem in libyaml?

CHANGELOG: No yaml value converted to null
VERSION: 2.15.1