### PR TITLE
Adding httpClientSessionInitv2 which through an argument will give the internal return code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,13 @@
 - Bugfix: removed "ByteOutputStream" debug message, which was part of the `zwe` command output (#491)
 - Bugfix: HEAPPOOLS and HEAPPOOLS64 no longer need to be set to OFF for configmgr (#497)
 - Enhancement: module registry (#405)
+- Enhancement:  Adding more arguments to httpClientSessionInit to allow passing back internal rc and
+  removing the reference from changelog in `3.0.0`. (#499).
 
 ## `3.0.0`
 - Feature: added javascript `zos.getStatvfs(path)` function to obtain file system information (#482).
 - Add support for LE 64-bit in isgenq.c (#422).
 - Bugfix: IARV64 results must be checked for 0x7FFFF000 (#474)
-- Adding more arguments to httpClientSessionInit to allow passing back rc (#467).
 - Bugfix: SLH should not ABEND when MEMLIMIT is reached (additional NULL check)
 - Bugfix: support cross-memory server parameters longer than 128 characters 
   (zowe/zss#684)

--- a/c/httpclient.c
+++ b/c/httpclient.c
@@ -647,9 +647,20 @@ void httpClientSessionDestroy(HttpClientSession *session) {
 /**
  * After this call, an stcbase'd caller should 'register' the socket
  */
+
 int httpClientSessionInit(HttpClientContext *ctx, HttpClientSession **outSession) {
+  int rc = 0;
+  int ret = 0;
+
+  rc = httpClientSessionInitv2(ctx, outSession, &ret); // 'ret' is a dummy arugment just to call v2
+
+  return rc;
+}
+
+int httpClientSessionInitv2(HttpClientContext *ctx, HttpClientSession **outSession, int *rc) {
   int sts = 0;
-  int bpxrc = 0, bpxrsn = 0;
+  int bpxrsn = 0;
+  int *bpxrc = rc;
 
   HttpClientSession *session = NULL;
   ShortLivedHeap *slh = NULL;
@@ -660,13 +671,13 @@ int httpClientSessionInit(HttpClientContext *ctx, HttpClientSession **outSession
       break;
     }
 
-    Socket *socket = tcpClient2(ctx->serverAddress, 1000 * ctx->recvTimeoutSeconds, &bpxrc, &bpxrsn);
-    if ((bpxrc != 0) || (NULL == socket)) {
+    Socket *socket = tcpClient2(ctx->serverAddress, 1000 * ctx->recvTimeoutSeconds, bpxrc, &bpxrsn);
+    if ((*bpxrc != 0) || (NULL == socket)) {
 #ifdef __ZOWE_OS_ZOS
-      HTTP_CLIENT_TRACE_VERBOSE("%s (rc=%d, rsn=0x%x, addr=0x%08x, port=%d)\n", HTTP_CLIENT_MSG_CONNECT_FAILED, bpxrc,
+      HTTP_CLIENT_TRACE_VERBOSE("%s (rc=%d, rsn=0x%x, addr=0x%08x, port=%d)\n", HTTP_CLIENT_MSG_CONNECT_FAILED, *bpxrc,
                                 bpxrsn, ctx->serverAddress->v4Address, ctx->serverAddress->port);
 #else
-      HTTP_CLIENT_TRACE_VERBOSE("%s (rc=%d, rsn=0x%x, addr=0x%08x, port=%d)\n", HTTP_CLIENT_MSG_CONNECT_FAILED, bpxrc,
+      HTTP_CLIENT_TRACE_VERBOSE("%s (rc=%d, rsn=0x%x, addr=0x%08x, port=%d)\n", HTTP_CLIENT_MSG_CONNECT_FAILED, *bpxrc,
                                 bpxrsn, ctx->serverAddress->internalAddress.v4Address, ctx->serverAddress->port);
 #endif
       sts = HTTP_CLIENT_CONNECT_FAILED;
@@ -684,7 +695,7 @@ int httpClientSessionInit(HttpClientContext *ctx, HttpClientSession **outSession
     int rc = tlsSocketInit(ctx->tlsEnvironment, &socket->tlsSocket, socket->sd, false);
     if (rc != 0) {
       HTTP_CLIENT_TRACE_VERBOSE("failed to init tls socket, rc=%d, (%s)", rc, tlsStrError(rc));
-      socketClose(socket, &bpxrc, &bpxrsn);
+      socketClose(socket, bpxrc, &bpxrsn);
       sts = HTTP_CLIENT_TLS_ERROR;
       break;
     }

--- a/c/qjsnet.c
+++ b/c/qjsnet.c
@@ -189,6 +189,7 @@ static int httpGet(bool isTLS,
   int status = 0;
   char buffer[2048];
   LoggingContext *loggingContext = getLoggingContext();
+  int rc = 0;
 
   do{
     clientSettings.host = host;
@@ -216,7 +217,7 @@ static int httpGet(bool isTLS,
     if (httpTrace){
       printf("successfully initialized http client\n");
     }
-    status = httpClientSessionInit(httpClientContext, &session);
+    status = httpClientSessionInitv2(httpClientContext, &session, &rc);
     if (status){
       if (httpTrace){
 	printf("error initing session: %d\n", status);

--- a/h/httpclient.h
+++ b/h/httpclient.h
@@ -123,6 +123,8 @@ void httpClientSessionDestroy(HttpClientSession *session);
 
 int httpClientSessionInit(HttpClientContext *ctx, HttpClientSession **outSession);
 
+int httpClientSessionInitv2(HttpClientContext *ctx, HttpClientSession **outSession, int *rc);
+
 int httpClientSessionStageRequest(HttpClientContext *ctx,
                                   HttpClientSession *session,
                                   char *method,   /* required, e.g. GET, PUT, POST */


### PR DESCRIPTION

## Problem
httpClientSessionInit has its own set of status values it returns, but the actual rc/rsn of commands it does within are hidden behind compile-time printf statements.
This is unhelpful because this function does fail sometimes, and on zOS the reason is opaque and requires a GSK trace to then discover the cause. It just costs extra debug time then.

## Proposed changes
Here we have httpClientSessionInit to  httpClientSessionInitv2 to allow passing back internal rc. The original api still exists and calls the new version by passing a dummy argument.

This PR addresses Issue: https://github.com/zowe/zowe-common-c/issues/468


## Type of change
Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zss/blob/v2.x/master/CONTRIBUTING.md))
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings



