### PR TITLE
Fix unhandled EWOULDBLOCK on httpclient

### DIFF
--- a/c/httpclient.c
+++ b/c/httpclient.c
@@ -1049,7 +1049,17 @@ int httpClientSessionReceiveNativeLoop(HttpClientContext *ctx, HttpClientSession
       bytesRead = socketRead(session->socket, buf, sizeof(buf), &bpxrc, &bpxrsn);
       if (bytesRead < 1) {
         HTTP_CLIENT_TRACE_VERBOSE("http client nativeLoop socket read error rc=%d, rsn=0x%x\n", bpxrc, bpxrsn);
-        sts = HTTP_CLIENT_READ_ERROR;
+        if (bpxrc == 0x44E) { // EWOULDBLOCK
+          if (bpxrsn == 0x0211) { // JRTimeOut
+            sts = HTTP_CLIENT_SOCKET_TIMEOUT;
+          } else {
+            sts = HTTP_CLIENT_UNBLOCKED_TRY_AGAIN;
+          }
+        } else if (bpxrc == 0x70) { // EAGAIN
+          sts = HTTP_CLIENT_UNBLOCKED_TRY_AGAIN;
+        } else {
+          sts = HTTP_CLIENT_READ_ERROR;
+        }
         break;
       }
       ansiStatus = processHttpResponseFragment(session->responseParser, buf, bytesRead, &(session->response));
@@ -1093,7 +1103,17 @@ int httpClientSessionReceiveNative(HttpClientContext *ctx, HttpClientSession *se
     buf = SLHAlloc(session->slh, maxlen);
     buflen = socketRead(session->socket, buf, maxlen, &bpxrc, &bpxrsn);
     if (buflen < 1) {
-      sts = HTTP_CLIENT_READ_ERROR;
+      if (bpxrc == 0x44E) { // EWOULDBLOCK
+        if (bpxrsn == 0x0211) { // JRTimeOut
+          sts = HTTP_CLIENT_SOCKET_TIMEOUT;
+        } else {
+          sts = HTTP_CLIENT_UNBLOCKED_TRY_AGAIN;
+        }
+      } else if (bpxrc == 0x70) { // EAGAIN
+        sts = HTTP_CLIENT_UNBLOCKED_TRY_AGAIN;
+      } else {
+        sts = HTTP_CLIENT_READ_ERROR;
+      }
       break;
     }
 

--- a/h/httpclient.h
+++ b/h/httpclient.h
@@ -47,6 +47,8 @@ extern "C" {
 #define HTTP_CLIENT_RESPONSE_ZEROLEN      16
 #define HTTP_CLIENT_TLS_ERROR             17
 #define HTTP_CLIENT_TLS_NOT_CONFIGURED    18
+#define HTTP_CLIENT_UNBLOCKED_TRY_AGAIN   19
+#define HTTP_CLIENT_SOCKET_TIMEOUT        20
 
 typedef struct HttpClientSettings_tag {
   char *host;


### PR DESCRIPTION
This PR adds status codes HTTP_CLIENT_UNBLOCKED_TRY_AGAIN (19) and HTTP_CLIENT_SOCKET_TIMEOUT (20) to httpclient.
httpclient is a non-blocking client, so it is up to users to implement wait-retry logic, yet codes such as EWOULDBLOCK were unhandled before, so there was no way to do this.

This appears to have been a bug that would prevent all use of httpclient, except that in the case of GSK, either it's blocking or introduces just enough delay that EWOULDBLOCK is uncommon.

This bug became apparent when using ATTLS, in which GSK is not present within Zowe itself. In this case, the socket read can happen faster than data is available, and therefore clients need to handle EWOULDBLOCK somehow.

This is accomplished by assigning such EWOULDBLOCK and errors like it (EAGAIN, JRTimeOut) to HTTP_CLIENT_UNBLOCKED_TRY_AGAIN and HTTP_CLIENT_SOCKET_TIMEOUT.

This is an fix to functions httpClientSessionReceiveNativeLoop and httpClientSessionReceiveNative
