### PR TITLE
IARV64 results need to be checked for 0x7FFFF000 (Zowe v3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## `3.0.0`
 - Add support for LE 64-bit in isgenq.c (#422).
+- Bugfix: IARV64 results must be checked for 0x7FFFF000 (#474)
 
 ## `2.17.0`
 - Fixed `xplatform.loadFileUTF8` when trying to open nonexistent file (#454)

--- a/c/alloc.c
+++ b/c/alloc.c
@@ -181,7 +181,12 @@ static char* __ptr64 getmain64(long long sizeInMegabytes, int *returnCode, int *
 
    if (returnCode) *returnCode = macroRetCode;
    if (reasonCode) *reasonCode = macroResCode;
-  
+
+  // IARV64 returns 0x7FFFF000 when MEMLIMIT is reached
+  if (data == (void *)0x7FFFF000) {
+    data = NULL;
+  }
+
    return data;
 
 }
@@ -202,7 +207,12 @@ static char* __ptr64 getmain64ByToken(long long sizeInMegabytes, long long token
 
   if (returnCode) *returnCode = macroRetCode;
   if (reasonCode) *reasonCode = macroResCode;
-  
+
+  // IARV64 returns 0x7FFFF000 when MEMLIMIT is reached
+  if (data == (void *)0x7FFFF000) {
+    data = NULL;
+  }
+
   return data;
   
 }


### PR DESCRIPTION
This is a v3 version of https://github.com/zowe/zowe-common-c/pull/475.