### PR TITLE
Allocating SLH for http server with configuring httpHeapMaxBlocks in yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fixed `xplatform.loadFileUTF8` when trying to open nonexistent file (#454)
 - Bugfix: fix an incorrect check in the recovery router code which might lead to
   the state cell-pool being released prematurely (#446)
+- Allocating SLH for http server with configurable value 'httpRequestHeapMaxBlocks' in yaml (#447).
 
 ## `2.16.0`
 - No yaml value converted to null (#442)

--- a/h/httpserver.h
+++ b/h/httpserver.h
@@ -64,6 +64,10 @@
 
 #define HTTP_SERVER_PRIVILEGED_SERVER_PROPERTY  "zisServerName"
 
+#define HTTP_REQUEST_HEAP_DEFAULT_BLOCKS 1024
+#define HTTP_REQUEST_HEAP_MIN_BLOCKS 100
+#define HTTP_REQUEST_HEAP_MAX_BLOCKS 4096
+
 typedef struct BigBuffer_tag{
   ShortLivedHeap *slh;  /* can be null */
   char *data;
@@ -220,6 +224,7 @@ typedef struct HTTPServerConfig_tag {
   hashtable *userTimeouts;
   hashtable *groupTimeouts;
   int defaultTimeout;
+  unsigned int httpRequestHeapMaxBlocks;
   /* The config manager is optional, but zss and other servers need 
      a near-global way to get configuration data.
      */


### PR DESCRIPTION
## Proposed changes
The heap available to the http server is currently capped to around 6MB, because of this there is a limit in the size of the dataset that can be uploaded using ZSS API's.
To solve this, we are providing an option in configuration under 'components ->zss ->httpHeapMaxBlocks'. By default it would be 1024 meaning, 64KB * 1024, and as of now we have capped the max value of this option to be 4096 meaning, 64kb * 4096.

This PR addresses Issue: https://github.com/zowe/zss/issues/698

This PR depends upon the following PRs:

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Change in a documentation
- [x] Refactor the code 
- [ ] Chore, repository cleanup, updates the dependencies.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zss/blob/v2.x/master/CONTRIBUTING.md))
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [ ] video or image is included if visual changes are made
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works, or describe a test method below

## Testing
You can try with uploading a dataset with size greater than 6mb using a python script
