### PR TITLE
Revert "Returning internal return code through function argument for 'httpClientSessionInit'"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,5 @@
 # Zowe Common C Changelog
 
-## `2.19.0`
-- Adding more arguments to httpClientSessionInit to allow passing back rc (#467).
-
 ## `2.18.1`
 - Bugfix: IARV64 results must be checked for 0x7FFFF000 (#474)
 - Bugfix: SLH should not ABEND when MEMLIMIT is reached (additional NULL check)

--- a/c/qjsnet.c
+++ b/c/qjsnet.c
@@ -189,7 +189,6 @@ static int httpGet(bool isTLS,
   int status = 0;
   char buffer[2048];
   LoggingContext *loggingContext = getLoggingContext();
-  int rc = 0;
 
   do{
     clientSettings.host = host;
@@ -217,7 +216,7 @@ static int httpGet(bool isTLS,
     if (httpTrace){
       printf("successfully initialized http client\n");
     }
-    status = httpClientSessionInit2(httpClientContext, &session, &rc);
+    status = httpClientSessionInit(httpClientContext, &session);
     if (status){
       if (httpTrace){
 	printf("error initing session: %d\n", status);

--- a/h/httpclient.h
+++ b/h/httpclient.h
@@ -121,7 +121,7 @@ int httpClientContextInitSecure(HttpClientSettings *settings,
 
 void httpClientSessionDestroy(HttpClientSession *session);
 
-int httpClientSessionInit2(HttpClientContext *ctx, HttpClientSession **outSession, int *rc);
+int httpClientSessionInit(HttpClientContext *ctx, HttpClientSession **outSession);
 
 int httpClientSessionStageRequest(HttpClientContext *ctx,
                                   HttpClientSession *session,


### PR DESCRIPTION
Reverts zowe/zowe-common-c#469.  The original API should have been retained and it can be implemented by calling the new API with a dummy argument for the return code.