### PR TITLE
`zos.getStatvfs` to obtain file system information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Zowe Common C Changelog
 
 ## `3.1.0`
-- Feature: added javascript `zos.getStatvfs(path)` function to obtain file system information (#???).
+- Feature: added javascript `zos.getStatvfs(path)` function to obtain file system information (#482).
 
 ## `3.0.0`
 - Add support for LE 64-bit in isgenq.c (#422).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Zowe Common C Changelog
 
+## `3.1.0`
+- Feature: added javascript `zos.getStatvfs(path)` function to obtain file system information (#???).
+
 ## `3.0.0`
 - Add support for LE 64-bit in isgenq.c (#422).
 - Bugfix: IARV64 results must be checked for 0x7FFFF000 (#474)


### PR DESCRIPTION
## Proposed changes
This PR addresses Issue: https://github.com/zowe/zowe-install-packaging/issues/807

A C function `statsvfs` wrapped in javascript. This function could be utilized to get status if the filesystem is mounted with `NOSUID` option.

```javascript
import * as zos from 'zos';
const result = zos.getStatvfs('/');
console.log(`Stats=${JSON.stringify(result[0])}`);
```

## Type of change
Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zss/blob/v2.x/master/CONTRIBUTING.md))
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings

## Testing
```javascript
import * as zos from 'zos';
import * as shell from '/zowe/bin/libs/shell';
const ST_NOSUID = 0x00000002;

function mountTestUnmount(fs, mp, security) {
    console.log(`FS=${fs} with ${security == '' ? 'no -s flag' : security}`);
    let result = shell.execSync('sh', '-c', `mount -t ZFS -f ${fs} ${security} -o aggrgrow ${mp}`);
    result = zos.getStatvfs(`${mp}`);
    if (result[1] == 0) {
        if ((result[0].flag & ST_NOSUID) != 0) {
            console.log('  NOSUID set!');
        } 
    }
    result = shell.execSync('sh', '-c', `unmount ${mp}`);
}

const PATHS = [
    './', '/', '/bin/',
    '', '/aaaaaaaaaaaaaaa',
    null, true, false, undefined, 0, -1, 800
];

for (let p = 0; p < PATHS.length; p++) {
    const result = zos.getStatvfs(PATHS[p]);
    console.log(`RC=${result[1]} for "${PATHS[p]}"`);
    if (result[0]) {
        console.log(`Stats=${JSON.stringify(result[0])}`);
    }
}

console.log('\n*** NOSUID test ***\n')

mountTestUnmount('ZOWE.ZFS', '/zowe', '');
mountTestUnmount('ZOWE.ZFS', '/zowe', '-s nosetuid');
mountTestUnmount('ZOWE.ZFS', '/zowe', '-s nosecurity');
```
```console
RC=0 for "./"
Stats={"bsize":1024,"blocks":4096080,"bavail":1781919,"fsid":4009,"flag":0,"frsize":1024,"bfree":1781919,"files":4294967295,"ffree":4294935683,"favail":4294935683,"namemax":255,"OEmaxfilesizehw":1023,"OEmaxfilesizelw":-1024,"OEusedspace":2314161,"OEinvarsec":0}
RC=0 for "/"
Stats={"bsize":1024,"blocks":3600,"bavail":3275,"fsid":1,"flag":1,"frsize":1024,"bfree":3275,"files":4294967295,"ffree":4294967244,"favail":4294967244,"namemax":255,"OEmaxfilesizehw":1023,"OEmaxfilesizelw":-1024,"OEusedspace":325,"OEinvarsec":0}
RC=0 for "/bin/"
Stats={"bsize":1024,"blocks":3954960,"bavail":159562,"fsid":2,"flag":1,"frsize":1024,"bfree":159562,"files":4294967295,"ffree":4294940191,"favail":4294940191,"namemax":255,"OEmaxfilesizehw":1023,"OEmaxfilesizelw":-1024,"OEusedspace":3795398,"OEinvarsec":0}
RC=129 for ""
RC=129 for "/aaaaaaaaaaaaaaa"
RC=129 for "null"
RC=129 for "true"
RC=129 for "false"
RC=129 for "undefined"
RC=129 for "0"
RC=129 for "-1"
RC=129 for "800"

*** NOSUID test ***

FS=ZOWE.ZFS with no -s flag
FS=ZOWE.ZFS with -s nosetuid
  NOSUID set!
FS=ZOWE.ZFS with -s nosecurity
  NOSUID set!
```
### Same stat, different method
```rexx
/* REXX */                                   
if syscalls('ON') = 0 then do                
  address syscall "statvfs '/' s."           
  say 'STFS_AVAIL     =' s.STFS_AVAIL        
  say 'STFS_BFREE     =' s.STFS_BFREE        
  say 'STFS_BLOCKSIZE =' s.STFS_BLOCKSIZE    
  say 'STFS_FAVAIL    =' s.STFS_FAVAIL       
  say 'STFS_FFREE     =' s.STFS_FFREE        
  say 'STFS_FILES     =' s.STFS_FILES        
  say 'STFS_FRSIZE    =' s.STFS_FRSIZE       
  say 'STFS_FSID      =' s.STFS_FSID         
  say 'STFS_INUSE     =' s.STFS_INUSE        
  say 'STFS_INVARSEC  =' s.STFS_INVARSEC     
  say 'STFS_NAMEMAX   =' s.STFS_NAMEMAX      
  say 'STFS_NOSEC     =' s.STFS_NOSEC        
  say 'STFS_NOSUID    =' s.STFS_NOSUID       
  say 'STFS_RDONLY    =' s.STFS_RDONLY       
  say 'STFS_TOTAL     =' s.STFS_TOTAL        
end                                          
```
### Comparing of `rexx` and `js` output
```
STFS_AVAIL     = 3275        	"bavail":3275
STFS_BFREE     = 3275        	"bfree":3275
STFS_BLOCKSIZE = 1024        	"bsize":1024,
STFS_FAVAIL    = 4294967244	"favail":4294967244  
STFS_FFREE     = 4294967244	"ffree":4294967244  
STFS_FILES     = 4294967295	"files":4294967295
STFS_FRSIZE    = 1024        	"frsize":1024
STFS_FSID      = 1           	"fsid":1
STFS_INUSE     = 325         	"OEusedspace":325
STFS_INVARSEC  = 0           	"OEinvarsec":0
STFS_NAMEMAX   = 255         	"namemax":255
STFS_NOSEC     = 0           	"flag":1 => Read-only file system 
STFS_NOSUID    = 0           	"flag":1 => Read-only file system
STFS_RDONLY    = 1          	"flag":1 => Read-only file system 
STFS_TOTAL     = 3600        	"blocks":3600
```