### PR TITLE
Hide `bos extend currSiz` debug message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Zowe Common C Changelog
 
 ## `3.1.0`
-- Bugfix: removed "ByteOutputStream" debug message, which was part of the `zwe` command output (#4??)
+- Bugfix: removed "ByteOutputStream" debug message, which was part of the `zwe` command output (#491)
 
 ## `3.0.0`
 - Feature: added javascript `zos.getStatvfs(path)` function to obtain file system information (#482).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Zowe Common C Changelog
 
+## `3.1.0`
+- Bugfix: removed "ByteOutputStream" debug message, which was part of the `zwe` command output (#4??)
+
 ## `3.0.0`
 - Feature: added javascript `zos.getStatvfs(path)` function to obtain file system information (#482).
 - Add support for LE 64-bit in isgenq.c (#422).

--- a/c/yaml2json.c
+++ b/c/yaml2json.c
@@ -731,8 +731,10 @@ ByteOutputStream *makeByteOutputStream(int chunkSize){
 int bosWrite(ByteOutputStream *bos, char *data, int dataSize){
   if (bos->size+dataSize > bos->capacity){
     int extendSize = (bos->chunkSize > dataSize) ? bos->chunkSize : dataSize;
+#ifdef NDEBUG
     printf("bos extend currSize=0x%x dataSize=0x%x chunk=0x%x extend=0x%x\n",
            bos->size,dataSize,bos->chunkSize,extendSize);
+#endif
     int newCapacity = bos->capacity + extendSize;
     char *newData = safeMalloc(newCapacity,"BOS extend");
     memcpy(newData,bos->data,bos->size);


### PR DESCRIPTION
<!-- Thank you for submitting a PR to Zowe! To help us understand, test, and give feedback on your code, please fill in the details below. -->

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

This PR addresses Issue: 
* #490 
* https://github.com/zowe/zowe-install-packaging/issues/4005

When the config file is above 4KB, it is processed by chunks. There is a debug message showing this information and is routed to `stdout`, which makes scripting challenging. See testing.

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## PR Checklist
Please delete options that are not relevant.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline]
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works, or describe a test method below

## Testing

Run the command with old and new `configmgr`.

### Script
```shell
#!/bin/sh

echo "Without fix"
ls -al ./utils/configmgr
result=$(./zwe internal config get -p "zowe.setup.vsam.storageClass" -c ./zowe.yaml)
echo "result=$result"

mv ./utils/configmgr ./utils/configmgr.backup
cp /martin/git/repos/commonC.bos/bin/configmgr  ./utils/configmgr

echo ""

echo "With fix"
ls -al ./utils/configmgr

result=$(./zwe internal config get -p "zowe.setup.vsam.storageClass" -c ./zowe.yaml)
echo "result=$result"

rm ./utils/configmgr
mv ./utils/configmgr.backup ./utils/configmgr

```
### Result
Note: _The expected output is empty string._
```
Without fix
-rwxr-xr-x   1 MARTIN  DEFAULT  4493312 Sep 25 03:43 ./utils/configmgr
result=bos extend currSize=0x0 dataSize=0x1531 chunk=0x1000 extend=0x1531

With fix
-rwxr-xr-x   1 MARTIN  DEFAULT  4489216 Sep 25 04:49 ./utils/configmgr
result=
```
