### PR TITLE
Returning internal return code through function argument for 'httpClientSessionInit'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Zowe Common C Changelog
 
+## `2.19.0`
+- Adding more arguments to httpClientSessionInit to allow passing back rc (#467).
+
 ## `2.18.1`
 - Bugfix: IARV64 results must be checked for 0x7FFFF000 (#474)
 - Bugfix: SLH should not ABEND when MEMLIMIT is reached (additional NULL check)

--- a/c/httpclient.c
+++ b/c/httpclient.c
@@ -647,12 +647,14 @@ void httpClientSessionDestroy(HttpClientSession *session) {
 /**
  * After this call, an stcbase'd caller should 'register' the socket
  */
-int httpClientSessionInit(HttpClientContext *ctx, HttpClientSession **outSession) {
+int httpClientSessionInit2(HttpClientContext *ctx, HttpClientSession **outSession, int *rc) {
   int sts = 0;
-  int bpxrc = 0, bpxrsn = 0;
+  int bpxrsn = 0;
+  int *bpxrc = rc;
 
   HttpClientSession *session = NULL;
   ShortLivedHeap *slh = NULL;
+  *bpxrc = 0;
 
   do {
     if ((NULL == ctx) || (NULL == outSession)) {
@@ -660,13 +662,13 @@ int httpClientSessionInit(HttpClientContext *ctx, HttpClientSession **outSession
       break;
     }
 
-    Socket *socket = tcpClient2(ctx->serverAddress, 1000 * ctx->recvTimeoutSeconds, &bpxrc, &bpxrsn);
-    if ((bpxrc != 0) || (NULL == socket)) {
+    Socket *socket = tcpClient2(ctx->serverAddress, 1000 * ctx->recvTimeoutSeconds, bpxrc, &bpxrsn);
+    if ((*bpxrc != 0) || (NULL == socket)) {
 #ifdef __ZOWE_OS_ZOS
-      HTTP_CLIENT_TRACE_VERBOSE("%s (rc=%d, rsn=0x%x, addr=0x%08x, port=%d)\n", HTTP_CLIENT_MSG_CONNECT_FAILED, bpxrc,
+      HTTP_CLIENT_TRACE_VERBOSE("%s (rc=%d, rsn=0x%x, addr=0x%08x, port=%d)\n", HTTP_CLIENT_MSG_CONNECT_FAILED, *bpxrc,
                                 bpxrsn, ctx->serverAddress->v4Address, ctx->serverAddress->port);
 #else
-      HTTP_CLIENT_TRACE_VERBOSE("%s (rc=%d, rsn=0x%x, addr=0x%08x, port=%d)\n", HTTP_CLIENT_MSG_CONNECT_FAILED, bpxrc,
+      HTTP_CLIENT_TRACE_VERBOSE("%s (rc=%d, rsn=0x%x, addr=0x%08x, port=%d)\n", HTTP_CLIENT_MSG_CONNECT_FAILED, *bpxrc,
                                 bpxrsn, ctx->serverAddress->internalAddress.v4Address, ctx->serverAddress->port);
 #endif
       sts = HTTP_CLIENT_CONNECT_FAILED;
@@ -684,7 +686,7 @@ int httpClientSessionInit(HttpClientContext *ctx, HttpClientSession **outSession
     int rc = tlsSocketInit(ctx->tlsEnvironment, &socket->tlsSocket, socket->sd, false);
     if (rc != 0) {
       HTTP_CLIENT_TRACE_VERBOSE("failed to init tls socket, rc=%d, (%s)", rc, tlsStrError(rc));
-      socketClose(socket, &bpxrc, &bpxrsn);
+      socketClose(socket, bpxrc, &bpxrsn);
       sts = HTTP_CLIENT_TLS_ERROR;
       break;
     }

--- a/c/qjsnet.c
+++ b/c/qjsnet.c
@@ -189,6 +189,7 @@ static int httpGet(bool isTLS,
   int status = 0;
   char buffer[2048];
   LoggingContext *loggingContext = getLoggingContext();
+  int rc = 0;
 
   do{
     clientSettings.host = host;
@@ -216,7 +217,7 @@ static int httpGet(bool isTLS,
     if (httpTrace){
       printf("successfully initialized http client\n");
     }
-    status = httpClientSessionInit(httpClientContext, &session);
+    status = httpClientSessionInit2(httpClientContext, &session, &rc);
     if (status){
       if (httpTrace){
 	printf("error initing session: %d\n", status);

--- a/h/httpclient.h
+++ b/h/httpclient.h
@@ -121,7 +121,7 @@ int httpClientContextInitSecure(HttpClientSettings *settings,
 
 void httpClientSessionDestroy(HttpClientSession *session);
 
-int httpClientSessionInit(HttpClientContext *ctx, HttpClientSession **outSession);
+int httpClientSessionInit2(HttpClientContext *ctx, HttpClientSession **outSession, int *rc);
 
 int httpClientSessionStageRequest(HttpClientContext *ctx,
                                   HttpClientSession *session,


### PR DESCRIPTION

## Proposed changes
Function 'httpClientSessionInit' calls other functions inside it and the return codes for those calls are not availabe outside 'httpClientSessionInit'. Adding a return code as argument will solve this requirement.

This PR addresses Issue: https://github.com/zowe/zowe-common-c/issues/468

This PR depends upon the following PRs:

## Type of change
Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Change in a documentation
- [ ] Refactor the code 
- [ ] Chore, repository cleanup, updates the dependencies.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zss/blob/v2.x/master/CONTRIBUTING.md))
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] video or image is included if visual changes are made
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works, or describe a test method below
