### PR TITLE
IARV64 results need to be checked for 0x7FFFF000

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Zowe Common C Changelog
 
+## `2.18.1`
+- Bugfix: IARV64 results must be checked for 0x7FFFF000 (#474)
+
 ## `2.18.0`
 - Minor `components.zss.logLevels._zss.httpserver=5` debug messages enhancement (#471)
 

--- a/c/alloc.c
+++ b/c/alloc.c
@@ -181,7 +181,12 @@ static char* __ptr64 getmain64(long long sizeInMegabytes, int *returnCode, int *
 
    if (returnCode) *returnCode = macroRetCode;
    if (reasonCode) *reasonCode = macroResCode;
-  
+
+  // IARV64 returns 0x7FFFF000 when MEMLIMIT is reached
+  if (data == (void *)0x7FFFF000) {
+    data = NULL;
+  }
+
    return data;
 
 }
@@ -202,7 +207,12 @@ static char* __ptr64 getmain64ByToken(long long sizeInMegabytes, long long token
 
   if (returnCode) *returnCode = macroRetCode;
   if (reasonCode) *reasonCode = macroResCode;
-  
+
+  // IARV64 returns 0x7FFFF000 when MEMLIMIT is reached
+  if (data == (void *)0x7FFFF000) {
+    data = NULL;
+  }
+
   return data;
   
 }


### PR DESCRIPTION

## Proposed changes

When MEMLIMIT is reached, IARV64 GETSTOR returns 0x7FFFF000; this conditions needs to be checked before memsetting.


<!-- Thank you for submitting a PR to Zowe! To help us understand, test, and give feedback on your code, please fill in the details below. -->

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

This PR addresses Issue: #474


## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Change in a documentation
- [ ] Refactor the code 
- [ ] Chore, repository cleanup, updates the dependencies.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zss/blob/v2.x/master/CONTRIBUTING.md))
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [ ] video or image is included if visual changes are made
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works, or describe a test method below

## Testing

See #474

