### PR TITLE
Use single-line WTOs for single-line messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## `3.2.0`
 - Bugfix: allocate storage to be executed with EXECUTABLE=YES (#507)
 - Bugfix: fix a leak in the rsusermap code (#467)
+- Bugfix: use single-line WTOs for single-line messages (#509)
 
 ## `3.1.0`
 - Enhancement: `configmgr extract` option supports simple array (#502)

--- a/c/crossmemory.c
+++ b/c/crossmemory.c
@@ -237,6 +237,40 @@ typedef struct MultilineWTOHandle_tag {
   MultilineWTONLine lines[0];
 } MultilineWTOHandle;
 
+typedef struct SinglelineWTOLine_tag {
+#define SINGLELINE_WTO_MAX_LEN 126
+#define SINGLELINE_WTO_VERSION 2
+  unsigned short length;
+  unsigned short flags;
+  char text[SINGLELINE_WTO_MAX_LEN];
+  unsigned char version;
+  unsigned char miscFlags;
+  unsigned char replyLength;
+  unsigned char wpxLength;
+  unsigned short extendedFlags;
+  char reserved2[2];
+  char * __ptr32 replyBuffer;
+  int  * __ptr32 replyECB;
+  unsigned int connectID;
+  unsigned short descriptorCodes;
+  char reserved3[2];
+  char extendedRoutingCodes[16];
+  unsigned short messageType;
+  unsigned short messagePriority;
+  char jobID[8];
+  char jobName[8];
+  char retrievalKey[8];
+  unsigned int tokenForDOM;
+  unsigned int consoleID;
+  char systemName[8];
+  char consoleName[8];
+  void * __ptr32 replyConsoleID;
+  void * __ptr32 cart;
+  void * __ptr32 wsparm;
+} SinglelineWTOLine;
+
+#define WTO_EXT_FLAG_CONSID_SPECIFIED 0x4000
+
 ZOWE_PRAGMA_PACK_RESET
 
 static MultilineWTOHandle *wtoGetMultilineHandle(unsigned int maxLineCount) {
@@ -309,8 +343,6 @@ static void wtoAddLine(MultilineWTOHandle *handle, const char *formatString, ...
 
 static void wtoPrintMultilineMessage(MultilineWTOHandle *handle, int consoleID, CART cart) {
 
-#define WTO_EXT_FLAG_CONSID_SPECIFIED 0x4000
-
   MultilineWTONLine *finalLine = &handle->lines[handle->lineCount];
   handle->firstLine.consoleID = consoleID;
   if (consoleID != 0) {
@@ -339,23 +371,53 @@ static void wtoRemoveMultilineHandle(MultilineWTOHandle *handle) {
   handle = NULL;
 }
 
-void wtoPrintf2(int consoleID, CART cart, char *formatString, ...) {
+static void wtoPrintSinglelineMessage(const char text[], size_t textLen,
+                                      int consoleID, CART cart) {
 
-  MultilineWTOHandle *handle = wtoGetMultilineHandle(4);
-  if (handle == NULL) {
-    return;
+  SinglelineWTOLine line = {
+    .length = sizeof(line.text) + 4,
+    .flags = WTO_EXTENDED_WPL,
+    .version = SINGLELINE_WTO_VERSION,
+  };
+
+  memset(line.text, ' ', sizeof(line.text));
+  memcpy(line.text, text, min(sizeof(line.text), textLen));
+
+  memset(line.jobID, ' ', sizeof(line.jobID));
+  memset(line.jobName, ' ', sizeof(line.jobName));
+  memset(line.retrievalKey, ' ', sizeof(line.retrievalKey));
+  memset(line.systemName, ' ', sizeof(line.systemName));
+  memset(line.consoleName, ' ', sizeof(line.consoleName));
+
+  line.consoleID = consoleID;
+  if (consoleID != 0) {
+    line.extendedFlags = WTO_EXT_FLAG_CONSID_SPECIFIED;
   }
 
-  char text[sizeof(handle->firstLine.text)];
+  line.cart = &cart;
+
+  __asm(
+      "         XGR   0,0                                                      \n"
+      "         WTO   MF=(E,(%[parm]))                                         \n"
+      :
+      : [parm]"r"(&line)
+      : "r0", "r1", "r14", "r15"
+  );
+
+}
+
+void wtoPrintf2(int consoleID, CART cart, char *formatString, ...) {
+
+  char text[SINGLELINE_WTO_MAX_LEN + 1];
   va_list argPointer;
   va_start(argPointer,formatString);
-  vsnprintf(text, sizeof(text), formatString, argPointer);
+  int charsPrinted = vsnprintf(text, sizeof(text), formatString, argPointer);
   va_end(argPointer);
 
-  wtoAddLine(handle, text);
-  wtoPrintMultilineMessage(handle, consoleID, cart);
-  wtoRemoveMultilineHandle(handle);
-  handle = NULL;
+  if (charsPrinted >= 0) {
+    wtoPrintSinglelineMessage(text, min(charsPrinted, SINGLELINE_WTO_MAX_LEN),
+                              consoleID, cart);
+  }
 
 }
 


### PR DESCRIPTION


## Proposed changes

This pull-request adjusts the `wtoPtintf2` function, which is intended for printing single-line messages, to use the proper WTO call and issue single-line WTO messages.

This PR addresses Issue: #509


## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zss/blob/v2.x/master/CONTRIBUTING.md))
- [x] New and existing unit tests pass locally with my changes
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings

## Testing
<!-- Describe how this code should be tested. I've you've added an automated or unit test, then describe how to run it. Otherwise, describe how you have tested it and how others should test it. -->
* Start our ZIS;
* Verify that, in the JESMSGLG log, the ZIS single-line WTO messages like `ZWES0109I` have **no** numbers at the end:
```
incorrect:    ZWES0109I Core server ready 690
correct:      ZWES0109I Core server ready
```
* Multi-line messages (e.g., `ZWES0200I`) should still have the numbers indicating multiple-lines:
```
08.39.55 S0442115  ZWES0200I Modify commands:  165
   165                        DISPLAY [OPTION_NAME] - Print service information
   165                          OPTION_NAME:
   165                            CONFIG - Print server configuration information (defau
   165                        FLUSH   - Print all pending log messages
   165                        LOG <COMP_ID> <LOG_LEVEL> - Set log level
   165                          COMP_ID:
   165                            CMS   - Cross memory server
   165                            CMSPC - PC routines
   165                            STC   - STC base
   165                          LOG_LEVEL:
   165                            SEVERE
   165                            WARNING
   165                            INFO
   165                            DEBUG
   165                            DEBUG2
   165                            DEBUG3
```

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, or if there are follow-up tasks and TODOs etc... -->
