### PR TITLE
[DO NOT MERGE] Cross memory server name is 72 chars now

### DIFF
--- a/h/crossmemory.h
+++ b/h/crossmemory.h
@@ -152,7 +152,7 @@ extern const char *CMS_RC_DESCRIPTION[];
 ZOWE_PRAGMA_PACK
 
 typedef struct CrossMemoryServerName_tag {
-  char nameSpacePadded[16];
+  char nameSpacePadded[CMS_CONFIG_PARM_MAX_NAME_LENGTH];
 } CrossMemoryServerName;
 
 #ifndef __LONGNAME__

--- a/h/crossmemory.h
+++ b/h/crossmemory.h
@@ -4,9 +4,9 @@
   This program and the accompanying materials are
   made available under the terms of the Eclipse Public License v2.0 which accompanies
   this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
-  
+
   SPDX-License-Identifier: EPL-2.0
-  
+
   Copyright Contributors to the Zowe Project.
 */
 
@@ -146,6 +146,9 @@
 #define RC_CMS_CONFIG_VALUE_BUF_TOO_SMALL   95
 #define RC_CMS_MODREG_FAILED                96
 #define RC_CMS_MAX_RC                       96
+
+#define CMS_CONFIG_PARM_MAX_NAME_LENGTH   72
+#define CMS_CONFIG_PARM_MAX_VALUE_SIZE    128
 
 extern const char *CMS_RC_DESCRIPTION[];
 
@@ -387,9 +390,6 @@ typedef enum CrossMemoryServerParmType_tag {
 } CrossMemoryServerParmType;
 #pragma enum(reset)
 
-#define CMS_CONFIG_PARM_MAX_NAME_LENGTH   72
-#define CMS_CONFIG_PARM_MAX_VALUE_SIZE    128
-
 typedef struct CrossMemoryServerConfigParm_tag {
   char eyecatcher[8];
 #define CMS_PARM_EYECATCHER "RSCMSCFG"
@@ -538,7 +538,7 @@ int cmsCallService3(CrossMemoryServerGlobalArea *cmsGlobalArea,
  */
 int cmsPrintf(const CrossMemoryServerName *serverName, const char *formatString, ...);
 
-/* 
+/*
    @brief the var-args version of cmsPrintf, see above
  */
 int vcmsPrintf(const CrossMemoryServerName *serverName, const char *formatString, va_list argPointer);
@@ -1184,9 +1184,9 @@ typedef struct CMSDynlinkEnv_tag {
   This program and the accompanying materials are
   made available under the terms of the Eclipse Public License v2.0 which accompanies
   this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
-  
+
   SPDX-License-Identifier: EPL-2.0
-  
+
   Copyright Contributors to the Zowe Project.
 */
 


### PR DESCRIPTION
The Cross Memory Server name was expanded to 72 chars.
```
ZWES0101I 00000000  0059C4C5 C2E4C76B D5C1D4C5 7EE9E6F2 |..DEBUG,NAME=ZW2|
ZWES0101I 00000010  6DC1C1C1 C1C1C1C1 C1C1C1C1 C1C1C1C1 |_AAAAAAAAAAAAAAA|
ZWES0101I 00000020  C1C1C1C1 C1C1C1C1 C1C1C1C1 C1C1C1C1 |AAAAAAAAAAAAAAAA|
ZWES0101I 00000030  C1C1C1C1 C1C1C1C1 C1C1C1C1 C1C3C3C3 |AAAAAAAAAAAAACCC|
ZWES0101I 00000040  C3C3C3C3 C3C3C4C3 C3C3C3C3 C3C3C3C3 |CCCCCCDCCCCCCCCC|
ZWES0101I 00000050  C3C3C3C3 6BD4C5D4 7EF0F0            |CCCC,MEM=00|
ZWES0004I Server name is 'ZW2_AAAAAAAAAAAA'
```

Message `ZWES0004I` is printing hardcoded length of 16.