### PR TITLE
Allow PARMLIB YAML to have multiple member names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Zowe Common C Changelog
 
+## `3.3.0`
+- Enhancement: configmgr path elements of type PARMLIB can now contain a member name, in the format of "PARMLIB(DATA.SET(member))", as an alternative to the older format of "PARMLIB(DATA.SET)" with the member name being specified in a separate argument. This enhancement allows use of multiple members with different names within the same PARMLIB dataset. The older format can still be used as desired. (??)
+
 ## `3.2.0`
 - Bugfix: allocate storage to be executed with EXECUTABLE=YES (#507)
 - Bugfix: fix a leak in the rsusermap code (#467)

--- a/build/build_cmgr_xlclang.sh
+++ b/build/build_cmgr_xlclang.sh
@@ -55,6 +55,8 @@ rm -f "${COMMON}/bin/configmgr"
 GSKDIR=/usr/lpp/gskssl
 GSKINC="${GSKDIR}/include"
 
+echo "Compiling libraries"
+
 xlclang \
   -c \
   -q64 \
@@ -85,12 +87,16 @@ xlclang \
   ${DEPS_DESTINATION}/${QUICKJS}/libunicode.c \
   ${DEPS_DESTINATION}/${QUICKJS}/libregexp.c \
   ${DEPS_DESTINATION}/${QUICKJS}/porting/polyfill.c
-#then
-#  echo "Done with qascii-compiled open-source parts"
-#else
-#  echo "Build failed"
-#  exit 8
-#fi
+rc=$?
+
+if [ "${rc}" -eq 0 ]; then
+  echo "Libraries compiled successfully"
+else
+  echo "Library compilation failed"
+  exit $rc
+fi
+
+echo "Building configmgr"
 
 xlclang \
   -q64 \
@@ -154,18 +160,16 @@ xlclang \
   ${COMMON}/c/zosfile.c \
   ${GSKDIR}/lib/GSKSSL64.x \
   ${GSKDIR}/lib/GSKCMS64.x
-#then
-#  echo "Build successful"
-#  ls -l "${COMMON}/bin"
-#  exit 0
-#else
-#  # remove configmgr in case the linker had RC=4 and produced the binary
-#  rm -f "${COMMON}/bin/configmgr"
-#  echo "Build failed"
-#  exit 8
-#fi
+rc=$?
+
+if [ "${rc}" -eq 0 ]; then
+  echo "Build successful"
+else
+  echo "Build failed"
+fi
 
 rm -rf "${TMP_DIR}"
+exit $rc
 
 
 # This program and the accompanying materials are

--- a/c/configmgr.c
+++ b/c/configmgr.c
@@ -432,7 +432,7 @@ static bool addPathElement(ConfigManager *mgr, CFGConfig *config, char *pathElem
   regmatch_t matches[10];
   regex_t *argPattern = regexAlloc();
   /* Nice Regex test site */
-  char *pat = "^(LIBRARY|DIR|FILE|PARMLIBS|PARMLIB)\\(([^)]+)\\)$";
+  char *pat = "^(LIBRARY|DIR|FILE|PARMLIBS|PARMLIB)\\((.+)\\)$";
   int compStatus = regexComp(argPattern,pat,REG_EXTENDED);
   if (compStatus != 0){
     

--- a/c/configmgr.c
+++ b/c/configmgr.c
@@ -405,9 +405,12 @@ static ConfigPathElement *addExpandedParmlibs(ConfigManager *mgr, CFGConfig *con
       char *volser = NULL;
       char *dsn = getParmlib(outBuffer,i,&volser);
       if (volser == NULL){ /* means it's a catalogued data set */
-	int dsnLen = 44;
-	while (dsnLen > 0 && (dsn[dsnLen-1] <= 0x40)) dsnLen--;
-	element = makePathElement(mgr,
+        int dsnLen = indexOf(dsn, strlen(dsn), ')', 0)+1; //already contains PDS member
+        if (dsnLen == 0) {
+          dsnLen = 44; //no PDS member
+          while (dsnLen > 0 && (dsn[dsnLen-1] <= 0x40)) dsnLen--;
+        }
+        element = makePathElement(mgr,
 				  config,
 				  CONFIG_PATH_MVS_PARMLIB | CONFIG_PATH_WAS_EXPANDED, 
 				  substring(mgr,"PARMLIB",0,7),
@@ -735,8 +738,14 @@ static Json *readJson(ConfigManager *mgr, CFGConfig *config, ConfigPathElement *
   } else if (pathElement->flags & CONFIG_PATH_MVS_PARMLIB){
     char pdsMemberSpec[MAX_PDS_NAME];
     trace(mgr,DEBUG,"pathElement=0x%p config=0x%p\n",pathElement,config);
-    int charsWritten = snprintf(pdsMemberSpec,MAX_PDS_NAME,"//'%s(%s)'",
+    int hasParen = indexOf(pathElement->data, strlen(pathElement->data), '(', 0) > -1;
+    if (!hasParen) {
+      snprintf(pdsMemberSpec,MAX_PDS_NAME,"//'%s(%s)'",
 				pathElement->data,config->parmlibMemberName);
+    } else {
+      snprintf(pdsMemberSpec,MAX_PDS_NAME,"//'%s'",
+				pathElement->data);
+    }
     trace(mgr,DEBUG,"PDS name = '%s'\n",pdsMemberSpec);
     bool nullAllowed = (pathElement->flags & CONFIG_PATH_WAS_EXPANDED);
     *nullAllowedPtr = nullAllowed;
@@ -1290,7 +1299,8 @@ static void showHelp(FILE *out){
   fprintf(out,"      validate            : just loads and validates merged configuration\n");
   fprintf(out,"      env <outEnvPath>    : prints merged configuration to a file as a list of environment vars\n");
   fprintf(out,"    configPathElement: \n");
-  fprintf(out,"      PARMLIB(datasetName) - a library that can contain config data\n");
+  fprintf(out,"      PARMLIB(datasetName(memberName)) - a library that can contain config data\n");
+  fprintf(out,"      PARMLIB(datasetName) - a library that can contain config data. Member name comes from the -m parameter\n");
   fprintf(out,"      FILE(filename)   - the name of a file containing Yaml\n");
   fprintf(out,"      PARMLIBS         - all PARMLIBS that are defined to this running Program in ZOS, nothing if not on ZOS\n");
 }


### PR DESCRIPTION
Resolves https://github.com/zowe/zowe-install-packaging/issues/4156
Used by https://github.com/zowe/launcher/pull/146
Used by https://github.com/zowe/zowe-install-packaging/pull/4285

This enhances configmgr to not need the `-m` (CLI) `setParmlibMemberName()` (JS), and `cfgSetParmlibMemberName()` (C) calls to be able to load YAML from PARMLIB.
This is non-disruptive. These calls are removed, and co-exist with this enhancement.

Now, the path element "PARMLIB" for configuration files can be of the format "DATA.SET(member)"
In other words, you can now load a PARMLIB in 2 ways

Old way: -m member -p "PARMLIB(DATA.SET)"  ... gives you contents of DATA.SET(member)
New way: -p "PARMLIB(DATA.SET(member))"    ... same.

You could use both at the same time.

-m yml1 -p "PARMLIB(DATA.SET):PARMLIB(DATA.SET(yml2))"

Basically, this just removes a restriction on there only being 1 member name allowed when loading PARMLIB, by allowing it to be specified within the path element name itself.

This makes the path argument of the configmgr CLI identical to the CONFIG argument of the `Launcher` and the --config argument of `zwe`. Those never supported the behavior of `-m`, they just would error if there was more than 1 member name found.

Separate PRs will be made to launcher and zwe to remove the restriction there.

