### PR TITLE
Allocate executable storage properly (v2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Bugfix: support cross-memory server parameters longer than 128 characters (zowe/zss#684)
 - Bugfix: HEAPPOOLS and HEAPPOOLS64 no longer need to be set to OFF for configmgr (#498)
 - Bugfix: make sure CEE3ERP is invoked in LE 31-bit XPLINK (#503)
+- Bugfix: allocate storage to be executed with EXECUTABLE=YES (#512)
 
 ## `2.18.0`
 - Minor `components.zss.logLevels._zss.httpserver=5` debug messages enhancement (#471)

--- a/c/cmutils.c
+++ b/c/cmutils.c
@@ -324,6 +324,16 @@ void cmFree(void *data, unsigned int size, int subpool, int key) {
   cmFree2(&data, size, subpool, key);
 }
 
+void *cmAllocExec(unsigned int size, int subpool, int key) {
+  void *data = NULL;
+  cmAlloc2Exec(size, subpool, key, &data);
+  return data;
+}
+
+void cmFreeExec(void *data, unsigned int size, int subpool, int key) {
+  cmFree2Exec(&data, size, subpool, key);
+}
+
 void cmAlloc2(unsigned int size, int subpool, int key, void **resultPtr) {
 
   *resultPtr = NULL;
@@ -377,6 +387,64 @@ void cmFree2(void **dataPtr, unsigned int size, int subpool, int key) {
       : [size]"NR:r0"(size), [storageAddr]"r"(localData),
         [sp]"r"(subpool), [key]"r"(key)
       : "r0", "r1", "r14", "r15"
+  );
+
+}
+
+void cmAlloc2Exec(unsigned int size, int subpool, int key, void **resultPtr) {
+
+  *resultPtr = NULL;
+  key <<= 4;
+
+  // Note: Used ADDR= option so STORAGE macro stores the address (for use by
+  // recovery) a few instructions sooner than the compiler would.
+#ifndef _LP64
+#define ROFF "0"
+#else
+#define ROFF "4"
+#endif
+
+  __asm(
+      ASM_PREFIX
+      "         STORAGE OBTAIN"
+      ",COND=YES"
+      ",LENGTH=(%[size])"
+      ",ADDR="ROFF"(,%[resultPtr])"
+      ",SP=(%[sp])"
+      ",LOC=31"
+      ",OWNER=SYSTEM"
+      ",KEY=(%[key])"
+      ",EXECUTABLE=YES"
+      ",LINKAGE=SYSTEM                                                         \n"
+      : [result]"=m"(*resultPtr)
+      : [size]"NR:r0"(size), [sp]"r"(subpool), [key]"r"(key),
+        [resultPtr]"r"(resultPtr)
+      : "r1", "r14", "r15"
+  );
+
+
+}
+
+void cmFree2Exec(void **dataPtr, unsigned int size, int subpool, int key) {
+
+  void *localData = *dataPtr;
+  *dataPtr = NULL;
+  key <<= 4;
+
+  __asm(
+      ASM_PREFIX
+      "         STORAGE RELEASE"
+      ",COND=NO"
+      ",LENGTH=(%[size])"
+      ",SP=(%[sp])"
+      ",ADDR=(%[storageAddr])"
+      ",KEY=(%[key])"
+      ",EXECUTABLE=YES"
+      ",LINKAGE=SYSTEM                                                         \n"
+      :
+      : [size]"NR:r0"(size), [storageAddr]"r"(localData),
+        [sp]"r"(subpool), [key]"r"(key)
+      : "r1", "r14", "r15"
   );
 
 }

--- a/c/crossmemory.c
+++ b/c/crossmemory.c
@@ -2165,6 +2165,14 @@ static void freeECSAStorage(void *data, unsigned int size) {
   cmFree(data, size, CROSS_MEMORY_SERVER_SUBPOOL, CROSS_MEMORY_SERVER_KEY);
 }
 
+static void *allocateECSAStorageExec(unsigned int size) {
+  return cmAllocExec(size, CROSS_MEMORY_SERVER_SUBPOOL, CROSS_MEMORY_SERVER_KEY);
+}
+
+static void freeECSAStorageExec(void *data, unsigned int size) {
+  cmFreeExec(data, size, CROSS_MEMORY_SERVER_SUBPOOL, CROSS_MEMORY_SERVER_KEY);
+}
+
 static void allocateECSAStorage2(unsigned int size,
                                  void **resultPtr) {
 
@@ -3103,11 +3111,10 @@ static CMSLookupRoutineAnchor *makeLookupRoutineAnchor(void) {
             anchorLength, sizeof(CMSLookupRoutineAnchor));
     return NULL;
   }
-  // TODO if the cmutils alloc functions are changed to allocate non-executable
-  //  storage, this call will need to change
-  CMSLookupRoutineAnchor *anchor = cmAlloc(sizeof(CMSLookupRoutineAnchor),
-                                           CMS_LOOKUP_ANCHOR_SUBPOOL,
-                                           CMS_LOOKUP_ANCHOR_KEY);
+
+  CMSLookupRoutineAnchor *anchor = cmAllocExec(sizeof(CMSLookupRoutineAnchor),
+                                               CMS_LOOKUP_ANCHOR_SUBPOOL,
+                                               CMS_LOOKUP_ANCHOR_KEY);
   if (anchor == NULL) {
     zowelog(NULL, LOG_COMP_ID_CMS, ZOWE_LOG_DEBUG,
             CMS_LOG_DEBUG_MSG_ID" Alloc failed for look-up anchor\n");
@@ -3147,8 +3154,8 @@ static CMSLookupRoutineAnchor *makeLookupRoutineAnchor(void) {
 }
 
 static void deleteLookupRoutineAnchor(CMSLookupRoutineAnchor *anchor) {
-  cmFree(anchor, anchor->size, CMS_LOOKUP_ANCHOR_SUBPOOL,
-         CMS_LOOKUP_ANCHOR_KEY);
+  cmFreeExec(anchor, anchor->size, CMS_LOOKUP_ANCHOR_SUBPOOL,
+             CMS_LOOKUP_ANCHOR_KEY);
 }
 
 static int discardLookupRoutineAnchor(CrossMemoryServer *server) {
@@ -4635,7 +4642,7 @@ static int installResourceManager(CrossMemoryServerGlobalArea *globalArea, Resou
         resmgrRoutine, resmgrRoutineSize);
     zowedump(NULL, LOG_COMP_ID_CMS, ZOWE_LOG_DEBUG, resmgrRoutine, resmgrRoutineSize);
 
-    resmgrRoutineInECSA = allocateECSAStorage(resmgrRoutineSize);
+    resmgrRoutineInECSA = allocateECSAStorageExec(resmgrRoutineSize);
     if (resmgrRoutineInECSA == NULL) {
       zowelog(NULL, LOG_COMP_ID_CMS, ZOWE_LOG_SEVERE, CMS_LOG_RESMGR_ECSA_FAILURE_MSG, resmgrRoutineSize);
       status = RC_CMS_ECSA_ALLOC_FAILED;
@@ -4651,7 +4658,7 @@ static int installResourceManager(CrossMemoryServerGlobalArea *globalArea, Resou
       int createTokenRC = nameTokenCreatePersistent(NAME_TOKEN_LEVEL_SYSTEM, &resmgrRoutineNTName, &resmgrRoutineNTToken.token);
       if (createTokenRC != 0) {
         zowelog(NULL, LOG_COMP_ID_CMS, ZOWE_LOG_SEVERE, CMS_LOG_RESMGR_NT_NOT_CREATED_MSG, createTokenRC);
-        freeECSAStorage(resmgrRoutineInECSA, resmgrRoutineSize);
+        freeECSAStorageExec(resmgrRoutineInECSA, resmgrRoutineSize);
         resmgrRoutineInECSA = NULL;
         status = RC_CMS_NAME_TOKEN_CREATE_FAILED;
       }

--- a/c/qsam.c
+++ b/c/qsam.c
@@ -40,6 +40,16 @@ char *malloc24(int size){
   return data;
 }
 
+static void *malloc24Exec(int size) {
+  char *data;
+  __asm(ASM_PREFIX
+        " STORAGE OBTAIN,LENGTH=(%[length]),LOC=24,EXECUTABLE=YES\n"
+        : [address]"=NR:r1"(data)
+        : [length]"NR:r0"(size)
+        : "r14", "r15");
+  return data;
+}
+
 static char *malloc31(int size){
   char *data;
   __asm(ASM_PREFIX
@@ -59,6 +69,15 @@ char *free24(char *data, int size){
         :"r15");
   /* printf("succeed\n"); */
   return NULL;
+}
+
+static void free24Exec(void *data, int size) {
+  __asm(ASM_PREFIX
+      " STORAGE RELEASE,LENGTH=(%[length]),ADDR=(%[address]),CALLRKY=YES"
+      ",EXECUTABLE=YES\n"
+      :
+      : [length]"NR:r0"(size), [address]"NR:r1"(data)
+      : "r14", "r15");
 }
 
 static void free31(void *data, int size){
@@ -446,7 +465,7 @@ static int openCloseBBQ(char *dcb, int mode, int svc){
        reqDcb->dcb.Common.macroFormat != DCB_MACRF_EXCP &&
        reqDcb->dcb.BBQCommon.blksize_s <= 0) {
 
-      openexitData = (openexitData_t *)malloc24(sizeof(openexitData_t));
+      openexitData = malloc24Exec(sizeof(openexitData_t));
       memset(openexitData,0,sizeof(openexitData_t));
 
    /* If a block size of -2 is specified as the value for the block
@@ -766,7 +785,7 @@ static int openCloseBBQ(char *dcb, int mode, int svc){
 
     if (openexitData){
       reqDcb->dcb.Common.exlst = (unsigned int)NULL;
-      free24((char *)openexitData,sizeof(openexitData_t));
+      free24Exec(openexitData,sizeof(openexitData_t));
     }
   } else{
     __asm(ASM_PREFIX

--- a/h/cmutils.h
+++ b/h/cmutils.h
@@ -47,6 +47,10 @@
 #define cmFree CMFREE
 #define cmAlloc2 CMALLOC2
 #define cmFree2 CMFREE2
+#define cmAllocExec CMALLCX
+#define cmFreeExec CMFREEX
+#define cmAlloc2Exec CMALLC2X
+#define cmFree2Exec CMFREE2X
 
 #define makeCrossMemoryMap CMUMKMAP
 #define removeCrossMemoryMap CMURMMAP
@@ -209,6 +213,30 @@ void *cmAlloc(unsigned int size, int subpool, int key);
 void cmFree(void *data, unsigned int size, int subpool, int key);
 
 /**
+ * @brief Allocates executable storage. The function can be used in cross-memory
+ * mode.
+ *
+ * @param size Size of the storage.
+ * @param subpool Subpool of the storage.
+ * @param key Key of the storage
+ * @return The address of the storage in case of success, NULL if the request
+ * has failed.
+ */
+void *cmAllocExec(unsigned int size, int subpool, int key);
+
+/**
+ * @brief Releases executable  storage. The call is unconditional, that is, it
+ * will ABEND
+ * if bad storage is passed. The function can be used in cross-memory mode.
+ *
+ * @param data Storage to be released.
+ * @param size Size of the storage.
+ * @param subpool Subpool of the storage.
+ * @param key Key of the storage.
+ */
+void cmFreeExec(void *data, unsigned int size, int subpool, int key);
+
+/**
  * @brief Allocates storage. The function can be used in cross-memory mode.
  *
  * This version should be used in code which uses recovery as the window between
@@ -240,6 +268,41 @@ void cmAlloc2(unsigned int size, int subpool, int key, void **resultPtr);
  * @param key Key of the storage.
  */
 void cmFree2(void **dataPtr, unsigned int size, int subpool, int key);
+
+/**
+ * @brief Allocates executable storage. The function can be used in cross-memory
+ * mode.
+ *
+ * This version should be used in code which uses recovery as the window between
+ * the actual allocation and returning the result is much smaller than in
+ * cmAlloc.
+ *
+ * @param size Size of the storage.
+ * @param subpool Subpool of the storage.
+ * @param key Key of the storage.
+ * @param resultPtr Pointer to the result address of the storage. The pointer is
+ * set to NULL if the request fails.
+ */
+void cmAlloc2Exec(unsigned int size, int subpool, int key, void **resultPtr);
+
+/**
+ * @brief Releases executable storage. The function can be used in cross-memory
+ * mode.
+ *
+ * The call is unconditional, that is, it will ABEND if bad storage is passed.
+ * This version should be used in code which uses recovery as it first sets
+ * the provided address to NULL and then releases the storage, whereby
+ * helping to prevent double-free. If an ABEND happens in between setting
+ * provided address to NULL and releasing the storage, the storage will be
+ * leaked.
+ *
+ * @param dataPtr Pointer to the address of the storage to be released. It will
+ * be set to NULL.
+ * @param size Size of the storage.
+ * @param subpool Subpool of the storage.
+ * @param key Key of the storage.
+ */
+void cmFree2Exec(void **dataPtr, unsigned int size, int subpool, int key);
 
 typedef struct CrossMemoryMap_tag CrossMemoryMap;
 


### PR DESCRIPTION
<!-- Thank you for submitting a PR to Zowe! To help us understand, test, and give feedback on your code, please fill in the details below. -->

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

Some storage that is intended to be executed is not allocated with the `EXECUTABLE=YES` option, can lead to ABENDs when certain z/OS options are set.

This PR changes the code which allocates such storage to allocate it with `EXECUTABLE=YES`.


## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)


## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zss/blob/v2.x/master/CONTRIBUTING.md))
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings


## Testing
<!-- Describe how this code should be tested. I've you've added an automated or unit test, then describe how to run it. Otherwise, describe how you have tested it and how others should test it. -->

You will need a z/OS system where the special diagnostics for non-executable storage has been enabled.

Do the following: 
* Regression testing of ZIS;
* Cancel a ZIS instance to trigger the address space resource manager; no ABENDs should occur.
