### PR TITLE
Add blocking option for httpclient

### DIFF
--- a/c/bpxskt.c
+++ b/c/bpxskt.c
@@ -397,7 +397,19 @@ Socket *tcpClient4(SocketAddress *socketAddress,
         writeTimeout.tv_usec = (long)((writeTimeoutInMillis % 1000UL)*1000UL);
 
         setSocketOption(socket, SOL_SOCKET, SOCK_SO_RCVTIMEO, sizeof(struct timeval), (char*)&readTimeout, returnCode, reasonCode);
+        if (returnCode) {
+          if (socketTrace) {
+            printf("Failed to set read timeout for socket. rc=0x%x, rsn=0x%x\n", returnCode, reasonCode);
+          }
+          return NULL;
+        }
         setSocketOption(socket, SOL_SOCKET, SOCK_SO_SNDTIMEO, sizeof(struct timeval), (char*)&writeTimeout, returnCode, reasonCode);
+        if (returnCode) {
+          if (socketTrace) {
+            printf("Failed to set write timeout for socket. rc=0x%x, rsn=0x%x\n", returnCode, reasonCode);
+          }
+          return NULL;
+        }
         setSocketBlockingMode(socket, TRUE, returnCode, reasonCode);
       } else {
         setSocketBlockingMode(socket, FALSE, returnCode, reasonCode);

--- a/c/bpxskt.c
+++ b/c/bpxskt.c
@@ -14,10 +14,12 @@
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
+#include <sys/time.h>
 #include "zowetypes.h"
 #include "alloc.h"
 #include "utils.h"
 #include "bpxnet.h"
+
 
 #ifdef USE_RS_SSL
 #include "rs_ssl.h"
@@ -222,6 +224,7 @@ int getSocketDebugID(Socket *s){
 Socket *tcpClient4(SocketAddress *socketAddress,
          int connectTimeoutInMillis,
          int readTimeoutInMillis,
+         int writeTimeoutInMillis,
          int tlsFlags,
          int *returnCode,
          int *reasonCode) {
@@ -369,8 +372,32 @@ Socket *tcpClient4(SocketAddress *socketAddress,
       /* manual says returnCode and value only meaningful if return value = -1 */
       *returnCode = 0;
       *reasonCode = 0;
+
+      if (readTimeoutInMillis > 0 && writeTimeoutInMillis <= 0) {
+        writeTimeoutInMillis = readTimeoutInMillis;
+        if (socketTrace){
+          printf("Cannot set write timeout without read timeout. Read timeout value set to write timeout value\n");
+        }
+      }
+      if (writeTimeoutInMillis > 0 && readTimeoutInMillis <= 0) {
+        readTimeoutInMillis = writeTimeoutInMillis;
+        if (socketTrace){
+          printf("Cannot set read timeout without write timeout. Write timeout value set to read timeout value\n");
+        }
+      }
+
       if (readTimeoutInMillis >= 0) {
-        setSocketOption(socket, SOL_SOCKET, SOCK_SO_RCVTIMEO, sizeof(int), (char*)&readTimeoutInMillis, returnCode, reasonCode);
+        struct timeval readTimeout;
+        struct timeval writeTimeout;
+
+        readTimeout.tv_sec = (long)(readTimeoutInMillis / 1000UL);
+        readTimeout.tv_usec = (long)((readTimeoutInMillis % 1000UL)*1000UL);
+
+        writeTimeout.tv_sec = (long)(writeTimeoutInMillis / 1000UL);
+        writeTimeout.tv_usec = (long)((writeTimeoutInMillis % 1000UL)*1000UL);
+
+        setSocketOption(socket, SOL_SOCKET, SOCK_SO_RCVTIMEO, sizeof(struct timeval), (char*)&readTimeout, returnCode, reasonCode);
+        setSocketOption(socket, SOL_SOCKET, SOCK_SO_SNDTIMEO, sizeof(struct timeval), (char*)&writeTimeout, returnCode, reasonCode);
         setSocketBlockingMode(socket, TRUE, returnCode, reasonCode);
       } else {
         setSocketBlockingMode(socket, FALSE, returnCode, reasonCode);
@@ -390,6 +417,7 @@ Socket *tcpClient3(SocketAddress *socketAddress,
   return tcpClient4(socketAddress,
                     connectTimeoutInMillis,
                     -1,
+                    -1,
                     tlsFlags,
                     returnCode,
                     reasonCode);
@@ -401,6 +429,7 @@ Socket *tcpClient2(SocketAddress *socketAddress,
        int *reasonCode) { /* errnum - JR's */
   return tcpClient4(socketAddress,
                     connectTimeoutInMillis,
+                    -1,
                     -1,
                     0,
                     returnCode,

--- a/c/bpxskt.c
+++ b/c/bpxskt.c
@@ -219,8 +219,9 @@ int getSocketDebugID(Socket *s){
 /*--5---10---15---20---25---30---35---40---45---50---55---60---65---70---75---*/
 #define SO_ERROR    0x1007
 
-Socket *tcpClient3(SocketAddress *socketAddress,
-         int timeoutInMillis,
+Socket *tcpClient4(SocketAddress *socketAddress,
+         int connectTimeoutInMillis,
+         int readTimeoutInMillis,
          int tlsFlags,
          int *returnCode,
          int *reasonCode) {
@@ -263,7 +264,7 @@ Socket *tcpClient3(SocketAddress *socketAddress,
     return NULL;
   } else{
     int socketAddrSize = SOCKET_ADDRESS_SIZE_IPV4;
-    if (timeoutInMillis >= 0){
+    if (connectTimeoutInMillis >= 0){
       Socket tempSocket;
       tempSocket.sd = socketVector[0];
 
@@ -285,7 +286,7 @@ Socket *tcpClient3(SocketAddress *socketAddress,
         returnValue = 0;
         *returnCode  = 0;
         *reasonCode  = 0;
-        int status = tcpStatus(&tempSocket, timeoutInMillis, 1, returnCode, reasonCode);
+        int status = tcpStatus(&tempSocket, connectTimeoutInMillis, 1, returnCode, reasonCode);
         if (status == SD_STATUS_TIMEOUT) {
           int sd = socketVector[0];
           if (socketTrace) {
@@ -326,8 +327,7 @@ Socket *tcpClient3(SocketAddress *socketAddress,
           returnValue = 0;
         }
       } else{
-	/* all was good on 1st try, but why aren't we setting blocking mode here?
-	   seems inconsistent */
+        /* all was good on 1st try */
       }
     }
     else{
@@ -369,18 +369,39 @@ Socket *tcpClient3(SocketAddress *socketAddress,
       /* manual says returnCode and value only meaningful if return value = -1 */
       *returnCode = 0;
       *reasonCode = 0;
+      if (readTimeoutInMillis >= 0) {
+        setSocketOption(socket, SOL_SOCKET, SOCK_SO_RCVTIMEO, sizeof(int), (char*)&readTimeoutInMillis, returnCode, reasonCode);
+        setSocketBlockingMode(socket, TRUE, returnCode, reasonCode);
+      } else {
+        setSocketBlockingMode(socket, FALSE, returnCode, reasonCode);
+      }
       socket->protocol = IPPROTO_TCP;
+
       return socket;
     }
   }                    
 }
 
-Socket *tcpClient2(SocketAddress *socketAddress,
-       int timeoutInMillis,
+Socket *tcpClient3(SocketAddress *socketAddress,
+       int connectTimeoutInMillis,
+       int tlsFlags,
        int *returnCode, /* errnum */
        int *reasonCode) { /* errnum - JR's */
-  return tcpClient3(socketAddress,
-                    timeoutInMillis,
+  return tcpClient4(socketAddress,
+                    connectTimeoutInMillis,
+                    -1,
+                    tlsFlags,
+                    returnCode,
+                    reasonCode);
+}
+
+Socket *tcpClient2(SocketAddress *socketAddress,
+       int connectTimeoutInMillis,
+       int *returnCode, /* errnum */
+       int *reasonCode) { /* errnum - JR's */
+  return tcpClient4(socketAddress,
+                    connectTimeoutInMillis,
+                    -1,
                     0,
                     returnCode,
                     reasonCode);
@@ -1068,6 +1089,7 @@ int socketRead(Socket *socket, char *buffer, int desiredBytes,
 #else
   reasonCodePtr = reasonCode;
 #endif
+
   BPXRED(&sd,
           &buffer,
           &zero,

--- a/c/bpxskt.c
+++ b/c/bpxskt.c
@@ -390,11 +390,11 @@ Socket *tcpClient4(SocketAddress *socketAddress,
         struct timeval readTimeout;
         struct timeval writeTimeout;
 
-        readTimeout.tv_sec = (long)(readTimeoutInMillis / 1000UL);
-        readTimeout.tv_usec = (long)((readTimeoutInMillis % 1000UL)*1000UL);
+        readTimeout.tv_sec = readTimeoutInMillis / 1000;
+        readTimeout.tv_usec = ((readTimeoutInMillis % 1000)*1000);
 
-        writeTimeout.tv_sec = (long)(writeTimeoutInMillis / 1000UL);
-        writeTimeout.tv_usec = (long)((writeTimeoutInMillis % 1000UL)*1000UL);
+        writeTimeout.tv_sec = writeTimeoutInMillis / 1000;
+        writeTimeout.tv_usec = ((writeTimeoutInMillis % 1000)*1000);
 
         setSocketOption(socket, SOL_SOCKET, SOCK_SO_RCVTIMEO, sizeof(struct timeval), (char*)&readTimeout, returnCode, reasonCode);
         if (returnCode) {

--- a/c/httpclient.c
+++ b/c/httpclient.c
@@ -671,7 +671,11 @@ int httpClientSessionInitv2(HttpClientContext *ctx, HttpClientSession **outSessi
       break;
     }
 
-    Socket *socket = tcpClient2(ctx->serverAddress, 1000 * ctx->recvTimeoutSeconds, bpxrc, &bpxrsn);
+    int readTimeoutMillis = 1000 * ctx->recvTimeoutSeconds;
+    int connectTimeoutMillis = readTimeoutMillis;
+    int tlsFlags = 0; //no TLS
+
+    Socket *socket = tcpClient4(ctx->serverAddress, connectTimeoutMillis, readTimeoutMillis, tlsFlags, bpxrc, &bpxrsn);
     if ((*bpxrc != 0) || (NULL == socket)) {
 #ifdef __ZOWE_OS_ZOS
       HTTP_CLIENT_TRACE_VERBOSE("%s (rc=%d, rsn=0x%x, addr=0x%08x, port=%d)\n", HTTP_CLIENT_MSG_CONNECT_FAILED, *bpxrc,

--- a/c/httpclient.c
+++ b/c/httpclient.c
@@ -672,10 +672,11 @@ int httpClientSessionInitv2(HttpClientContext *ctx, HttpClientSession **outSessi
     }
 
     int readTimeoutMillis = 1000 * ctx->recvTimeoutSeconds;
+    int writeTimeoutMillis = 1000 * ctx->sendTimeoutSeconds;
     int connectTimeoutMillis = readTimeoutMillis;
     int tlsFlags = 0; //no TLS
 
-    Socket *socket = tcpClient4(ctx->serverAddress, connectTimeoutMillis, readTimeoutMillis, tlsFlags, bpxrc, &bpxrsn);
+    Socket *socket = tcpClient4(ctx->serverAddress, connectTimeoutMillis, readTimeoutMillis, writeTimeoutMillis, tlsFlags, bpxrc, &bpxrsn);
     if ((*bpxrc != 0) || (NULL == socket)) {
 #ifdef __ZOWE_OS_ZOS
       HTTP_CLIENT_TRACE_VERBOSE("%s (rc=%d, rsn=0x%x, addr=0x%08x, port=%d)\n", HTTP_CLIENT_MSG_CONNECT_FAILED, *bpxrc,

--- a/h/bpxnet.h
+++ b/h/bpxnet.h
@@ -337,6 +337,7 @@ Socket *tcpClient3(SocketAddress *socketAddress,
 Socket *tcpClient4(SocketAddress *socketAddress,
        int connectTimeoutInMillis,
        int readTimeoutInMillis,
+       int writeTimeoutInMillis,
        int tlsFlags,
        int *returnCode,
        int *reasonCode);

--- a/h/bpxnet.h
+++ b/h/bpxnet.h
@@ -315,7 +315,7 @@ int getSocketOption(Socket *socket, int optionName, int *optionDataLength, char 
 #define tcpClient2 tcpclie2
 
 Socket *tcpClient2(SocketAddress *socketAddress,
-		   int timeoutInMillis,
+		   int connectTimeoutInMillis,
 		   int *returnCode, /* errnum */
 		   int *reasonCode); /* errnum - JR's */
 
@@ -327,10 +327,20 @@ Socket *tcpServer(InetAddr *addr, /* usually NULL/0 */
 #define tcpClient3 tcpclie3
 
 Socket *tcpClient3(SocketAddress *socketAddress,
-       int timeoutInMillis,
+       int connectTimeoutInMillis,
        int tlsFlags,
        int *returnCode,
        int *reasonCode);
+
+#define tcpClient4 tcpclie4
+
+Socket *tcpClient4(SocketAddress *socketAddress,
+       int connectTimeoutInMillis,
+       int readTimeoutInMillis,
+       int tlsFlags,
+       int *returnCode,
+       int *reasonCode);
+
 
 /* 
    * Create a TCP socket

--- a/h/httpclient.h
+++ b/h/httpclient.h
@@ -61,6 +61,7 @@ typedef struct HttpClientContext_tag {
   LoggingContext *logContext;
   SocketAddress *serverAddress;
   int recvTimeoutSeconds; /* try next server on timeout */
+  int sendTimeoutSeconds;
 #ifdef USE_ZOWE_TLS
   TlsEnvironment *tlsEnvironment;
 #endif


### PR DESCRIPTION
~~this PR recreates PR https://github.com/zowe/zowe-common-c/pull/516 for v3.~~
It attempts to address:
~~1) The HTTP client code does not block when it should~~
~~2) The HTTP client code does not propagate the code, EWOULDBLOCK, when it's in non-blocking mode, so callers can do little about it.~~
1) The HTTP client code only has a nonblocking mode, there is no blocking mode.
