### PR TITLE
Fix unhandled EWOULDBLOCK on httpclient (v2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Zowe Common C Changelog
 
+## `2.18.2`
+- Bugfix: Improve httpclient non-blocking error codes for use by clients ([#534](https://github.com/zowe/zowe-common-c/pull/534))
+
 ## `2.18.1`
 - Bugfix: IARV64 results must be checked for 0x7FFFF000 (#474)
 - Bugfix: SLH should not ABEND when MEMLIMIT is reached (additional NULL check)

--- a/c/httpclient.c
+++ b/c/httpclient.c
@@ -1038,7 +1038,17 @@ int httpClientSessionReceiveNativeLoop(HttpClientContext *ctx, HttpClientSession
       bytesRead = socketRead(session->socket, buf, sizeof(buf), &bpxrc, &bpxrsn);
       if (bytesRead < 1) {
         HTTP_CLIENT_TRACE_VERBOSE("http client nativeLoop socket read error rc=%d, rsn=0x%x\n", bpxrc, bpxrsn);
-        sts = HTTP_CLIENT_READ_ERROR;
+        if (bpxrc == 0x44E) { // EWOULDBLOCK
+          if (bpxrsn == 0x0211) { // JRTimeOut
+            sts = HTTP_CLIENT_SOCKET_TIMEOUT;
+          } else {
+            sts = HTTP_CLIENT_UNBLOCKED_TRY_AGAIN;
+          }
+        } else if (bpxrc == 0x70) { // EAGAIN
+          sts = HTTP_CLIENT_UNBLOCKED_TRY_AGAIN;
+        } else {
+          sts = HTTP_CLIENT_READ_ERROR;
+        }
         break;
       }
       ansiStatus = processHttpResponseFragment(session->responseParser, buf, bytesRead, &(session->response));
@@ -1082,7 +1092,17 @@ int httpClientSessionReceiveNative(HttpClientContext *ctx, HttpClientSession *se
     buf = SLHAlloc(session->slh, maxlen);
     buflen = socketRead(session->socket, buf, maxlen, &bpxrc, &bpxrsn);
     if (buflen < 1) {
-      sts = HTTP_CLIENT_READ_ERROR;
+      if (bpxrc == 0x44E) { // EWOULDBLOCK
+        if (bpxrsn == 0x0211) { // JRTimeOut
+          sts = HTTP_CLIENT_SOCKET_TIMEOUT;
+        } else {
+          sts = HTTP_CLIENT_UNBLOCKED_TRY_AGAIN;
+        }
+      } else if (bpxrc == 0x70) { // EAGAIN
+        sts = HTTP_CLIENT_UNBLOCKED_TRY_AGAIN;
+      } else {
+        sts = HTTP_CLIENT_READ_ERROR;
+      }
       break;
     }
 

--- a/h/httpclient.h
+++ b/h/httpclient.h
@@ -47,6 +47,8 @@ extern "C" {
 #define HTTP_CLIENT_RESPONSE_ZEROLEN      16
 #define HTTP_CLIENT_TLS_ERROR             17
 #define HTTP_CLIENT_TLS_NOT_CONFIGURED    18
+#define HTTP_CLIENT_UNBLOCKED_TRY_AGAIN   19
+#define HTTP_CLIENT_SOCKET_TIMEOUT        20
 
 typedef struct HttpClientSettings_tag {
   char *host;


### PR DESCRIPTION
See https://github.com/zowe/zowe-common-c/pull/533 for description - this is the same but for v2.