### PR TITLE
Fix an incorrect check in the recovery router (v2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## `2.17.0`
 - Fixed `xplatform.loadFileUTF8` when trying to open nonexistent file (#454)
+- Bugfix: fix an incorrect check in the recovery router code which might lead to
+  the state cell-pool being released prematurely (#446)
 
 ## `2.16.0`
 - No yaml value converted to null (#442)

--- a/c/recovery.c
+++ b/c/recovery.c
@@ -497,7 +497,7 @@ static void * __ptr32 getRecoveryRouterAddress() {
       "         LA    1,RCVXINF           LOAD ROUTER SERVICE INFO             \n"
       "         BRAS  14,RCVSIFLB         RECORD IT, REMOVE CONTEXT, PERCOLATE \n"
       "         TM    RCXFLAG1,R@CF1USP   USER STATE POOL?                     \n"
-      "         BZ    RCVFRL04            NO, DO NOT FREE IT                   \n"
+      "         BNZ   RCVFRL04            NO, DO NOT FREE IT                   \n"
       "         LT    2,RCXSCPID          CELL POOL ZERO?                      \n"
       "         BZ    RCVFRL04            YES, DO NOT FREE IT                  \n"
 #ifdef _LP64
@@ -505,6 +505,8 @@ static void * __ptr32 getRecoveryRouterAddress() {
       "         SYSSTATE AMODE64=NO                                            \n"
 #endif
       "         CPOOL DELETE,CPID=(2)     FREE THE STATE CELL POOL             \n"
+      "         LGFI  2,X'7FFFFBA3'       MAKE AN OBVIOUSLY BAD ADDRESS        \n"
+      "         ST    2,RCXSCPID          MARK THE CPID FOR DEBUGGING PURPOSES \n"
 #ifdef _LP64
       "         SAM64                                                          \n"
       "         SYSSTATE AMODE64=YES                                           \n"
@@ -1291,6 +1293,8 @@ RecoveryStatePool *recoveryMakeStatePool(unsigned int stateCount) {
 
 void recoveryRemoveStatePool(RecoveryStatePool *statePool) {
   removeRecoveryStatePool(statePool->cellPool);
+  // put a bad address for debugging (in case the statePool storage survives)
+  statePool->cellPool = 0x7FFFFBA1;
   storageRelease(statePool, sizeof(RecoveryStatePool));
 }
 


### PR DESCRIPTION
The recovery facility might erroneously free the state cell-pool if an ABEND occurs right after the ESTAEX has been set but before any recovery states with the retry option have been pushed; this issued is caused by an incorrectly coded check in the recovery router code (the check is inverted).


## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

The PR fixes the incorrect instruction and adds some code to leave "bread crumbs" when the state cell-pool is deleted.

This PR addresses Issue: #446

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zss/blob/v2.x/master/CONTRIBUTING.md))
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Relevant update to CHANGELOG.md
- [x My changes generate no new warnings

## Testing
<!-- Describe how this code should be tested. I've you've added an automated or unit test, then describe how to run it. Otherwise, describe how you have tested it and how others should test it. -->

There is no reliable way to reproduce this, but in the context of the cross-memory server, one could write a service which disables all the recovery states and then ABENDs on purpose; all the subsequent calls to this server should ABEND without the fix.


