### PR TITLE
Return null for no output

### DIFF
--- a/c/qjszos.c
+++ b/c/qjszos.c
@@ -344,7 +344,7 @@ static JSValue zosDatasetInfo(JSContext *ctx, JSValueConst this_val,
   if (trace){
     printf("entrySet=0x%p\n",entrySet);
   }
-  if (!entrySet){
+  if (!entrySet || entrySet->length == 0){
     return JS_NULL;
   }
   char *resumeName = returnParms->resume_name;


### PR DESCRIPTION
<!-- Thank you for submitting a PR to Zowe! To help us understand, test, and give feedback on your code, please fill in the details below. -->

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

`zos.dsinfo` is returning `null` for empty string, object with empty array for invalid input and object with data for valid input. This is not a good practice. Return `null` when no data otherwise return object.

This PR addresses Issue: #493 

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zss/blob/v2.x/master/CONTRIBUTING.md))
- [x] My changes generate no new warnings


## Testing

### Without fix, see #493 

### With fix
```
zos.dslist()=null
zos.dslist(null)=null
zos.dslist(undefined)=null
zos.dslist(0)=null
zos.dslist(apple,banana,orange)=null
zos.dslist(false)=null
zos.dslist(sys1.maclib)=null
zos.dslist(SYS1.PARMLIB)={"datasets":[{"dsn":"SYS1.PARMLIB","entryType":"A"}]}
zos.dslist(SYS1.MACLIB)={"datasets":[{"dsn":"SYS1.MACLIB","entryType":"A"}]}
```
## Additional information
The `zos.dslist(sys1.maclib)=null` is questionable. Do we want to be so strict is `javascript`?