### PR TITLE
Allow strings to be null for backward compat on recent bugfix

### DIFF
--- a/c/jsonschema.c
+++ b/c/jsonschema.c
@@ -1108,7 +1108,27 @@ static JSValueSpec *resolveRef(JsonValidator *validator, ValidityException *pend
 static VResult validateJSONSimple(JsonValidator *validator,
                                   Json *value, JSValueSpec *valueSpec, int depth, EvalSet *evalSetList){
   if (jsonIsNull(value)){
-    return validateType(validator,JSTYPE_NULL,valueSpec,depth+1);
+    VResult typeResult = validateType(validator,JSTYPE_NULL,valueSpec,depth+1);
+    if (vStatusValid(typeResult.status)) {
+      return typeResult;
+    } else if (validator->allowStringToBeNull) {
+      // FIXME: Some users were relying upon a bug we fixed, where an empty value would be treated as a string.
+      // TODO: Remove this in v3, we should not keep this bug compatability forever.
+      if (((1 << JSTYPE_STRING) & valueSpec->typeMask) != 0){
+        Json *emptyStringJson = (Json*)safeMalloc(sizeof(Json), "Empty String JSON");
+        emptyStringJson->type = JSON_TYPE_STRING;
+        char emptyString[1] = {0};
+        emptyStringJson->data.string = emptyString;
+        // Check if schema is okay with an "empty string" as the previous bug had null be empty string.
+        VResult stringResult = validateJSONString(validator,emptyStringJson,valueSpec,depth+1);
+        safeFree((char*)emptyStringJson, sizeof(Json));
+        return stringResult;
+      } else{
+        return simpleFailure(validator, "string cannot be null for %s\n", validatorAccessPath(validator));
+      }                   
+    } else {
+      return typeResult;
+    }
   } else if (jsonIsBoolean(value)){
     return validateType(validator,JSTYPE_BOOLEAN,valueSpec,depth+1);
   } else if (jsonIsObject(value)){
@@ -1420,6 +1440,8 @@ static VResult validateJSON(JsonValidator *validator,
 int jsonValidateSchema(JsonValidator *validator, Json *value, JsonSchema *topSchema,
                        JsonSchema **otherSchemas, int otherSchemaCount){
   int result = 0;
+  validator->allowStringToBeNull = true;
+
   if (setjmp(validator->recoveryData) == 0) {  /* normal execution */
     validator->topSchema = topSchema;
     validator->otherSchemas = otherSchemas;

--- a/h/jsonschema.h
+++ b/h/jsonschema.h
@@ -117,6 +117,7 @@ typedef struct JsonValidator_tag {
   int         fileRegexError;
   jmp_buf     recoveryData;
   ShortLivedHeap *evalHeap;
+  bool        allowStringToBeNull;
 } JsonValidator;
 
 #define JSON_SCHEMA_DRAFT_4 400


### PR DESCRIPTION
Prior to v2.16.0 rc1, yaml entries such as `foo: ` were wrongly identified as an empty string when yaml spec says these should be null.
However, some programs were relying upon this in their schema, and upon us fixing the bug, their schemas became invalid when they strictly checked for type=string, when in reality their config was set up so that type could be either string OR null.

This is a temporary fix which allows the same behavior.
It does so by, upon seeing a null, checking if the schema says it should instead be a string.
If so, it will craft an empty string and do a string validation upon it, because it is still possible the user's schema required a string with size greater than 0.

This behavior is toggled by validator->allowStringToBeNull
I suggest removing it in v3, but keeping it for now to not cause disruption.