### PR TITLE
Properly initialize the WTO parm list for single-line WTOs

### DIFF
--- a/c/crossmemory.c
+++ b/c/crossmemory.c
@@ -378,6 +378,7 @@ static void wtoPrintSinglelineMessage(const char text[], size_t textLen,
     .length = sizeof(line.text) + 4,
     .flags = WTO_EXTENDED_WPL,
     .version = SINGLELINE_WTO_VERSION,
+    .wpxLength = 104, // from the WTO list form macro
   };
 
   memset(line.text, ' ', sizeof(line.text));


### PR DESCRIPTION


<!-- Thank you for submitting a PR to Zowe! To help us understand, test, and give feedback on your code, please fill in the details below. -->

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

One of the fields in the WTO parameter list for single-line WTOs was not set properly which would lead to missing overlay messages in, e.g., SDSF. This PR fixes that.

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zss/blob/v2.x/master/CONTRIBUTING.md))
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings

## Testing
<!-- Describe how this code should be tested. I've you've added an automated or unit test, then describe how to run it. Otherwise, describe how you have tested it and how others should test it. -->

For testing, SDSF will be needed.

* Start ZIS
* Issue `F zisstc,D`
* You should get an overlay message with the following text (at least): `RESPONSE=xxxx      ZWES0220I Modify D command received`



