### PR TITLE
Curve customization support:  Curve definitions and setting them using gsk_attribute_set_buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Zowe Common C Changelog
 
+## `3.4.0`
+- Enhancement: As a part of curve customization support, supported curves and their mapping to iana numbers are defined in tls.h. They are set using 'gsk_attribute_set_buffer' in tls.c. Currently, the list of supported curves can be seen here https://www.ibm.com/docs/en/zos/3.1.0?topic=programming-cipher-suite-definitions#csdcwh__tttcsd (#466).
+
 ## `3.3.0`
 - Enhancement: add a `copyConfigurationAndDeleteKey` API to configmgr (#524)
 - Enhancement: configmgr path elements of type PARMLIB can now contain a member name, in the format of "PARMLIB(DATA.SET(member))", as an alternative to the older format of "PARMLIB(DATA.SET)" with the member name being specified in a separate argument. This enhancement allows use of multiple members with different names within the same PARMLIB dataset. The older format can still be used as desired. (#522)

--- a/c/tls.c
+++ b/c/tls.c
@@ -123,6 +123,16 @@ int tlsInit(TlsEnvironment **outEnv, TlsSettings *settings) {
   rc = rc || gsk_attribute_set_enum(env->envHandle, GSK_PROTOCOL_TLSV1, GSK_PROTOCOL_TLSV1_OFF);
   rc = rc || gsk_attribute_set_enum(env->envHandle, GSK_PROTOCOL_TLSV1_1, GSK_PROTOCOL_TLSV1_1_OFF);
 
+  char *curves = settings->curves;
+  if (curves) {
+    rc = rc || gsk_attribute_set_buffer(env->envHandle, GSK_CLIENT_ECURVE_LIST, curves, 0);
+    if (!rc) {
+      zowelog(NULL, LOG_COMP_HTTPSERVER, ZOWE_LOG_DEBUG, "Curves set using gsk_attribute_set_buffer\n");
+    } else {
+      zowelog(NULL, LOG_COMP_HTTPSERVER, ZOWE_LOG_DEBUG, "Failure to set curves using gsk_attribute_set_buffer\n");
+    }
+  }
+
   int tlsMin = getTlsMin(settings);
   int tlsMax = getTlsMax(settings);
   if (tlsMax < tlsMin) {
@@ -233,6 +243,15 @@ int tlsSocketInit(TlsEnvironment *env, TlsSocket **outSocket, int fd, bool isSer
     zowelog(NULL, LOG_COMP_HTTPSERVER, ZOWE_LOG_DEBUG, "Ciphers set to %s\n", ciphers);
     rc = rc || gsk_attribute_set_buffer(socket->socketHandle, GSK_V3_CIPHER_SPECS_EXPANDED, ciphers, 0);
     rc = rc || gsk_attribute_set_enum(socket->socketHandle, GSK_V3_CIPHERS, GSK_V3_CIPHERS_CHAR4);
+  }
+  char *curves = env->settings->curves;
+  if (curves) {
+    rc = rc || gsk_attribute_set_buffer(socket->socketHandle, GSK_CLIENT_ECURVE_LIST, curves, 0);
+    if (!rc) {
+      zowelog(NULL, LOG_COMP_HTTPSERVER, ZOWE_LOG_DEBUG, "Curves set using gsk_attribute_set_buffer\n");
+    } else {
+      zowelog(NULL, LOG_COMP_HTTPSERVER, ZOWE_LOG_DEBUG, "Failure to set curves using gsk_attribute_set_buffer\n");
+    }
   }
   rc = rc || gsk_attribute_set_enum(socket->socketHandle, GSK_SESSION_TYPE, isServer ? GSK_SERVER_SESSION_WITH_CL_AUTH : GSK_CLIENT_SESSION);
 

--- a/c/tls.c
+++ b/c/tls.c
@@ -124,13 +124,15 @@ int tlsInit(TlsEnvironment **outEnv, TlsSettings *settings) {
   rc = rc || gsk_attribute_set_enum(env->envHandle, GSK_PROTOCOL_TLSV1_1, GSK_PROTOCOL_TLSV1_1_OFF);
 
   char *curves = settings->curves;
+  int curveRC = 0;
   if (curves) {
-    rc = rc || gsk_attribute_set_buffer(env->envHandle, GSK_CLIENT_ECURVE_LIST, curves, 0);
-    if (!rc) {
+    curveRC = gsk_attribute_set_buffer(env->envHandle, GSK_CLIENT_ECURVE_LIST, curves, 0);
+    if (!curveRC) {
       zowelog(NULL, LOG_COMP_HTTPSERVER, ZOWE_LOG_DEBUG, "Curves set using gsk_attribute_set_buffer\n");
     } else {
       zowelog(NULL, LOG_COMP_HTTPSERVER, ZOWE_LOG_DEBUG, "Failure to set curves using gsk_attribute_set_buffer\n");
     }
+    rc = rc || curveRC;
   }
 
   int tlsMin = getTlsMin(settings);
@@ -245,13 +247,15 @@ int tlsSocketInit(TlsEnvironment *env, TlsSocket **outSocket, int fd, bool isSer
     rc = rc || gsk_attribute_set_enum(socket->socketHandle, GSK_V3_CIPHERS, GSK_V3_CIPHERS_CHAR4);
   }
   char *curves = env->settings->curves;
+  int curveRC = 0;
   if (curves) {
-    rc = rc || gsk_attribute_set_buffer(socket->socketHandle, GSK_CLIENT_ECURVE_LIST, curves, 0);
-    if (!rc) {
+    curveRC = gsk_attribute_set_buffer(socket->socketHandle, GSK_CLIENT_ECURVE_LIST, curves, 0);
+    if (!curveRC) {
       zowelog(NULL, LOG_COMP_HTTPSERVER, ZOWE_LOG_DEBUG, "Curves set using gsk_attribute_set_buffer\n");
     } else {
       zowelog(NULL, LOG_COMP_HTTPSERVER, ZOWE_LOG_DEBUG, "Failure to set curves using gsk_attribute_set_buffer\n");
     }
+    rc = rc || curveRC;
   }
   rc = rc || gsk_attribute_set_enum(socket->socketHandle, GSK_SESSION_TYPE, isServer ? GSK_SERVER_SESSION_WITH_CL_AUTH : GSK_CLIENT_SESSION);
 

--- a/h/tls.h
+++ b/h/tls.h
@@ -136,6 +136,41 @@ typedef struct TlsSettings_tag {
   */
   char *maxTls;
   char *minTls;
+#define TLS_CURVE_RESERVED_DEFAULT "0000"
+#define TLS_CURVE_SECT163K1 "0001"
+#define TLS_CURVE_SECT163R1 "0002"
+#define TLS_CURVE_SECT163R2 "0003"
+#define TLS_CURVE_SECT193R1 "0004"
+#define TLS_CURVE_SECT193R2 "0005"
+#define TLS_CURVE_SECT233K1 "0006"
+#define TLS_CURVE_SECT233R1 "0007"
+#define TLS_CURVE_SECT239K1 "0008"
+#define TLS_CURVE_SECT283K1 "0009"
+#define TLS_CURVE_SECT283R1 "0010"
+#define TLS_CURVE_SECT409K1 "0011"
+#define TLS_CURVE_SECT409R1 "0012"
+#define TLS_CURVE_SECT571K1 "0013"
+#define TLS_CURVE_SECT571R1 "0014"
+#define TLS_CURVE_SECP160K1 "0015"
+#define TLS_CURVE_SECP160R1 "0016"
+#define TLS_CURVE_SECP160R2 "0017"
+#define TLS_CURVE_SECP192K1 "0018"
+#define TLS_CURVE_PRIME192V "0019"
+#define TLS_CURVE_SECP224K1 "0020"
+#define TLS_CURVE_SECP224R1 "0021"
+#define TLS_CURVE_SECP256K1 "0022"
+#define TLS_CURVE_SECP384R1 "0024"
+#define TLS_CURVE_PRIME256V1 "0023"
+#define TLS_CURVE_SECP521R1 "0025"
+#define TLS_CURVE_BRAINPOOLP256R1 "0026"
+#define TLS_CURVE_BRAINPOOLP384R1 "0027"
+#define TLS_CURVE_BRAINPOOLP512R1 "0028"
+#define TLS_CURVE_X25519 "0029"
+#define TLS_CURVE_X448 "0030"
+#define TLS_CURVE_BRAINPOOLP256R1TLS13 "0031"
+#define TLS_CURVE_BRAINPOOLP384R1TLS13 "0032"
+#define TLS_CURVE_BRAINPOOLP512R1TLS13 "0033"
+  char *curves;
 } TlsSettings;
 
 typedef struct TlsEnvironment_tag {
@@ -243,6 +278,75 @@ typedef struct CipherMap_tag {
     {"TLS_CHACHA20_POLY1305_SHA256", TLS_CHACHA20_POLY1305_SHA256},\
     {0, NULL}\
 };
+
+  typedef struct CurveMap_tag {
+  const char* name;
+  const char* groupId;  //number string
+} CurveMap;
+
+#define TLS_IANA_CURVE_MAP(ianaCurveMap)\
+  static const CurveMap ianaCurveMap[] = {\
+    {"secp192r1",TLS_CURVE_PRIME192V},\
+    {"NIST P-192",TLS_CURVE_PRIME192V},\
+    {"prime192v",TLS_CURVE_PRIME192V},\
+    {"secp224r1", TLS_CURVE_SECP224R1},\
+    {"NIST P-224", TLS_CURVE_SECP224R1},\
+    {"NIST P-256",TLS_CURVE_PRIME256V1},\
+    {"secp256r1",TLS_CURVE_PRIME256V1},\
+    {"prime256v1",TLS_CURVE_PRIME256V1},\
+    {"NIST P-384", TLS_CURVE_SECP384R1},\
+    {"secp384r1", TLS_CURVE_SECP384R1},\
+    {"NIST P-521", TLS_CURVE_SECP521R1},\
+    {"secp521r1", TLS_CURVE_SECP521R1},\
+    {"x25519", TLS_CURVE_X25519},\
+    {"x448", TLS_CURVE_X448},\
+    {0, NULL}\
+};
+
+/*
+  Currently, only the curves mentioned https://www.ibm.com/docs/en/zos/3.1.0?topic=programming-cipher-suite-definitions#csdcwh__tttcsd
+  are supported, if any curves are added in the future they should be added to the above array.
+
+    {"NIST K-163", TLS_CURVE_SECT163K1},\
+    {"NIST K-283", TLS_CURVE_SECT283K1},\
+    {"brainpoolP256r1", TLS_CURVE_BRAINPOOLP256R1},\
+    {"sect163k1", TLS_CURVE_SECT163K1},\
+    {"NIST K-163", TLS_CURVE_SECT163K1},\
+    {"sect163r2", TLS_CURVE_SECT163R2},\
+    {"NIST B-163", TLS_CURVE_SECT163R2},\
+    {"sect233k1", TLS_CURVE_SECT233K1},\
+    {"NIST K-233", TLS_CURVE_SECT233K1},\
+    {"sect233r1", TLS_CURVE_SECT233R1},\
+    {"NIST K-233", TLS_CURVE_SECT233R1},\
+    {"sect283k1", TLS_CURVE_SECT283K1},\
+    {"NIST K-283", TLS_CURVE_SECT283K1},\
+    {"sect283r1", TLS_CURVE_SECT283R1},\
+    {"NIST B-283", TLS_CURVE_SECT283R1},\
+    {"sect409k1", TLS_CURVE_SECT409K1},\
+    {"NIST K-409", TLS_CURVE_SECT409K1},\
+    {"sect409r1", TLS_CURVE_SECT409R1},\
+    {"NIST B-409", TLS_CURVE_SECT409R1},\
+    {"sect571k1", TLS_CURVE_SECT571K1},\
+    {"NIST K-571", TLS_CURVE_SECT571K1},\
+    {"sect571r1", TLS_CURVE_SECT571R1},\
+    {"NIST B-571", TLS_CURVE_SECT571R1},\
+    {"sect163r1", TLS_CURVE_SECT163R1},\
+    {"sect193r1", TLS_CURVE_SECT193R1},\
+    {"sect193r2", TLS_CURVE_SECT193R2},\
+    {"sect239k1", TLS_CURVE_SECT239K1},\
+    {"secp160k1", TLS_CURVE_SECP160K1},\
+    {"secp160r1", TLS_CURVE_SECP160R1},\
+    {"secp160r2", TLS_CURVE_SECP160R2},\
+    {"secp192k1", TLS_CURVE_SECP192K1},\
+    {"secp224k1", TLS_CURVE_SECP224K1},\
+    {"secp256k1", TLS_CURVE_SECP256K1},\
+    {"brainpoolP256r1", TLS_CURVE_BRAINPOOLP256R1},\
+    {"brainpoolP384r1", TLS_CURVE_BRAINPOOLP384R1},\
+    {"brainpoolP512r1", TLS_CURVE_BRAINPOOLP512R1},\
+    {"brainpoolP256r1tls13", TLS_CURVE_BRAINPOOLP256R1TLS13},\
+    {"brainpoolP384r1tls13", TLS_CURVE_BRAINPOOLP384R1TLS13},\
+    {"brainpoolP512r1tls13", TLS_CURVE_BRAINPOOLP512R1TLS13},\
+*/
 
 int tlsInit(TlsEnvironment **outEnv, TlsSettings *settings);
 int tlsDestroy(TlsEnvironment *env);

--- a/h/tls.h
+++ b/h/tls.h
@@ -281,7 +281,7 @@ typedef struct CipherMap_tag {
 
   typedef struct CurveMap_tag {
   const char* name;
-  const char* groupId;  //number string
+  const char* groupId;  //I.A.N.A Elliptic curve enumerator (number string)
 } CurveMap;
 
 #define TLS_IANA_CURVE_MAP(ianaCurveMap)\


### PR DESCRIPTION
## Proposed changes
'zowe.network.server.tls.curves' is an array a user can set in zowe.yaml to customize crypto curves. 
GSK handles curves as a string of 4 digit numbers(IANA numbers) back to back without any spaces or symbols in between.
Its very unfriendly to a human, so a mapping from names to numbers is needed, this is done in tls.h, for now only supported curves are in the array. Unsupported curves are commented and can be moved into this array as and when the supported curves are updated.

Curves are set during TLS settings initialization using gsk_attribute_set_buffer(), using 'GSK_CLIENT_ECURVE_LIST', see here
https://www.ibm.com/docs/en/zos/3.1.0?topic=reference-gsk-attribute-set-buffer for reference,

Currently, the supported curves are here, https://www.ibm.com/docs/en/zos/3.1.0?topic=programming-cipher-suite-definitions#csdcwh__tttcsd

Testing:
The curves that are not supported show an error in gsktrace as below, this was tested by adding some unsupported curves into the curve map array.
        ERROR set_binary_ecurves(): Elliptical curve 0001 not supported
        ERROR set_binary_ecurves(): Elliptical curve 0009 not supported
        ERROR set_binary_ecurves(): Elliptical curve 0026 not supported

To show the error in normal logs, only valid curves are in the mapping array. So if any invalid curve is mentioned in zowe.yaml an invalid curve message is logged.

zowe.network.server.tls.curves: ["x25519", "x448", "secp192r1", "secp224r1","prime256v1","secp384r1", "secp521r1"]
,
 is converted to number string  0029003000190021002300240025

This PR addresses Issue: https://github.com/zowe/zss/issues/713

## Type of change
Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Change in a documentation
- [ ] Refactor the code 
- [ ] Chore, repository cleanup, updates the dependencies.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zss/blob/v2.x/master/CONTRIBUTING.md))
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [ ] video or image is included if visual changes are made
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works, or describe a test method below
