### PR TITLE
Move debug messages out of the loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Zowe Common C Changelog
 
+## `2.18.0`
+- Minor `components.zss.logLevels._zss.httpserver=5` debug messages enhancement (#471)
+
 ## `2.17.0`
 - Fixed `xplatform.loadFileUTF8` when trying to open nonexistent file (#454)
 - Bugfix: fix an incorrect check in the recovery router code which might lead to

--- a/c/httpserver.c
+++ b/c/httpserver.c
@@ -2913,8 +2913,8 @@ int extractBearerToken(HttpRequest *request, HttpHeader *authHeader) {
   AUTH_TRACE("start tokenEnd loop\n");
   while ((tokenEnd < headerLength) && (ebcdicHeader[tokenEnd] > 0x041)){
     tokenEnd++;
-    zowelog(NULL, LOG_COMP_HTTPSERVER, ZOWE_LOG_DEBUG3, "tokenEnd=%d\n", tokenEnd);
   }
+  zowelog(NULL, LOG_COMP_HTTPSERVER, ZOWE_LOG_DEBUG3, "tokenEnd=%d\n", tokenEnd);
   const int tokenLen = tokenEnd - tokenStart;
   AUTH_TRACE("bearer token length = %d\n", tokenLen);
 

--- a/c/httpserver.c
+++ b/c/httpserver.c
@@ -2846,9 +2846,9 @@ int extractBasicAuth(HttpRequest *request, HttpHeader *authHeader){
     char *authString = NULL;
     AUTH_TRACE("start authEnd loop\n");
     while ((authEnd < headerLength) && (ebcdicHeader[authEnd] > 0x041)){
-      zowelog(NULL, LOG_COMP_HTTPSERVER, ZOWE_LOG_DEBUG3, "authEnd=%d\n",authEnd);
       authEnd++;
     }
+    zowelog(NULL, LOG_COMP_HTTPSERVER, ZOWE_LOG_DEBUG3, "authEnd=%d\n",authEnd);
     authLen = authEnd-authStart;
     encodedAuthString = SLHAlloc(slh,authLen+1);
     authString = SLHAlloc(slh,authLen+1);


### PR DESCRIPTION
## Proposed changes

Move 2 `ZOWE_LOG_DEBUG3` messages out of the loops.

This PR addresses Issue: https://github.com/zowe/zowe-common-c/issues/463

## Type of change
- [x] Refactor the code 

## PR Checklist
- [x] My code follows the style guidelines of this project

VERSION: 2.18.0
CHANGELOG: Minor `components.zss.logLevels._zss.httpserver=5` debug messages enhancement