### PR TITLE
SLHAlloc must return NULL when internal allocations fail (Zowe v3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## `3.1.0`
 - Feature: added javascript `zos.getStatvfs(path)` function to obtain file system information (#482).
+- Bugfix: SLH should not ABEND when MEMLIMIT is reached (additional NULL check)
 
 ## `3.0.0`
 - Add support for LE 64-bit in isgenq.c (#422).

--- a/c/utils.c
+++ b/c/utils.c
@@ -1502,6 +1502,7 @@ char *SLHAlloc(ShortLivedHeap *slh, int size){
                       safeMalloc31(size+4,"SLH Oversize Extend"));
     if (bigBlock == NULL){
       reportSLHFailure(slh,size);
+      return NULL;
     }
     int *sizePtr = (int*)bigBlock;
     *sizePtr = size;
@@ -1528,6 +1529,7 @@ char *SLHAlloc(ShortLivedHeap *slh, int size){
                   safeMalloc31(slh->blockSize+4,"SLH Extend") );
     if (data == NULL){
       reportSLHFailure(slh,size);
+      return NULL;
     }
     int *sizePtr = (int*)data;
     *sizePtr = slh->blockSize;


### PR DESCRIPTION
This is the v3 counterpart of https://github.com/zowe/zowe-common-c/pull/476.