### PR TITLE
Help should not require a parameter

### DIFF
--- a/c/configmgr.c
+++ b/c/configmgr.c
@@ -1675,7 +1675,7 @@ static int simpleMain(int argc, char **argv){
 
   while (argx < argc){
     char *optionValue = NULL;
-    if (getStringOption(argc,argv,&argx,"-h")){
+    if (strcmp(argv[argx], "-h") == 0) {
       showHelp(traceOut);
       return 0;
     } else if ((optionValue = getStringOption(argc,argv,&argx,"-s")) != NULL){


### PR DESCRIPTION
## Without fix
```
/zowe/runtime/bin/utils/configmgr -h

 *** unknown option *** '-h'
Usage:
  configmgr [options] <command> <args>
    options
      -h                  : show help
      -script <path>      : quickjs-compatible javascript file to run with configmgr utilities
      -t <level>          : enable tracing with level from 1-3
      -o <outStream>      : OUT|ERR , ERR is default
      -s <path:path...>   : <topSchema>(:<referencedSchema)+
      -w <path>           : workspace directory
      -c                  : compact output for jq and extract commands
      -r                  : raw string output for jq and extract commands
      -m <memberName>     : member name to find the zowe config in each PARMLIBs specified
      -p <configPath>     : list of colon-separated configPathElements - see below
    commands:
      extract <jsonPath>  : prints value to stdout
      validate            : just loads and validates merged configuration
      env <outEnvPath>    : prints merged configuration to a file as a list of environment vars
    configPathElement:
      PARMLIB(datasetName) - a library that can contain config data
      FILE(filename)   - the name of a file containing Yaml
      PARMLIBS         - all PARMLIBS that are defined to this running Program in ZOS, nothing if not on ZOS

echo $?
12
```
## With fix
Missing ` *** unknown option *** '-h'` in the output and `echo $? -> 0`

## Note
`-c` and `-r` are flags too, but also using `getStringOption()`. This might need some review too.