### PR TITLE
[TEST] quickjs with profiling enabled

### DIFF
--- a/.github/workflows/build-configmgr.yml
+++ b/.github/workflows/build-configmgr.yml
@@ -131,9 +131,9 @@ jobs:
       - name: '[Dep 2] Quickjs'
         uses: actions/checkout@v3
         with:
-          repository: JoeNemo/quickjs-portable
+          repository: MarkAckert/quickjs-profiling
           path: deps/configmgr/quickjs
-          ref: 'main'
+          ref: 'profiling-portable'
 
       - name: '[Prep 2] Setup jFrog CLI'
         uses: jfrog/setup-jfrog-cli@v2

--- a/.github/workflows/build-rexxconfigmgr.yml
+++ b/.github/workflows/build-rexxconfigmgr.yml
@@ -47,9 +47,9 @@ jobs:
       - name: '[Dep 2] Quickjs'
         uses: actions/checkout@v3
         with:
-          repository: joenemo/quickjs-portable
+          repository: MarkAckert/quickjs-profiling
           path: deps/configmgr/quickjs
-          ref: 'main'
+          ref: 'profiling-portable'
 
       - name: '[Prep 2] Setup jFrog CLI'
         uses: jfrog/setup-jfrog-cli@v2

--- a/build/build_cmgr_xlclang.sh
+++ b/build/build_cmgr_xlclang.sh
@@ -3,9 +3,9 @@
 # This program and the accompanying materials are
 # made available under the terms of the Eclipse Public License v2.0 which accompanies
 # this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
-# 
+#
 # Copyright Contributors to the Zowe Project.
 
 WORKING_DIR=$(cd $(dirname "$0") && pwd)
@@ -32,7 +32,6 @@ date_stamp=$(date +%Y%m%d%S)
 TMP_DIR="${WORKING_DIR}/tmp-${date_stamp}"
 
 mkdir -p "${TMP_DIR}" && cd "${TMP_DIR}"
-
 
 # Split version into parts
 OLDIFS=$IFS
@@ -68,6 +67,8 @@ xlclang \
   -D_OPEN_SYS_FILE_EXT=1 \
   -D_XOPEN_SOURCE=600 \
   -D_OPEN_THREADS=1 \
+  -DUSE_BF_DEC \
+  -DCONFIG_PROFILE_CALLS \
   -DCONFIG_VERSION=\"2021-03-27\" \
   -I "${DEPS_DESTINATION}/${LIBYAML}/include" \
   -I "${DEPS_DESTINATION}/${QUICKJS}" \
@@ -82,6 +83,7 @@ xlclang \
   ${DEPS_DESTINATION}/${QUICKJS}/cutils.c \
   ${DEPS_DESTINATION}/${QUICKJS}/quickjs.c \
   ${DEPS_DESTINATION}/${QUICKJS}/quickjs-libc.c \
+  ${DEPS_DESTINATION}/${QUICKJS}/libbf.c \
   ${DEPS_DESTINATION}/${QUICKJS}/libunicode.c \
   ${DEPS_DESTINATION}/${QUICKJS}/libregexp.c \
   ${DEPS_DESTINATION}/${QUICKJS}/porting/polyfill.c
@@ -102,6 +104,7 @@ xlclang \
   -DUSE_ZOWE_TLS=1 \
   -DNEW_CAA_LOCATIONS=1 \
   -DCMGRTEST=1 \
+  -DCONFIG_PROFILE_CALLS \
   -I "${COMMON}/h" \
   -I "${COMMON}/platform/posix" \
   -I ${GSKINC} \
@@ -119,6 +122,7 @@ xlclang \
   cutils.o \
   quickjs.o \
   quickjs-libc.o \
+  libbf.o \
   libunicode.o \
   libregexp.o \
   polyfill.o \
@@ -167,11 +171,10 @@ xlclang \
 
 rm -rf "${TMP_DIR}"
 
-
 # This program and the accompanying materials are
 # made available under the terms of the Eclipse Public License v2.0 which accompanies
 # this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
-# 
+#
 # Copyright Contributors to the Zowe Project.

--- a/build/configmgr.proj.env
+++ b/build/configmgr.proj.env
@@ -3,8 +3,8 @@ VERSION=3.1.0
 DEPS="QUICKJS LIBYAML"
 
 QUICKJS="quickjs"
-QUICKJS_SOURCE="git@github.com:JoeNemo/quickjs-portable.git"
-QUICKJS_BRANCH="main"
+QUICKJS_SOURCE="git@github.com:MarkAckert/quickjs-profiling.git"
+QUICKJS_BRANCH="profiling-portable"
 
 LIBYAML="libyaml"
 LIBYAML_SOURCE="git@github.com:yaml/libyaml.git"

--- a/c/embeddedjs.c
+++ b/c/embeddedjs.c
@@ -2056,6 +2056,39 @@ JSModuleDef *ejsModuleLoader(JSContext *ctx,
   return m;
 }
 
+#ifdef CONFIG_PROFILE_CALLS
+void profile_function_start(JSContext *ctx, JSAtom func, JSAtom filename, void *opaque) {
+    const char* func_str = JS_AtomToCString(ctx, func);
+    const char *func_str2 = func_str[0] ? func_str : "<anonymous>";
+    FILE *logfile = (FILE *)opaque;
+    // Format documented here:
+    // https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview?tab=t.0#heading=h.yr4qxyxotyw
+    fprintf(logfile, "{"
+            "\"name\": \"%s\","
+            "\"cat\": \"js\","
+            "\"ph\": \"B\","
+            "\"ts\": %ld,"
+            "\"pid\": 1,"
+            "\"tid\": 1"
+        "},\n", func_str2, clock());
+    JS_FreeCString(ctx, func_str);
+}
+void profile_function_end(JSContext *ctx, JSAtom func, JSAtom filename, void *opaque) {
+    const char* func_str = JS_AtomToCString(ctx, func);
+    const char *func_str2 = func_str[0] ? func_str : "<anonymous>";
+    FILE *logfile = (FILE *)opaque;
+    fprintf(logfile, "{"
+            "\"name\": \"%s\","
+            "\"cat\": \"js\","
+            "\"ph\": \"E\","
+            "\"ts\": %ld,"
+            "\"pid\": 1,"
+            "\"tid\": 1"
+        "},\n", func_str2, clock());
+    JS_FreeCString(ctx, func_str);
+}
+#endif
+
 bool configureEmbeddedJS(EmbeddedJS *embeddedJS, 
                          EJSNativeModule **nativeModules, int nativeModuleCount,
                          int argc, char **argv){
@@ -2086,7 +2119,7 @@ bool configureEmbeddedJS(EmbeddedJS *embeddedJS,
   /* profiling */
   embeddedJS->profile_file = fopen("profile_data.json", "w");
   embeddedJS->profile_sampling = 1;
-  JS_EnableProfileCalls(embeddedJS->rt, profile_function_start, profile_function_end, profile_sampling, profile_file);
+  JS_EnableProfileCalls(embeddedJS->rt, profile_function_start, profile_function_end, embeddedJS->profile_sampling, embeddedJS->profile_file);
   fprintf(profile_file, "{\"traceEvents\": [")
 #endif
 

--- a/c/embeddedjs.c
+++ b/c/embeddedjs.c
@@ -2085,7 +2085,7 @@ bool configureEmbeddedJS(EmbeddedJS *embeddedJS,
 #ifdef CONFIG_PROFILE_CALLS
   /* profiling */
   embeddedJS->profile_file = fopen("profile_data.json", "w");
-  embeddedJS->profileSampling = 1;
+  embeddedJS->profile_sampling = 1;
   JS_EnableProfileCalls(embeddedJS->rt, profile_function_start, profile_function_end, profile_sampling, profile_file);
   fprintf(profile_file, "{\"traceEvents\": [")
 #endif

--- a/c/embeddedjs.c
+++ b/c/embeddedjs.c
@@ -111,10 +111,6 @@ struct EmbeddedJS_tag {
   int traceLevel;
 };
 
-#ifdef CONFIG_PROFILE_CALLS
-  FILE *profile_file = fopen("profile_data.json", "w");
-#endif
-
 struct JSValueBox_tag {
   JSValue value;
 };
@@ -2121,10 +2117,11 @@ bool configureEmbeddedJS(EmbeddedJS *embeddedJS,
 
 #ifdef CONFIG_PROFILE_CALLS
   /* profiling */
+  FILE *profile_file = fopen("profile_out.json", "w");
   embeddedJS->profile_file = profile_file;
   embeddedJS->profile_sampling = 1;
   JS_EnableProfileCalls(embeddedJS->rt, profile_function_start, profile_function_end, embeddedJS->profile_sampling, embeddedJS->profile_file);
-  fprintf(profile_file, "{\"traceEvents\": [")
+  fprintf(profile_file, "{\"traceEvents\": [");
 #endif
 
   /* loader for ES6 modules */

--- a/c/embeddedjs.c
+++ b/c/embeddedjs.c
@@ -8,6 +8,7 @@
   Copyright Contributors to the Zowe Project.
 */
 
+
 #ifdef METTLE 
 
 #include <metal/metal.h>
@@ -99,6 +100,10 @@ struct EmbeddedJS_tag {
   LongHashtable *nativeClassTable;
 #ifdef CONFIG_BIGNUM
   int load_jscalc;
+#endif
+#ifdef CONFIG_PROFILE_CALLS
+    FILE *profile_file; /* = NULL; */
+    uint32_t profile_sampling; /* = 1; */;
 #endif
   size_t stack_size; /* = 0; */
   void *userPointer;
@@ -2076,6 +2081,14 @@ bool configureEmbeddedJS(EmbeddedJS *embeddedJS,
   }
   /* how to do this workers, is still not well explored */
   initContextModules(ctx,nativeModules,nativeModuleCount);
+
+#ifdef CONFIG_PROFILE_CALLS
+  /* profiling */
+  embeddedJS->profile_file = fopen("profile_data.json", "w");
+  embeddedJS->profileSampling = 1;
+  JS_EnableProfileCalls(embeddedJS->rt, profile_function_start, profile_function_end, profile_sampling, profile_file);
+  fprintf(profile_file, "{\"traceEvents\": [")
+#endif
 
   /* loader for ES6 modules */
   JS_SetModuleLoaderFunc(embeddedJS->rt, NULL, ejsModuleLoader, NULL);

--- a/c/embeddedjs.c
+++ b/c/embeddedjs.c
@@ -111,6 +111,10 @@ struct EmbeddedJS_tag {
   int traceLevel;
 };
 
+#ifdef CONFIG_PROFILE_CALLS
+  FILE *profile_file = fopen("profile_data.json", "w");
+#endif
+
 struct JSValueBox_tag {
   JSValue value;
 };
@@ -2117,7 +2121,7 @@ bool configureEmbeddedJS(EmbeddedJS *embeddedJS,
 
 #ifdef CONFIG_PROFILE_CALLS
   /* profiling */
-  embeddedJS->profile_file = fopen("profile_data.json", "w");
+  embeddedJS->profile_file = profile_file;
   embeddedJS->profile_sampling = 1;
   JS_EnableProfileCalls(embeddedJS->rt, profile_function_start, profile_function_end, embeddedJS->profile_sampling, embeddedJS->profile_file);
   fprintf(profile_file, "{\"traceEvents\": [")

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -67,7 +67,7 @@ libyaml:
 	git clone git@github.com:yaml/libyaml.git
 
 quickjs-portable:	
-	git clone git@github.com:JoeNemo/quickjs-portable.git
+	git clone -b profiling-portable git@github.com:MarkAckert/quickjs-profiling.git
 
 prepare: libyaml quickjs-portable
 	


### PR DESCRIPTION
Upstream quickjs pull request 371 enables profiling which includes some coverage information in its output. Goal is to see if we can use this to enable line coverage for zwe tests.

I used a new fork to merge code changes from quickjs-portable into the upstream PR.