### PR TITLE
Add use new caa location to configmgr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## `3.1.0`
 - Bugfix: removed "ByteOutputStream" debug message, which was part of the `zwe` command output (#491)
+- Bugfix: HEAPPOOLS and HEAPPOOLS64 no longer need to be set to OFF for configmgr (#497)
 
 ## `3.0.0`
 - Feature: added javascript `zos.getStatvfs(path)` function to obtain file system information (#482).

--- a/build/build_cmgr_xlclang.sh
+++ b/build/build_cmgr_xlclang.sh
@@ -100,6 +100,7 @@ xlclang \
   -D_OPEN_THREADS=1 \
   -DNOIBMHTTP=1 \
   -DUSE_ZOWE_TLS=1 \
+  -DNEW_CAA_LOCATIONS=1 \
   -DCMGRTEST=1 \
   -I "${COMMON}/h" \
   -I "${COMMON}/platform/posix" \


### PR DESCRIPTION
Other build scripts have been using "-DNEW_CAA_LOCATIONS=1" but not configmgr.
I believe this should allow configmgr to work with heappools being on, without any drawbacks.

How to test:

Before:
```
 _CEE_RUNOPTS="HEAPPOOLS(ON),HEAPPOOLS64(ON)" ./configmgr -h
CEE3204S The system detected a protection exception (System Completion Code=0C4).
         From compile unit ZZOW08:/ZOWE/tmp/pax-packaging-configmgr-1723644907470/content/build/../c/logging.c at entry point logConfigureDestination at statement 436 at compile unit offset +000000003C6B6C56 at entry offset +00000000000001CE at address
         000000003C6B6C56.
Segmentation fault
```

After:
```
_CEE_RUNOPTS="HEAPPOOLS(ON),HEAPPOOLS64(ON)" ./configmgr -h

 *** unknown option *** '-h'
Usage:
  configmgr [options] <command> <args>
    options
      -h                  : show help
      -script <path>      : quickjs-compatible javascript file to run with configmgr utilities
      -t <level>          : enable tracing with level from 1-3
      -o <outStream>      : OUT|ERR , ERR is default
      -s <path:path...>   : <topSchema>(:<referencedSchema)+
      -w <path>           : workspace directory
      -c                  : compact output for jq and extract commands
      -r                  : raw string output for jq and extract commands
      -m <memberName>     : member name to find the zowe config in each PARMLIBs specified
      -p <configPath>     : list of colon-separated configPathElements - see below
    commands:
      extract <jsonPath>  : prints value to stdout
      validate            : just loads and validates merged configuration
      env <outEnvPath>    : prints merged configuration to a file as a list of environment vars
    configPathElement:
      PARMLIB(datasetName) - a library that can contain config data
      FILE(filename)   - the name of a file containing Yaml
      PARMLIBS         - all PARMLIBS that are defined to this running Program in ZOS, nothing if not on ZOS
```