### PR TITLE
add configmgr api `copyConfigurationAndDeleteKey`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Zowe Common C Changelog
 
 ## `3.3.0`
-- Feature: add a `deleteFromConfiguration` API to configmgr (#524)
+- Feature: add a `copyConfigurationAndDeleteKey` API to configmgr (#524)
 - Enhancement: configmgr path elements of type PARMLIB can now contain a member name, in the format of "PARMLIB(DATA.SET(member))", as an alternative to the older format of "PARMLIB(DATA.SET)" with the member name being specified in a separate argument. This enhancement allows use of multiple members with different names within the same PARMLIB dataset. The older format can still be used as desired. (??)
 
 ## `3.2.0`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Zowe Common C Changelog
 
 ## `3.3.0`
-- Feature: add a `copyConfigurationAndDeleteKey` API to configmgr (#524)
+- Enhancement: add a `copyConfigurationAndDeleteKey` API to configmgr (#524)
 - Enhancement: configmgr path elements of type PARMLIB can now contain a member name, in the format of "PARMLIB(DATA.SET(member))", as an alternative to the older format of "PARMLIB(DATA.SET)" with the member name being specified in a separate argument. This enhancement allows use of multiple members with different names within the same PARMLIB dataset. The older format can still be used as desired. (#522)
 
 ## `3.2.0`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## `3.3.0`
 - Feature: add a `copyConfigurationAndDeleteKey` API to configmgr (#524)
-- Enhancement: configmgr path elements of type PARMLIB can now contain a member name, in the format of "PARMLIB(DATA.SET(member))", as an alternative to the older format of "PARMLIB(DATA.SET)" with the member name being specified in a separate argument. This enhancement allows use of multiple members with different names within the same PARMLIB dataset. The older format can still be used as desired. (??)
+- Enhancement: configmgr path elements of type PARMLIB can now contain a member name, in the format of "PARMLIB(DATA.SET(member))", as an alternative to the older format of "PARMLIB(DATA.SET)" with the member name being specified in a separate argument. This enhancement allows use of multiple members with different names within the same PARMLIB dataset. The older format can still be used as desired. (#522)
 
 ## `3.2.0`
 - Bugfix: allocate storage to be executed with EXECUTABLE=YES (#507)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Zowe Common C Changelog
 
+## `3.3.0`
+- Feature: add a `deleteFromConfiguration` API to configmgr (#524)
+
 ## `3.2.0`
 - Bugfix: allocate storage to be executed with EXECUTABLE=YES (#507)
 - Bugfix: fix a leak in the rsusermap code (#467)

--- a/c/configmgr.c
+++ b/c/configmgr.c
@@ -858,6 +858,38 @@ static int overloadConfiguration(ConfigManager *mgr,
   }
 }
 
+int cfgDeleteFromConfiguration(ConfigManager* mgr, 
+         const char *configName,
+         const char *modifiedConfigName,
+         const char *keyToDelete) {
+
+  CFGConfig *config = getConfig(mgr, configName);
+  if (!config) {
+    return ZCFG_UNKNOWN_CONFIG_NAME;
+  }
+  int deleteStatus = 0;
+
+  Json *modifiedData = jsonDelete(mgr->slh, 
+            keyToDelete, 
+            config->configData, 
+            &deleteStatus);
+  
+  if (deleteStatus) {
+    return deleteStatus;
+  }
+
+  CFGConfig *modifiedConfig = cfgAddConfig(mgr,modifiedConfigName);
+  modifiedConfig->schemaPath = config->schemaPath;
+  /* is this path really true anymore?? */
+  modifiedConfig->configPath = config->configPath;
+  modifiedConfig->topSchema = config->topSchema;
+  modifiedConfig->otherSchemas = config->otherSchemas;
+  modifiedConfig->otherSchemasCount = config->otherSchemasCount;
+  modifiedConfig->parmlibMemberName = config->parmlibMemberName;
+  modifiedConfig->configData = modifiedData;
+  return ZCFG_SUCCESS;
+}
+
 int cfgMakeModifiedConfiguration(ConfigManager *mgr, 
 				 const char *configName, 
 				 const char *modifiedConfigName,

--- a/c/configmgr.c
+++ b/c/configmgr.c
@@ -1702,7 +1702,7 @@ int cfgDeleteFromConfiguration(ConfigManager* mgr,
          const char *modifiedConfigName,
          const char *keyToDelete) {
    */
-  EJSNativeMethod *deleteFromConfiguration = ejsMakeNativeMethod(ejs,configmgr,"deleteFromConfiguration",
+  EJSNativeMethod *deleteFromConfiguration = ejsMakeNativeMethod(ejs,configmgr,"copyConfigurationAndDeleteKey",
     EJS_NATIVE_TYPE_INT32,
     (EJSForeignFunction*)deleteFromConfigurationWrapper);
   ejsAddMethodArg(ejs,deleteFromConfiguration,"configName",EJS_NATIVE_TYPE_CONST_STRING);

--- a/c/configmgr.c
+++ b/c/configmgr.c
@@ -867,6 +867,7 @@ static int overloadConfiguration(ConfigManager *mgr,
   }
 }
 
+// This method always succeeds. If the keyToDelete is not found, configuration is returned with modification.
 int cfgDeleteFromConfiguration(ConfigManager* mgr, 
          const char *configName,
          const char *modifiedConfigName,
@@ -876,20 +877,13 @@ int cfgDeleteFromConfiguration(ConfigManager* mgr,
   if (!config) {
     return ZCFG_UNKNOWN_CONFIG_NAME;
   }
-  int deleteStatus = 0;
 
   Json *modifiedData = jsonDelete(mgr->slh, 
             keyToDelete, 
-            config->configData, 
-            &deleteStatus);
+            config->configData);
   
-  if (deleteStatus) {
-    return deleteStatus;
-  }
-
   CFGConfig *modifiedConfig = cfgAddConfig(mgr,modifiedConfigName);
   modifiedConfig->schemaPath = config->schemaPath;
-  /* is this path really true anymore?? */
   modifiedConfig->configPath = config->configPath;
   modifiedConfig->topSchema = config->topSchema;
   modifiedConfig->otherSchemas = config->otherSchemas;

--- a/c/configmgr.c
+++ b/c/configmgr.c
@@ -1516,6 +1516,19 @@ static int loadConfigurationWrapper(ConfigManager *mgr, EJSNativeInvocation *inv
   return EJS_OK;
 }
 
+static int deleteFromConfigurationWrapper(ConfigManager *mgr, EJSNativeInvocation *invocation){
+  const char *configName = NULL;
+  ejsStringArg(invocation,0,&configName);
+  const char *modifiedConfigName = NULL;
+  ejsStringArg(invocation,1,&modifiedConfigName);
+  const char *keyToDelete = NULL;
+  ejsStringArg(invocation,2,&keyToDelete);
+  
+  int status = cfgDeleteFromConfiguration(mgr,configName,modifiedConfigName,keyToDelete);
+  ejsReturnInt(invocation,status);
+  return EJS_OK;
+}
+
 static int makeModifiedConfigurationWrapper(ConfigManager *mgr, EJSNativeInvocation *invocation){
   const char *configName = NULL;
   ejsStringArg(invocation,0,&configName);
@@ -1671,6 +1684,20 @@ static EJSNativeModule *exportConfigManagerToEJS(EmbeddedJS *ejs){
                                                           EJS_NATIVE_TYPE_INT32,
                                                           (EJSForeignFunction*)loadConfigurationWrapper);
   ejsAddMethodArg(ejs,loadConfiguration,"configName",EJS_NATIVE_TYPE_CONST_STRING);
+
+  /**
+   * 
+int cfgDeleteFromConfiguration(ConfigManager* mgr, 
+         const char *configName,
+         const char *modifiedConfigName,
+         const char *keyToDelete) {
+   */
+  EJSNativeMethod *deleteFromConfiguration = ejsMakeNativeMethod(ejs,configmgr,"deleteFromConfiguration",
+    EJS_NATIVE_TYPE_INT32,
+    (EJSForeignFunction*)deleteFromConfigurationWrapper);
+  ejsAddMethodArg(ejs,deleteFromConfiguration,"configName",EJS_NATIVE_TYPE_CONST_STRING);
+  ejsAddMethodArg(ejs,deleteFromConfiguration,"modifiedConfigName",EJS_NATIVE_TYPE_CONST_STRING);
+  ejsAddMethodArg(ejs,deleteFromConfiguration,"keyToDelete",EJS_NATIVE_TYPE_CONST_STRING);
 
   EJSNativeMethod *makeModifiedConfiguration = ejsMakeNativeMethod(ejs,configmgr,"makeModifiedConfiguration",
 								   EJS_NATIVE_TYPE_INT32,

--- a/c/json.c
+++ b/c/json.c
@@ -2701,7 +2701,7 @@ static void deleteJson(Json *base, const char *deleteKey) {
     Json *parentNode = NULL;
     Json *activeNode = base;
     char* copiedKey = strdup(deleteKey);
-    char workStr[500]; // huge working buffer on the stack for potential keys, all should realistically be <50 chars
+    char workStr[MAX_JSON_KEY]; // large working buffer
     char* jsonTok = strtok(copiedKey, ".");
     bool tokenMatchFound = true;
     // used to parse arrays like a[0]
@@ -2726,7 +2726,7 @@ static void deleteJson(Json *base, const char *deleteKey) {
         }
       } else {
         // If we have format like [a.b.c], ensure the jsonTok is [a.b.c], and not [a.b.c
-        memset(workStr, 0x00, sizeof(char)*500);
+        memset(workStr, 0x00, sizeof(char)*MAX_JSON_KEY);
         if (jsonTok && jsonTok[0] == '[') {
           strncpy(workStr, jsonTok, strlen(jsonTok));
           while (workStr[strlen(workStr)-1] != ']') {

--- a/c/json.c
+++ b/c/json.c
@@ -2912,7 +2912,7 @@ Json *jsonCopy(ShortLivedHeap *slh, Json *value){
   return builder.root;
 }
 
-Json *jsonDelete(ShortLivedHeap *slh, const char *keyToDelete, Json *base, int *statusPtr) {
+Json *jsonDelete(ShortLivedHeap *slh, const char *keyToDelete, Json *base) {
   JsonBuilder builder;
   memset(&builder, 0, sizeof(JsonBuilder));
   builder.parser.slh = slh;

--- a/c/json.c
+++ b/c/json.c
@@ -2737,9 +2737,11 @@ static void deleteJson(Json *base, const char *deleteKey) {
             strcat(workStr, ".");
             strcat(workStr, nextTok);
           }
-          // strip the first and last brackets
-          memmove(workStr, workStr + 1, strlen(workStr) - 1);
-          workStr[strlen(workStr) - 2] = '\0';
+          // strip the first and last brackets if they're present
+          if (workStr[0]== '[' && workStr[strlen(workStr)-1]== ']') {
+            memmove(workStr, workStr + 1, strlen(workStr) - 1);
+            workStr[strlen(workStr) - 2] = '\0';
+          }
           jsonTok = workStr;
         }
         //printf("jsonTokPostGroup: %s\n", jsonTok); fflush(stdout);

--- a/c/json.c
+++ b/c/json.c
@@ -1684,37 +1684,31 @@ static void jsonArrayRemoveNode(Json* base, Json* remove) {
 
 static
 void jsonObjectRemoveNode(Json* base, Json* remove) {
-
   JsonObject* baseObj = jsonAsObject(base);
-  // single property case
-  if (baseObj->firstProperty == baseObj->lastProperty) {
-    baseObj->firstProperty = NULL;
-    baseObj->lastProperty = NULL;
-    return;
-  }
   JsonProperty* prevProp = NULL;
   JsonProperty* activeProp = baseObj->firstProperty;
   bool propFound = false;
   while (activeProp && !propFound) {
-//    printf("on property key=%s\n", activeProp->key); fflush(stdout);   
     if (activeProp->value == remove) {
-//      printf("found property match activeKey=%s removeVal=%d\n", activeProp->key, remove->type); fflush(stdout);
       propFound = true;
     } else {
       prevProp = activeProp;
       activeProp = activeProp->next;
     }
   }
-  // TODO: silently accept failure?
+  // if someone calls us and we can't find the prop, return without modification
   if (!propFound){
     return;
   }
+
   if (baseObj->lastProperty == activeProp){ 
     baseObj->lastProperty = prevProp;
   }
+
   if (prevProp) {
     prevProp->next = activeProp->next;
   } else {
+    // prevprop = null occurs when our target prop was the object's firstProperty
     baseObj->firstProperty = activeProp->next;
   }
 }

--- a/c/json.c
+++ b/c/json.c
@@ -2632,6 +2632,34 @@ static void copyJson(JsonBuilder *builder, Json *parent, char *parentKey, Json *
   }
 }
 
+static int deleteJson(JsonMerger *merger, Json* parent, char *parentKey, char *deleteKey, Json *base) {
+  int errorCode = 0;
+  JsonBuilder *builder = &merger->builder;
+  if (jsonIsObject(base)) {
+    JsonObject *baseObject = jsonAsObject(base);
+    Json *copied = jsonBuildObject(builder,parent,parentKey,&errorCode);
+    JsonProperty *baseProp = jsonObjectGetFirstProperty(baseObject);
+    int status = 0;
+    while (baseProp) {
+      char *baseKey = baseProp->key;
+      Json *baseValue = baseProp->value;
+      printf("deleteJson baseKey=%s deleteKey=%s builder=0x%p\n",baseKey,deleteKey, builder);
+      fflush(stdout);
+      if (!strcmp(baseKey, deleteKey)) {
+        copyJson(builder, copied, baseKey, baseValue);
+      }
+      baseProp = jsonObjectGetNextProperty(baseProp);
+    }
+    if (jsonObjectHasKey(baseObject, deleteKey)) {
+      // remove this after verifying functionality;
+      return 1;
+    }
+  } else {
+    printf("unknown type, shouldn\'t base to delete always be type object? this isn't recursive");
+    printf("type found=%d", base->type);
+  }
+}
+
 static int mergeJson1(JsonMerger *merger, Json *parent, char *parentKey, Json *overrides, Json *base){
   int errorCode = 0;
   JsonBuilder *builder = &merger->builder;
@@ -2754,6 +2782,14 @@ Json *jsonCopy(ShortLivedHeap *slh, Json *value){
   memset(&builder,0,sizeof(JsonBuilder));
   builder.parser.slh = slh;
   copyJson(&builder,NULL,NULL,value);
+  return builder.root;
+}
+
+Json *jsonDelete(ShortLivedHeap *slh, char *keyToDelete, Json *base, int *statusPtr) {
+  JsonBuilder builder;
+  memset(&builder, 0, sizeof(JsonBuilder));
+  builder.parser.slh = slh;
+  deleteJson(&builder, NULL, NULL, keyToDelete, base);
   return builder.root;
 }
 

--- a/c/json.c
+++ b/c/json.c
@@ -2749,12 +2749,12 @@ static void deleteJson(Json *base, const char *deleteKey) {
 
         // use regexp to parse jsonToks of formats: "a[0]", "a.b.c[213132]". Invalid arrays like "abc]", "abc[a2]" are left untouched.
         if (jsonTok[strlen(jsonTok)-1] == ']') {
-          int rrc = 0;
           regmatch_t matches[4];
           regexComp(argPattern,pat,REG_EXTENDED);
-          regexExec(argPattern,jsonTok,4,matches,0);
+          int rrc = regexExec(argPattern,jsonTok,4,matches,0);
+          printf("match indexes: %d %d \n", matches[3].rm_so, matches[3].rm_eo); fflush(stdout);
           // if we have a matched array index, set the arrayIdx, otherwise, leave jsonTok as-is
-          if (matches[3].rm_so!= -1) {
+          if (rrc == 0 && matches[3].rm_so < matches[3].rm_eo) {
             arrayIdx = parseInt(jsonTok + matches[3].rm_so, 0, matches[3].rm_eo - matches[3].rm_so);
             // set the jsonTok array `[nnn]` to end-of-string, e.g. a[0] -> a
             if (matches[1].rm_so != -1) {

--- a/c/json.c
+++ b/c/json.c
@@ -2710,7 +2710,7 @@ static void deleteJson(Json *base, const char *deleteKey) {
     int arrayIdx = -1; // helps track composite nodes like a[0], where 'a' and '0' are both nodes in the JSON tree
 
     // This loop walks down the JSON tree one key/node at a time, except for arrays, where one key represents 2 nodes (array + index). e.g: a[0] 
-    //      The array "saves" the second step as arrayIdx, so each loop iteration is still crawls one node at a time.
+    //      The array "saves" the second step as arrayIdx, so each loop iteration still crawls one node at a time.
     while ((jsonTok || arrayIdx>=0) && tokenMatchFound) {
       // if we're a known array index, set it as the active node
       if (arrayIdx >= 0) {

--- a/c/json.c
+++ b/c/json.c
@@ -2712,6 +2712,7 @@ static void deleteJson(Json *base, const char *deleteKey) {
     // This loop walks down the JSON tree one key/node at a time, except for arrays, where one key represents 2 nodes (array + index). e.g: a[0] 
     //      The array "saves" the second step as arrayIdx, so each loop iteration still crawls one node at a time.
     while ((jsonTok || arrayIdx>=0) && tokenMatchFound) {
+      tokenMatchFound = false;
       // if we're a known array index, set it as the active node
       if (arrayIdx >= 0) {
         if (jsonIsArray(activeNode)) {
@@ -2761,8 +2762,6 @@ static void deleteJson(Json *base, const char *deleteKey) {
             }
           }
         }
-        //printf("deleteJson jsonTok=%s nodeType=%d\n", jsonTok, activeNode->type); fflush(stdout);
-        tokenMatchFound = false;
         if (jsonIsObject(activeNode)) {
           JsonProperty *baseProp = jsonObjectGetFirstProperty(jsonAsObject(activeNode));
           while (baseProp && !tokenMatchFound) {

--- a/c/json.c
+++ b/c/json.c
@@ -1667,6 +1667,44 @@ Json *jsonGetNull(JsonParser* parser) {
   return json;
 }
 
+static
+void jsonObjectRemoveNode(Json* base, Json* remove) {
+
+  JsonObject* baseObj = jsonAsObject(base);
+  // single property case
+  if (baseObj->firstProperty == baseObj->lastProperty) {
+    baseObj->firstProperty = NULL;
+    baseObj->lastProperty = NULL;
+    return;
+  }
+  JsonProperty* prevProp = NULL;
+  JsonProperty* activeProp = baseObj->firstProperty;
+  bool propFound = false;
+  while (activeProp && !propFound) {
+//    printf("on property key=%s\n", activeProp->key); fflush(stdout);   
+    if (activeProp->value == remove) {
+//      printf("found property match activeKey=%s removeVal=%d\n", activeProp->key, remove->type); fflush(stdout);
+      propFound = true;
+    } else {
+      prevProp = activeProp;
+      activeProp = activeProp->next;
+    }
+  }
+  // TODO: silently accept failure?
+  if (!propFound){
+    return;
+  }
+  if (baseObj->lastProperty == activeProp){ 
+    baseObj->lastProperty = prevProp;
+  }
+  if (prevProp) {
+    prevProp->next = activeProp->next;
+  } else {
+    baseObj->firstProperty = activeProp->next;
+  }
+  // free now orphaned activeProp?
+}
+
 static 
 void jsonObjectAddProperty(JsonParser *parser, JsonObject *obj, char *key, Json *value) {
   JsonProperty *property = (JsonProperty*) jsonParserAlloc(parser, sizeof (JsonProperty));
@@ -2126,6 +2164,13 @@ int jsonIsObject(Json *json) {
 
 int jsonIsArray(Json *json) {
   return json->type == JSON_TYPE_ARRAY;
+}
+
+int jsonIsPrimitive(Json *json) {
+  return jsonIsString(json) || 
+         jsonIsBoolean(json) ||
+         jsonIsNumber(json) ||
+         jsonIsNull(json);
 }
 
 int jsonIsString(Json *json) {
@@ -2632,31 +2677,34 @@ static void copyJson(JsonBuilder *builder, Json *parent, char *parentKey, Json *
   }
 }
 
-static int deleteJson(JsonMerger *merger, Json* parent, char *parentKey, char *deleteKey, Json *base) {
-  int errorCode = 0;
-  JsonBuilder *builder = &merger->builder;
-  if (jsonIsObject(base)) {
-    JsonObject *baseObject = jsonAsObject(base);
-    Json *copied = jsonBuildObject(builder,parent,parentKey,&errorCode);
-    JsonProperty *baseProp = jsonObjectGetFirstProperty(baseObject);
-    int status = 0;
-    while (baseProp) {
-      char *baseKey = baseProp->key;
-      Json *baseValue = baseProp->value;
-      printf("deleteJson baseKey=%s deleteKey=%s builder=0x%p\n",baseKey,deleteKey, builder);
-      fflush(stdout);
-      if (!strcmp(baseKey, deleteKey)) {
-        copyJson(builder, copied, baseKey, baseValue);
+static void deleteJson(Json *base, const char *deleteKey) {
+  if (deleteKey) {
+    char* jsonTok = strtok(strdup(deleteKey), ".");
+    Json *parentNode = NULL;
+    Json *activeNode = base;
+    bool matchFound = true;
+    while (jsonTok && matchFound) {
+//      printf("deleteJson jsonTok=%s nodeType=%d\n", jsonTok, activeNode->type); fflush(stdout);
+      matchFound = false;
+      if (jsonIsObject(activeNode)) {
+        JsonProperty *baseProp = jsonObjectGetFirstProperty(jsonAsObject(activeNode));
+        while (baseProp && !matchFound) {
+//          printf("deleteJson traverseObject baseProp=%s\n", baseProp->key); fflush(stdout);
+          if (strcmp(baseProp->key, jsonTok) == 0) {
+            matchFound = true;
+            parentNode = activeNode;
+            activeNode = baseProp->value;
+          } else {
+            baseProp = jsonObjectGetNextProperty(baseProp);
+          }
+        }
       }
-      baseProp = jsonObjectGetNextProperty(baseProp);
+      jsonTok = strtok(NULL, ".");
     }
-    if (jsonObjectHasKey(baseObject, deleteKey)) {
-      // remove this after verifying functionality;
-      return 1;
+    if (matchFound) {
+      jsonObjectRemoveNode(parentNode, activeNode);
     }
-  } else {
-    printf("unknown type, shouldn\'t base to delete always be type object? this isn't recursive");
-    printf("type found=%d", base->type);
+//   printf("deleteJson afterloop jsonTok=%s matchFound=%d nodeType=%d\n", jsonTok, matchFound, activeNode->type);
   }
 }
 
@@ -2785,11 +2833,12 @@ Json *jsonCopy(ShortLivedHeap *slh, Json *value){
   return builder.root;
 }
 
-Json *jsonDelete(ShortLivedHeap *slh, char *keyToDelete, Json *base, int *statusPtr) {
+Json *jsonDelete(ShortLivedHeap *slh, const char *keyToDelete, Json *base, int *statusPtr) {
   JsonBuilder builder;
   memset(&builder, 0, sizeof(JsonBuilder));
   builder.parser.slh = slh;
-  deleteJson(&builder, NULL, NULL, keyToDelete, base);
+  copyJson(&builder,NULL,NULL,base);
+  deleteJson(builder.root, keyToDelete);
   return builder.root;
 }
 

--- a/c/json.c
+++ b/c/json.c
@@ -51,6 +51,9 @@
 
 #ifdef __ZOWE_OS_WINDOWS
 typedef int64_t ssize_t;
+#include "winregex.h"
+#else
+#include "psxregex.h"  /* works on ZOS and Linux */
 #endif
 
 /* Having lots of problems including unistd, so here's a hack */
@@ -2698,41 +2701,87 @@ static void deleteJson(Json *base, const char *deleteKey) {
     Json *parentNode = NULL;
     Json *activeNode = base;
     char* copiedKey = strdup(deleteKey);
+    char workStr[500]; // huge working buffer on the stack for potential keys, all should realistically be <50 chars
     char* jsonTok = strtok(copiedKey, ".");
     bool tokenMatchFound = true;
-    while (jsonTok && tokenMatchFound) {
-//      printf("deleteJson jsonTok=%s nodeType=%d\n", jsonTok, activeNode->type); fflush(stdout);
-      tokenMatchFound = false;
-      if (jsonIsObject(activeNode)) {
-        JsonProperty *baseProp = jsonObjectGetFirstProperty(jsonAsObject(activeNode));
-        while (baseProp && !tokenMatchFound) {
-//          printf("deleteJson traverseObject baseProp=%s\n", baseProp->key); fflush(stdout);
-          if (strcmp(baseProp->key, jsonTok) == 0) {
-            tokenMatchFound = true;
-            parentNode = activeNode;
-            activeNode = baseProp->value;
-          } else {
-            baseProp = jsonObjectGetNextProperty(baseProp);
-          }
-        } 
-      } else if (jsonIsArray(activeNode)) {
-//        printf("deleteJson isArray nodeType=%d, token=%s, isUInt=%d\n", activeNode->type, jsonTok, isUInt); fflush(stdout);
-        if (isUnsignedInt(jsonTok)) {
-          int tokIdx = parseInt(jsonTok, 0, strlen(jsonTok));
+    // used to parse arrays like a[0]
+    regex_t *argPattern = regexAlloc();
+    char *pat = "(.*)(\\[([0-9]+)\\]).*";
+    int arrayIdx = -1; // helps track composite nodes like a[0], where 'a' and '0' are both nodes in the JSON tree
+
+    // This loop walks down the JSON tree one key/node at a time, except for arrays, where one key represents 2 nodes (array + index). e.g: a[0] 
+    //      The array "saves" the second step as arrayIdx, so each loop iteration is still crawls one node at a time.
+    while ((jsonTok || arrayIdx>=0) && tokenMatchFound) {
+      // if we're a known array index, set it as the active node
+      if (arrayIdx >= 0) {
+        if (jsonIsArray(activeNode)) {
           JsonArray *nodeArray = jsonAsArray(activeNode);
-//          printf("deleteJson noText tokIdx=%d, count=%d, capacity=%d\n", tokIdx, nodeArray->count, nodeArray->capacity); fflush(stdout);
-          if (tokIdx < nodeArray->count) {
+          if (arrayIdx < nodeArray->count) {
             tokenMatchFound = true;
             parentNode = activeNode;
-            activeNode = nodeArray->elements[tokIdx];
+            activeNode = nodeArray->elements[arrayIdx];
+            arrayIdx=-1; // reset
           }
         }
+      } else {
+        // If we have format like [a.b.c], ensure the jsonTok is [a.b.c], and not [a.b.c
+        memset(workStr, 0x00, sizeof(char)*500);
+        if (jsonTok && jsonTok[0] == '[') {
+          strncpy(workStr, jsonTok, strlen(jsonTok));
+          while (workStr[strlen(workStr)-1] != ']') {
+            char* nextTok = strtok(NULL, ".");
+            if (!nextTok) {
+              // end of string, unmatched '['
+              break;
+            }
+            strcat(workStr, ".");
+            strcat(workStr, nextTok);
+          }
+          // strip the first and last brackets
+          memmove(workStr, workStr + 1, strlen(workStr) - 1);
+          workStr[strlen(workStr) - 2] = '\0';
+          jsonTok = workStr;
+        }
+        //printf("jsonTokPostGroup: %s\n", jsonTok); fflush(stdout);
+
+        // use regexp to parse jsonToks of formats: "a[0]", "a.b.c[213132]". Invalid arrays like "abc]", "abc[a2]" are left untouched.
+        if (jsonTok[strlen(jsonTok)-1] == ']') {
+          int rrc = 0;
+          regmatch_t matches[4];
+          regexComp(argPattern,pat,REG_EXTENDED);
+          regexExec(argPattern,jsonTok,4,matches,0);
+          // if we have a matched array index, set the arrayIdx, otherwise, leave jsonTok as-is
+          if (matches[3].rm_so!= -1) {
+            arrayIdx = parseInt(jsonTok + matches[3].rm_so, 0, matches[3].rm_eo - matches[3].rm_so);
+            // set the jsonTok array `[nnn]` to end-of-string, e.g. a[0] -> a
+            if (matches[1].rm_so != -1) {
+              memset(jsonTok + matches[2].rm_so, '\0', matches[2].rm_eo - matches[2].rm_so); // sets effective memory in either workStr or copiedKey, both safe to mutate
+            }
+          }
+        }
+        //printf("deleteJson jsonTok=%s nodeType=%d\n", jsonTok, activeNode->type); fflush(stdout);
+        tokenMatchFound = false;
+        if (jsonIsObject(activeNode)) {
+          JsonProperty *baseProp = jsonObjectGetFirstProperty(jsonAsObject(activeNode));
+          while (baseProp && !tokenMatchFound) {
+            // printf("deleteJson traverseObject baseProp=%s\n", baseProp->key); fflush(stdout);
+            if (strcmp(baseProp->key, jsonTok) == 0) {
+              tokenMatchFound = true;
+              parentNode = activeNode;
+              activeNode = baseProp->value;
+            } else {
+              baseProp = jsonObjectGetNextProperty(baseProp);
+            }
+          } 
+        }
+        jsonTok = strtok(NULL, ".");
       }
-      jsonTok = strtok(NULL, ".");
     }
     if (tokenMatchFound) { // jsonTok must be NULL (no more tokens), so we matched everything
+      //printf("deleteJson deleting node 0x%p\n", activeNode); fflush(stdout);
       jsonRemoveNode(parentNode, activeNode);
     }
+    regexFree(argPattern);
     free(copiedKey);
   }
 }

--- a/c/json.c
+++ b/c/json.c
@@ -1667,6 +1667,21 @@ Json *jsonGetNull(JsonParser* parser) {
   return json;
 }
 
+static void jsonArrayRemoveNode(Json* base, Json* remove) {
+  JsonArray *baseArray = jsonAsArray(base);
+  Json **baseElements = baseArray->elements;
+  Json **iter = baseElements;
+  int idx = 0;
+  while (idx < baseArray->count) {
+    if (iter[idx] == remove) {
+      memmove(&iter[idx], &iter[idx+1], (baseArray->capacity - idx) * sizeof(Json *));
+      baseArray->count -= 1;
+      return;
+    }
+    idx++;
+  }
+}
+
 static
 void jsonObjectRemoveNode(Json* base, Json* remove) {
 
@@ -1702,7 +1717,14 @@ void jsonObjectRemoveNode(Json* base, Json* remove) {
   } else {
     baseObj->firstProperty = activeProp->next;
   }
-  // free now orphaned activeProp?
+}
+
+static void jsonRemoveNode(Json* base, Json* remove) {
+  if (jsonIsObject(base)) {
+    jsonObjectRemoveNode(base, remove);
+  } else if (jsonIsArray(base)) {
+    jsonArrayRemoveNode(base, remove);
+  }
 }
 
 static 
@@ -2679,32 +2701,45 @@ static void copyJson(JsonBuilder *builder, Json *parent, char *parentKey, Json *
 
 static void deleteJson(Json *base, const char *deleteKey) {
   if (deleteKey) {
-    char* jsonTok = strtok(strdup(deleteKey), ".");
     Json *parentNode = NULL;
     Json *activeNode = base;
-    bool matchFound = true;
-    while (jsonTok && matchFound) {
+    char* copiedKey = strdup(deleteKey);
+    char* jsonTok = strtok(copiedKey, ".");
+    bool tokenMatchFound = true;
+    while (jsonTok && tokenMatchFound) {
 //      printf("deleteJson jsonTok=%s nodeType=%d\n", jsonTok, activeNode->type); fflush(stdout);
-      matchFound = false;
+      tokenMatchFound = false;
       if (jsonIsObject(activeNode)) {
         JsonProperty *baseProp = jsonObjectGetFirstProperty(jsonAsObject(activeNode));
-        while (baseProp && !matchFound) {
+        while (baseProp && !tokenMatchFound) {
 //          printf("deleteJson traverseObject baseProp=%s\n", baseProp->key); fflush(stdout);
           if (strcmp(baseProp->key, jsonTok) == 0) {
-            matchFound = true;
+            tokenMatchFound = true;
             parentNode = activeNode;
             activeNode = baseProp->value;
           } else {
             baseProp = jsonObjectGetNextProperty(baseProp);
           }
+        } 
+      } else if (jsonIsArray(activeNode)) {
+//        printf("deleteJson isArray nodeType=%d, token=%s, isUInt=%d\n", activeNode->type, jsonTok, isUInt); fflush(stdout);
+        if (isUnsignedInt(jsonTok)) {
+          int tokIdx = parseInt(jsonTok, 0, strlen(jsonTok));
+          JsonArray *nodeArray = jsonAsArray(activeNode);
+//          printf("deleteJson noText tokIdx=%d, count=%d, capacity=%d\n", tokIdx, nodeArray->count, nodeArray->capacity); fflush(stdout);
+          if (tokIdx < nodeArray->count) {
+            tokenMatchFound = true;
+            parentNode = activeNode;
+            activeNode = nodeArray->elements[tokIdx];
+          }
         }
       }
       jsonTok = strtok(NULL, ".");
     }
-    if (matchFound) {
-      jsonObjectRemoveNode(parentNode, activeNode);
+    if (tokenMatchFound) { // jsonTok must be NULL (no more tokens), so we matched everything
+      jsonRemoveNode(parentNode, activeNode);
     }
-//   printf("deleteJson afterloop jsonTok=%s matchFound=%d nodeType=%d\n", jsonTok, matchFound, activeNode->type);
+    free(copiedKey);
   }
 }
 

--- a/c/json.c
+++ b/c/json.c
@@ -2757,9 +2757,7 @@ static void deleteJson(Json *base, const char *deleteKey) {
           if (rrc == 0 && matches[3].rm_eo < strlen(jsonTok) && matches[3].rm_so < matches[3].rm_eo) {
             arrayIdx = parseInt(jsonTok + matches[3].rm_so, 0, matches[3].rm_eo - matches[3].rm_so);
             // set the jsonTok array `[nnn]` to end-of-string, e.g. a[0] -> a
-            if (matches[1].rm_so != -1) {
-              memset(jsonTok + matches[2].rm_so, '\0', matches[2].rm_eo - matches[2].rm_so); // sets effective memory in either workStr or copiedKey, both safe to mutate
-            }
+            memset(jsonTok + matches[2].rm_so, '\0', matches[2].rm_eo - matches[2].rm_so); // sets effective memory in either workStr or copiedKey, both safe to mutate
           }
         }
         if (jsonIsObject(activeNode)) {

--- a/c/json.c
+++ b/c/json.c
@@ -2752,9 +2752,9 @@ static void deleteJson(Json *base, const char *deleteKey) {
           regmatch_t matches[4];
           regexComp(argPattern,pat,REG_EXTENDED);
           int rrc = regexExec(argPattern,jsonTok,4,matches,0);
-          printf("match indexes: %d %d \n", matches[3].rm_so, matches[3].rm_eo); fflush(stdout);
+          // printf("match indexes: %d %d \n", matches[3].rm_so, matches[3].rm_eo); fflush(stdout);
           // if we have a matched array index, set the arrayIdx, otherwise, leave jsonTok as-is
-          if (rrc == 0 && matches[3].rm_so < matches[3].rm_eo) {
+          if (rrc == 0 && matches[3].rm_eo < strlen(jsonTok) && matches[3].rm_so < matches[3].rm_eo) {
             arrayIdx = parseInt(jsonTok + matches[3].rm_so, 0, matches[3].rm_eo - matches[3].rm_so);
             // set the jsonTok array `[nnn]` to end-of-string, e.g. a[0] -> a
             if (matches[1].rm_so != -1) {

--- a/c/utils.c
+++ b/c/utils.c
@@ -88,6 +88,21 @@ int nullTerminate(char *str, int len){
   return 0;
 }
 
+int isUnsignedInt(const char *str) {
+  if (str == NULL || *str == '\0') {
+    return FALSE;
+  }
+
+  const char *p = str;
+  while (*p != '\0') {
+    if (!isdigit(*p)) {
+      return FALSE;
+    }
+    p++;
+  }
+  return TRUE;
+}
+
 int isZeros(char *data, int offset, int length){
   int i;
   for (i=0; i<length; i++){

--- a/c/yaml2json.c
+++ b/c/yaml2json.c
@@ -354,9 +354,6 @@ void pprintYAML(yaml_document_t *document){
   pprintYAML1(document,yaml_document_get_root_node(document),0);
 }
 
-#define MAX_JSON_KEY 256
-#define MAX_JSON_STRING 65536
-
 /* this needs to be smarter some day
    Refer to Yaml spec http://yaml.org/spec/1.2-old/spec.html#id2805071
  */

--- a/h/json.h
+++ b/h/json.h
@@ -668,7 +668,7 @@ char* jsonBuildKey(JsonBuilder *b, const char *key, int len);
 #define JSON_MERGE_FLAG_TAKE_BASE          0x0003   /* len(merge) = len(b) */
 #define JSON_MERGE_FLAG_TAKE_OVERRIDES     0x0004   /* len(merge) = len(a) */
 
-Json *jsonDelete(ShortLivedHeap *slh, char *keyToDelete, Json *base, int *statusPtr);
+Json *jsonDelete(ShortLivedHeap *slh, const char *keyToDelete, Json *base, int *statusPtr);
 Json *jsonMerge(ShortLivedHeap *slh, Json *overrides, Json *base, int flags, int *statusPtr);
 Json *jsonCopy(ShortLivedHeap *slh, Json *value);
 

--- a/h/json.h
+++ b/h/json.h
@@ -655,6 +655,9 @@ Json *jsonBuildNull(JsonBuilder *b,
 
 char* jsonBuildKey(JsonBuilder *b, const char *key, int len);
 
+#define MAX_JSON_KEY 256
+#define MAX_JSON_STRING 65536
+
 #define JSON_MERGE_STATUS_SUCCESS 0
 #define JSON_MERGE_STATUS_UNMERGEABLE_TYPES 1
 #define JSON_MERGE_STATUS_UNIMPLEMENTED 2

--- a/h/json.h
+++ b/h/json.h
@@ -668,6 +668,7 @@ char* jsonBuildKey(JsonBuilder *b, const char *key, int len);
 #define JSON_MERGE_FLAG_TAKE_BASE          0x0003   /* len(merge) = len(b) */
 #define JSON_MERGE_FLAG_TAKE_OVERRIDES     0x0004   /* len(merge) = len(a) */
 
+Json *jsonDelete(ShortLivedHeap *slh, char *keyToDelete, Json *base, int *statusPtr);
 Json *jsonMerge(ShortLivedHeap *slh, Json *overrides, Json *base, int flags, int *statusPtr);
 Json *jsonCopy(ShortLivedHeap *slh, Json *value);
 

--- a/h/json.h
+++ b/h/json.h
@@ -671,7 +671,7 @@ char* jsonBuildKey(JsonBuilder *b, const char *key, int len);
 #define JSON_MERGE_FLAG_TAKE_BASE          0x0003   /* len(merge) = len(b) */
 #define JSON_MERGE_FLAG_TAKE_OVERRIDES     0x0004   /* len(merge) = len(a) */
 
-Json *jsonDelete(ShortLivedHeap *slh, const char *keyToDelete, Json *base, int *statusPtr);
+Json *jsonDelete(ShortLivedHeap *slh, const char *keyToDelete, Json *base);
 Json *jsonMerge(ShortLivedHeap *slh, Json *overrides, Json *base, int flags, int *statusPtr);
 Json *jsonCopy(ShortLivedHeap *slh, Json *value);
 

--- a/tests/js/config1.js
+++ b/tests/js/config1.js
@@ -97,6 +97,29 @@ var loadAndExtract = function(){
             if (yamlStatus2 == 0){
               console.log(""+modText);
             }
+
+            const delCases = [
+                "A",
+                "colors",
+                "D.A",
+                "D",
+                "E.A",
+                "F.A",
+                "F.C",
+                "G.A.B.C.D",
+                "G"
+            ]
+            for (const delCase of delCases) {
+                const delCfgName = "delConfig_"+delCase;
+                status = cmgr.deleteFromConfiguration(configName, delCfgName, delCase);
+                console.log(status);
+                let [yamlStatus3, delText ] = cmgr.writeYAML(delCfgName);
+                console.log('------')
+                if (yamlStatus3 == 0) {
+                    console.log(""+delText)
+                } 
+            }
+            
         }
     } else {
         console.log("validation failed, contact Zowe support");

--- a/tests/js/config1.js
+++ b/tests/js/config1.js
@@ -81,7 +81,7 @@ var loadAndExtract = function(){
         } else {
             console.log("no exceptions seen");
             let theConfig = cmgr.getConfigData(configName);
-            console.log("configData is loaded \n"+JSON.stringify(theConfig,null,"\n"));
+            console.log("configData is loaded \n"+JSON.stringify(theConfig,null,2));
             console.log("listenerPort is "+theConfig.listenerPort)
             status = cmgr.makeModifiedConfiguration(configName, /* name of existing config */
                                                     "modConfig", /* name of new config with mods */
@@ -134,11 +134,11 @@ var loadAndExtract = function(){
                 status = cmgr.copyConfigurationAndDeleteKey(configName, delCfgName, delCase);
                 let [yamlStatus3, delText ] = cmgr.writeYAML(delCfgName);
                 if (yamlStatus3 == 0) {
-                    console.log(`Deleting ${delCase}`);
+                    console.log(`Deleting "${delCase}"`);
                     console.log(""+delText)
                 }
                 if (yamlStatus3 != 0 || status != 0) {
-                    throw new Error(`${delCase} test failed`);
+                    throw new Error(`"${delCase}" test failed`);
                 }
             }
 

--- a/tests/js/config1.js
+++ b/tests/js/config1.js
@@ -7,7 +7,7 @@ console.log("hello ConfigMgr, args were ["+scriptArgs+"]");
 
   From zowe-common-c/c
 
-  configmgr -script ../tests/js/config1.js -s "../tests/schemadata/zoweappserver.json:../tests/schemadata/zowebase.json:../tests/schemadata/zowecommon.json" -p "FILE(../tests/schemadata/bundle1.json)" 
+  configmgr -script ../tests/js/config1.js -s "../tests/schemadata/zoweappserver.json:../tests/schemadata/zowebase.json:../tests/schemadata/zowecommon.json" -p "FILE(../tests/schemadata/bundle1.json)"
 
   Testing ZSS schemas
 
@@ -120,7 +120,13 @@ var loadAndExtract = function(){
                 "_zsf.debugging.level",
                 "[_test.array[0]]",
                 "[_test.array[2]]",
-                "[_test.array[3]].[_test.nested[0]]"
+                "[_test.array[3]].[_test.nested[0]]",
+                "key256aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "key which is defined",
+                "key which is not defined",
+                "ugly\nkey",
+                " ",
+                "  "
             ]
             console.log(`----Delete Cases----`)
             for (const delCase of delCases) {
@@ -135,7 +141,7 @@ var loadAndExtract = function(){
                     throw new Error(`${delCase} test failed`);
                 }
             }
-            
+
         }
     } else {
         console.log("validation failed, contact Zowe support");

--- a/tests/js/config1.js
+++ b/tests/js/config1.js
@@ -98,7 +98,6 @@ var loadAndExtract = function(){
               console.log(""+modText);
             }
 
-
             const delCases = [
                 "",
                 "      ",
@@ -109,22 +108,32 @@ var loadAndExtract = function(){
                 "E.A",
                 "F.A",
                 "F.C",
-                "G.A.B.C.D",
-                "G",
-                "colors.0",
-                "colors.1ab",
-                "G.A.B.D.1",
-                "G.A.B.D.1.C"
+                "G[.A.B.C.D",
+                "G[",
+                "colors[0]",
+                "colors.1a",
+                "colors[5]",
+                "colors[5].1",
+                "G[.A.B.D[1]",
+                "G[.A.B.D[1].C",
+                "[_zsf.debugging.level]",
+                "_zsf.debugging.level",
+                "[_test.array[0]]",
+                "[_test.array[2]]",
+                "[_test.array[3]].[_test.nested[0]]"
             ]
+            console.log(`----Delete Cases----`)
             for (const delCase of delCases) {
                 const delCfgName = "delConfig_"+delCase;
-                status = cmgr.deleteFromConfiguration(configName, delCfgName, delCase);
-                console.log(status);
+                status = cmgr.copyConfigurationAndDeleteKey(configName, delCfgName, delCase);
                 let [yamlStatus3, delText ] = cmgr.writeYAML(delCfgName);
-                console.log('------')
                 if (yamlStatus3 == 0) {
+                    console.log(`Deleting ${delCase}`);
                     console.log(""+delText)
-                } 
+                }
+                if (yamlStatus3 != 0 || status != 0) {
+                    throw new Error(`${delCase} test failed`);
+                }
             }
             
         }

--- a/tests/js/config1.js
+++ b/tests/js/config1.js
@@ -98,7 +98,10 @@ var loadAndExtract = function(){
               console.log(""+modText);
             }
 
+
             const delCases = [
+                "",
+                "      ",
                 "A",
                 "colors",
                 "D.A",
@@ -107,7 +110,11 @@ var loadAndExtract = function(){
                 "F.A",
                 "F.C",
                 "G.A.B.C.D",
-                "G"
+                "G",
+                "colors.0",
+                "colors.1ab",
+                "G.A.B.D.1",
+                "G.A.B.D.1.C"
             ]
             for (const delCase of delCases) {
                 const delCfgName = "delConfig_"+delCase;

--- a/tests/schemadata/bundle1.json
+++ b/tests/schemadata/bundle1.json
@@ -3,7 +3,7 @@
   "listenerPort": 3444,
   "BB": "FOO",
   "Z": "60609",
-  "colors": [ "blue", "green"],
+  "colors": [ "blue", "green", "red", "yellow"],
   "D" : {
     "A": "apsle",
     "B": "bad"
@@ -29,6 +29,10 @@
           "A": "another",
           "B":"bad",
           "D":"day"
+          }, {
+            "C": "car",
+            "E": "evergreen",
+            "F": "flora"
           }]
       }
     }

--- a/tests/schemadata/bundle1.json
+++ b/tests/schemadata/bundle1.json
@@ -35,7 +35,7 @@
           "D": "daffodil",
           "E": "evergreen",
           "F": "flora"
-        }, 
+        },
         "D": [
           {
           "A": "another",
@@ -48,5 +48,10 @@
           }]
       }
     }
-  }
+  },
+  "key256aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa": "256",
+  "key which is defined": "true",
+  "ugly\nkey": "Ahoy",
+  " ": "Key is space",
+  "  ": "Key is two spaces"
 }

--- a/tests/schemadata/bundle1.json
+++ b/tests/schemadata/bundle1.json
@@ -3,7 +3,19 @@
   "listenerPort": 3444,
   "BB": "FOO",
   "Z": "60609",
-  "colors": [ "blue", "green", "red", "yellow"],
+  "_zsf.debugging.level": "TRACE",
+  "_test.array": [
+    "apple",
+    "banana",
+    "cherry",
+    { "_test.nested": ["dragonfruit", "eggplant"] }
+  ],
+  "_zsf": {
+    "debugging": {
+      "level": "TRACE"
+    }
+  },
+  "colors": [ "blue", "green", "red", "yellow", "0", {"1" : "not_a_color" }],
   "D" : {
     "A": "apsle",
     "B": "bad"
@@ -15,8 +27,8 @@
     "A": "afple",
     "B": "bfd",
     "C": "car"
-  }, 
-  "G": {
+  },
+  "G[": {
     "A": {
       "B": {
         "C": {

--- a/tests/schemadata/bundle1.json
+++ b/tests/schemadata/bundle1.json
@@ -3,5 +3,34 @@
   "listenerPort": 3444,
   "BB": "FOO",
   "Z": "60609",
-  "colors": [ "blue", "green"]
+  "colors": [ "blue", "green"],
+  "D" : {
+    "A": "apsle",
+    "B": "bad"
+  },
+  "E": {
+    "A": "aeple"
+  },
+  "F": {
+    "A": "afple",
+    "B": "bfd",
+    "C": "car"
+  }, 
+  "G": {
+    "A": {
+      "B": {
+        "C": {
+          "D": "daffodil",
+          "E": "evergreen",
+          "F": "flora"
+        }, 
+        "D": [
+          {
+          "A": "another",
+          "B":"bad",
+          "D":"day"
+          }]
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Proposed changes
**Note**: Ready for review.

This PR adds a new `copyConfigurationAndDeleteKey` API to configmgr which can be used to delete keys from a YAML document. e.g., deleting `zowe.setup` or `zowe.setup.dataset` is now possible. The `copyConfigurationAndDeleteKey` API requires that a new configuration name be supplied, so the mutation happens in a **new copy** of the configuration (matching other update APIs). This is required as part of the Node.JS removal from zwe scripts, and is last step to fully replace the `config-converter` component we use from zowe-install-packaging-tools. 

The existing modification APIs were not used after experimentation, as the modification / overlay is a union style merge operation rather than a replacement. While that could've been enhanced to support deleting keys, it felt better to have a clean line of separation between the 2 behaviors.

Limitations in regex made parsing of keys containing multiple periods less readable than I wanted, so the code has additional comments in the parsing section.


This PR addresses Issue: Part of https://github.com/zowe/zowe-install-packaging/pull/4307

## Type of change
Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Change in a documentation
- [ ] Refactor the code 
- [ ] Chore, repository cleanup, updates the dependencies.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zss/blob/v2.x/master/CONTRIBUTING.md))
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works, or describe a test method below

## Testing
Added unit tests in `tests/js/config1.js`.

## Further comments
Supports:
* Deleting composite array and object keys. e.g., both `zowe.externalHosts` and `zowe.externalHosts[0]` are supported (and yield different outputs).
* Deleting composite keys where a key entry contains periods. Syntax: `zowe.[_zsf.logging.level]`. Works for arrays too: `zowe.[_demo.key[0]].[another.key]`
```yaml
zowe:
  _zsf.logging.level: TRACE
  _demo.key:
    - another.key: SOMETHING
```


* If the delete key supplied does not exist, this is a no-op, and returns the document as-is. This matches the config-converter behavior.


Notes:
* If you delete the only property of an object, the render outputs curly braces. e.g.:
```yaml
zowe:
  a:
```
 Running `delete "zowe.a"` gives:
 ```yaml
zowe: {}
```
This is legal YAML, but might be confusing if a user comes across it? I don't know how to change the render behavior.

* Keys with `[` in position one will not parse as keys, but instead as a key containing periods, which means they will not match and the resulting output will be a no-op. I think this is an acceptable limitation until we have a use case which needs `[` in position one. This might be worked around by: `[[key]`, but is not tested.

