### PR TITLE
Fix a memory leak in getUseridByExternalInfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## `3.2.0`
 - Bugfix: allocate storage to be executed with EXECUTABLE=YES (#507)
+- Bugfix: fix a leak in the rsusermap code (#467)
 
 ## `3.1.0`
 - Enhancement: `configmgr extract` option supports simple array (#502)

--- a/c/rusermap.c
+++ b/c/rusermap.c
@@ -115,6 +115,7 @@ static int getUseridByExternalInfo(int functionCode,
     } 
     break;
   default:
+    FREE_STRUCT31(STRUCT31_NAME(parms31));
     return RUSERMAP_BAD_FUNCTION_CODE;
   }
 


### PR DESCRIPTION

<!-- Thank you for submitting a PR to Zowe! To help us understand, test, and give feedback on your code, please fill in the details below. -->

## Proposed changes

The PR adds a missing `FREE_STRUCT31` macro invocation to the branch taken when a bad function code is passed to `getUseridByExternalInfo`.

This PR addresses Issue: #467


## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zss/blob/v2.x/master/CONTRIBUTING.md))
- [x] New and existing unit tests pass locally with my changes
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings

## Testing
<!-- Describe how this code should be tested. I've you've added an automated or unit test, then describe how to run it. Otherwise, describe how you have tested it and how others should test it. -->
Regression testing of the `getUseridByExternalInfo` function in `c/rsusermap.c` is needed.

