### PR TITLE
SLHAlloc must return NULL when internal allocations fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## `2.18.1`
 - Bugfix: IARV64 results must be checked for 0x7FFFF000 (#474)
+- Bugfix: SLH should not ABEND when MEMLIMIT is reached (additional NULL check)
 
 ## `2.18.0`
 - Minor `components.zss.logLevels._zss.httpserver=5` debug messages enhancement (#471)

--- a/c/utils.c
+++ b/c/utils.c
@@ -1502,6 +1502,7 @@ char *SLHAlloc(ShortLivedHeap *slh, int size){
                       safeMalloc31(size+4,"SLH Oversize Extend"));
     if (bigBlock == NULL){
       reportSLHFailure(slh,size);
+      return NULL;
     }
     int *sizePtr = (int*)bigBlock;
     *sizePtr = size;
@@ -1528,6 +1529,7 @@ char *SLHAlloc(ShortLivedHeap *slh, int size){
                   safeMalloc31(slh->blockSize+4,"SLH Extend") );
     if (data == NULL){
       reportSLHFailure(slh,size);
+      return NULL;
     }
     int *sizePtr = (int*)data;
     *sizePtr = slh->blockSize;


### PR DESCRIPTION


<!-- Thank you for submitting a PR to Zowe! To help us understand, test, and give feedback on your code, please fill in the details below. -->

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

The SLHAlloc function keeps using the results of the internal allocations even when they're NULL which leads to S0C4 ABENDs. This commit makes SLHAlloc return NULL when the internal allocations fail.

This PR depends upon the following PRs: https://github.com/zowe/zowe-common-c/pull/475

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Change in a documentation
- [ ] Refactor the code 
- [ ] Chore, repository cleanup, updates the dependencies.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zss/blob/v2.x/master/CONTRIBUTING.md))
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] video or image is included if visual changes are made
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works, or describe a test method below

## Testing
<!-- Describe how this code should be tested. I've you've added an automated or unit test, then describe how to run it. Otherwise, describe how you have tested it and how others should test it. -->

Write an application which uses SLHAlloc; exhaust storage by reaching MEMLIMIT; SLHAlloc calls must return NULL and not ABEND.
