### PR TITLE
Add support for longer cross-memory server parms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## `2.18.1`
 - Bugfix: IARV64 results must be checked for 0x7FFFF000 (#474)
 - Bugfix: SLH should not ABEND when MEMLIMIT is reached (additional NULL check)
+- Bugfix: support cross-memory server parameters longer than 128 characters 
+  (zowe/zss#684)
 
 ## `2.18.0`
 - Minor `components.zss.logLevels._zss.httpserver=5` debug messages enhancement (#471)


### PR DESCRIPTION
<!-- Thank you for submitting a PR to Zowe! To help us understand, test, and give feedback on your code, please fill in the details below. -->

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

This PR extends the standard cross-memory server's service responsible for accessing configuration parameters and related data structures to allow it to handle PARMLIB parameter keys and values longer than 128 characters.

This PR addresses Issue: zowe/zss#684


## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)


## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zss/blob/v2.x/master/CONTRIBUTING.md))
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works, or describe a test method below

## Testing
<!-- Describe how this code should be tested. I've you've added an automated or unit test, then describe how to run it. Otherwise, describe how you have tested it and how others should test it. -->

#### Regression testing
Existing short parameters should work as usual.

#### Support of long parameters testing:
To test long parameters, specify something like this in the ZIS PARMLIB member:
```
LONG_TEST_PARM=\
this_is_line_value_0123456789_0\
this_is_line_value_0123456789_1\
this_is_line_value_0123456789_2\
this_is_line_value_0123456789_3\
this_is_line_value_0123456789_4\
this_is_line_value_0123456789_5\
this_is_line_value_0123456789_6\
this_is_line_value_0123456789_7\
this_is_line_value_0123456789_8\
this_is_line_value_0123456789_9\
this_is_line_value_0123456789_10\
this_is_line_value_0123456789_11\
this_is_line_value_0123456789_12\
this_is_line_value_0123456789_13\
this_is_line_value_0123456789_14\
this_is_line_value_0123456789_15\
this_is_line_value_0123456789_16\
this_is_line_value_0123456789_17\
this_is_line_value_0123456789_18\
this_is_line_value_0123456789_19\
this_is_line_value_0123456789_20\
this_is_line_value_0123456789_21\
this_is_line_value_0123456789_22\
this_is_line_value_0123456789_23\
this_is_line_value_0123456789_24\
this_is_line_value_0123456789_25\
this_is_line_value_0123456789_26\
this_is_line_value_0123456789_27\
this_is_line_value_0123456789_28\
this_is_line_value_0123456789_29\
this_is_line_value_0123456789_30\
this_is_line_value_0123456789_31\
this_is_line_value_0123456789_32\
this_is_line_value_0123456789_33\
this_is_line_value_0123456789_34\
this_is_line_value_0123456789_35\
this_is_line_value_0123456789_36\
this_is_line_value_0123456789_37\
this_is_line_value_0123456789_38\
this_is_line_value_0123456789_39\
end
```
Without the fix, ZIS should terminate with an error on start-up and it must successfully start with the fix. 

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, or if there are follow-up tasks and TODOs etc... -->
