### PR TITLE
IPv6 enhancements for bpx/mtl socket

### DIFF
--- a/c/bpxskt.c
+++ b/c/bpxskt.c
@@ -45,6 +45,8 @@
 #pragma linkage(BPX4WRT,OS)
 #pragma linkage(BPX4FCT,OS)
 #pragma linkage(BPX4CLO,OS)
+#pragma linkage(BPX4GAI,OS)
+#pragma linkage(BPX4FAI,OS)
 
 #define BPXSOC BPX4SOC
 #define BPXCON BPX4CON
@@ -64,6 +66,8 @@
 #define BPXWRT BPX4WRT
 #define BPXFCT BPX4FCT
 #define BPXCLO BPX4CLO
+#define BPXGAI BPX4GAI
+#define BPXFAI BPX4FAI
 
 #else
 
@@ -85,6 +89,9 @@
 #pragma linkage(BPX1WRT,OS)
 #pragma linkage(BPX1FCT,OS)
 #pragma linkage(BPX1CLO,OS)
+#pragma linkage(BPX1GAI,OS)
+#pragma linkage(BPX1FAI,OS)
+
 
 #define BPXSOC BPX1SOC
 #define BPXCON BPX1CON
@@ -104,6 +111,8 @@
 #define BPXWRT BPX1WRT
 #define BPXFCT BPX1FCT
 #define BPXCLO BPX1CLO
+#define BPXGAI BPX1GAI
+#define BPXFAI BPX1FAI
 
 #endif
 
@@ -127,7 +136,8 @@ int BPXRED();
 int BPXWRT();
 int BPXFCT();
 int BPXCLO();
-
+int BPXGAI();
+int BPXFAI();
 
 #define SOCK_SO_REUSEADDR 0x00000004
 #define SOCK_SO_SNDBUF    0x00001001
@@ -146,6 +156,637 @@ int BPXCLO();
 #endif
 
 static int socketTrace = 0;
+
+#ifndef Addr_Info
+
+/* the netdb.h version of addrinfo uses opaque types for ai_addr that prevent
+ * functions like AddrInfo_convert from working */
+
+#ifndef socklen_t
+typedef unsigned int socklen_t;
+#endif
+
+#ifndef AF_UNSPEC
+#define AF_UNSPEC       0       /* matches sys/socket.h */
+#endif
+
+/* confirmed applicability by looking at SYS1.MACLIB(EZBREHST) */
+typedef struct addrinfo
+{
+#define AI_PASSIVE      (1 << 0)
+#define AI_CANONNAMEOK  (1 << 1)
+#define AI_NUMERICHOST  (1 << 2)
+#define AI_NUMERICSERV  (1 << 3)
+#define AI_V4MAPPED     (1 << 4)
+#define AI_ALL          (1 << 5)
+#define AI_ADDRCONFIG   (1 << 6)
+#define AI_EXTFLAGS     (1 << 7)
+  int              ai_flags;     /* AI_PASSIVE, AI_CANONNAME */
+  int              ai_family;    /* PF_xxx */
+  int              ai_socktype;  /* SOCK_xxx */
+  int              ai_protocol;  /* 0 or IPPROTO_xxx */
+  socklen_t        ai_addrlen;   /* length of ai_addr */
+  int              __ai_reserved;/* reserved */
+  __pad31( __ai_canonname_r,4 )  /* 31-bit padding */
+  char            *ai_canonname; /* canonical name for hostname */
+  __pad31( __ai_addr_r,4 )       /* 31-bit padding */
+  struct socketAddr_tag *ai_addr; /* binary address consistent with sockaddr_in(6) */
+  __pad31( __ai_next_r,4 )       /* 31-bit padding */
+  struct addrinfo *ai_next;      /* next structure in list */
+  #if __EDC_TARGET >= __EDC_LE410C
+    int            ai_eflags;    /* source IP addr pref */
+  #endif  /* __EDC_TARGET >= __EDC_LE410C */
+} Addr_Info;
+
+#endif /* Addr_Info undefined */
+
+static int addrInfoTrace = 0;
+int setAddrInfoTrace(int toWhat) {
+  int was = addrInfoTrace;
+#ifndef METTLE
+  addrInfoTrace = toWhat;
+#endif
+  return was;
+}
+
+AddrInfoList getAddressInfoList(const char* nodeName, const char* serviceName,
+                                char** out_canonicalName,
+                                int *out_rc, int *out_rsn)
+{
+  Addr_Info *addrInfoList = NULL;
+  int rv = 0;
+  int nodeNameLen = 0;
+  int serviceNameLen = 0;
+  int canonicalNameLen = 0;
+  /* "To get the most useful set of IP addresses available for the
+   *  requested host name, applications that are enabled for IPv6
+   *  processing should specify AI_V4MAPPED, AI_ALL, and AI_ADDRCONFIG
+   *  in the ai_flags field; and AF_UNSPEC for the ai_family field in the
+   *  input Addr_Info structure pointed to by the Hints_Ptr parameter.
+   *
+   *  When the stack has IPv6 capability, requests that are coded with
+   *  AF_UNSPEC are treated as if the request is for AF_INET6, and all
+   *  addresses are returned using sock_inet6_sockaddr structures (with the
+   *  IPv4 addresses mapped appropriately, based on the AI_V4MAPPED setting).
+   *  If there is no IPv6 capability, IPv4 addresses are returned in
+   *  sock_inet_sockaddr structures.
+   *
+   *  This frees the application, to some extent, from having to decide what
+   *  format works for the stack." */
+  Addr_Info hints;
+  memset(&hints, 0x00, sizeof(Addr_Info));
+
+  hints.ai_flags = AI_V4MAPPED | AI_ALL | AI_ADDRCONFIG | AI_CANONNAMEOK;
+  hints.ai_family = AF_UNSPEC; /* AF_UNSPEC is defined to 0 in sys/socket.h */
+
+  Addr_Info *hintsPtr = &hints;
+
+  do {
+    if ((NULL == nodeName) && (NULL == serviceName)) {
+      break;
+    }
+    if (nodeName) {
+      nodeNameLen = strlen(nodeName);
+    }
+    if (serviceName) {
+      serviceNameLen = strlen(serviceName);
+    }
+
+    if (addrInfoTrace) {
+      printf("about to call BPXGAI...\n");
+    }
+
+    BPXGAI(nodeName,
+           &nodeNameLen,
+           serviceName,
+           &serviceNameLen,
+           &hintsPtr,
+           &addrInfoList,
+           &canonicalNameLen, /* length of ai_canonname in first returned list entry */
+           &rv,
+           out_rc,
+           out_rsn);
+    if (addrInfoTrace) {
+      printf("BPXGAI returned rv:%d, rc:%d, rsn:0x%x, ailist:0x%p, cnl=%d\n",
+             rv, *out_rc, *out_rsn, addrInfoList, canonicalNameLen);
+    }
+
+    if ((0 == *out_rc) && (0 < canonicalNameLen) && (NULL != out_canonicalName))
+    {
+      Addr_Info *firstAddrInfo = (Addr_Info*) addrInfoList;
+      char* name = (char*) safeMalloc(1 + canonicalNameLen, "name");
+      memcpy(name, firstAddrInfo->ai_canonname, canonicalNameLen);
+      name[canonicalNameLen] = '\0';
+      *out_canonicalName = name;
+      if (addrInfoTrace) {
+        printf("getAddressInfoList returning canonicalName: %s\n", name);
+      }
+    }
+
+  } while(0);
+
+  return (AddrInfoList) addrInfoList;
+}
+
+static int data6_isV4mappable(const struct ipV6Data in_data6)
+{
+  int ansiStatus = ANSI_FALSE;
+
+  do {
+    /**
+     *
+  Hinden                      Standards Track                    [Page 10]
+  RFC 4291              IPv6 Addressing Architecture         February 2006
+
+  2.5.5.2.  IPv4-Mapped IPv6 Address
+
+  A second type of IPv6 address that holds an embedded IPv4 address is
+  defined.  This address type is used to represent the addresses of
+  IPv4 nodes as IPv6 addresses.  The format of the "IPv4-mapped IPv6
+  address" is as follows:
+
+  |                80 bits               | 16 |      32 bits        |
+  +--------------------------------------+--------------------------+
+  |0000..............................0000|FFFF|    IPv4 address     |
+  +--------------------------------------+----+---------------------+
+     */
+    const unsigned char v4mappedPrefix[12] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                                              0x00, 0x00, 0xFF, 0xFF};
+    if (0 == memcmp(&(v4mappedPrefix[0]),
+                    &(in_data6.addrData[0]),
+                    sizeof(v4mappedPrefix)))
+    {
+      if (addrInfoTrace) {
+        printf("data6_isV4mappable TRUE because prefix matched addrData content\n");
+      }
+      ansiStatus = ANSI_TRUE;
+    }
+
+  } while(0);
+
+  return ansiStatus;
+}
+
+static int InetAddr_isV4mappable(const InetAddr *inetAddr)
+{
+  int ansiStatus = ANSI_FALSE;
+
+  do {
+    if (NULL == inetAddr)
+      break;
+
+    switch(inetAddr->type)
+    {
+      case AF_INET:
+      {
+        ansiStatus = ANSI_TRUE;
+        break;
+      }
+
+      case AF_INET6:
+      {
+        ansiStatus = data6_isV4mappable(inetAddr->data.data6);
+        break;
+      }
+    }
+  } while(0);
+
+  return ansiStatus;
+}
+
+static int SocketAddress_isV4mappable(const SocketAddress *socketAddress)
+{
+  int ansiStatus = ANSI_FALSE;
+
+  do {
+    if (NULL == socketAddress)
+      break;
+
+    int ifam = (int) socketAddress->family;
+    switch(ifam) {
+      case AF_INET:
+      {
+        ansiStatus = ANSI_TRUE;
+        break;
+      }
+
+      case AF_INET6:
+      {
+        ansiStatus = data6_isV4mappable(socketAddress->data6);
+        break;
+      }
+    }
+  } while(0);
+
+  return ansiStatus;
+}
+
+/**
+ * @brief       Output a string representation of an IP address to a caller-supplied buffer.
+ *
+ * @param[in]     socketAddress A handle returned by getAddressInfoList
+ * @param[in,out] strbuf        Caller-supplied output buffer
+ * @param[in,out] len           Pointer to caller-supplied int.
+ *                                On input, specify available size in inout_strbuf.
+ *                                On output:
+ *                                  If ANSI_OK, length of output including null terminator
+ *                                  If ANSI_FAILED due to insufficient space, required length
+ *
+ * @return      ANSI_OK if a string was composed and output to the buffer.
+ *              ANSI_FAILED if a string was not composed or the output space was too small.
+ */
+int SocketAddress_toString(const SocketAddress *in_socketAddress,
+                           char* inout_strbuf, int* inout_len)
+{
+  int ansiStatus = ANSI_FAILED;
+  /**
+   * As described in RFC 4291, the preferred form is "x:x:x:x:x:x:x:x", where
+   * Each x is a 16-bit section (dubbed a 'hextet') that can be represented
+   * using up to four hexadecimal digits, with the sections separated by colons.
+   *
+   * Longest form would be:
+   * "1234:5678:90ab:cdef:1234:5678:90ab:cdef[null]" so 40 bytes
+   *
+   * If we include a suffix for the port number (colon plus <=5 digits), the
+   * max length is 46 bytes.  64-byte buffer gives us some flexibility around
+   * formatting.
+   *
+   * Conventions for shortening:
+   * - omit leading zeroes from each hextet
+   * - omit hextets with all-zeroes
+   *    - double-colon "::" represents any continuuous string of
+   *      two or more hextets that are all zeroes, but this can
+   *      only be done once without ambiguous results
+   *
+   * For now, we'll ignore the shortening conventions and strive for
+   * accuracy of both AF_INET and AF_INET6 forms.
+   *
+   * One exception could be AF_INET6 addresses known to be V4-mapped. TBD.
+   */
+  do {
+    if ((NULL == in_socketAddress) || (NULL == inout_strbuf) || (NULL == inout_len)) {
+      break;
+    }
+    int available = *inout_len;
+    int required = 0;
+    char tmpbuf[64] = {0};
+    int ifam = (int) in_socketAddress->family;
+
+    switch(ifam)
+    {
+      case AF_INET:
+      {
+        const unsigned char* data = &(in_socketAddress->v4Addr[0]);
+        sprintf(tmpbuf, "%d.%d.%d.%d", data[0], data[1], data[2], data[3]);
+        required = 1 + strlen(tmpbuf);
+        break;
+      }
+
+      case AF_INET6:
+      {
+        if (SocketAddress_isV4mappable(in_socketAddress)) {
+          /* mapped V4 format - take bytes from indexes 12, 13, 14, 15 */
+          const unsigned char* data = &(in_socketAddress->data6.addrData[12]);
+          sprintf(tmpbuf, "::ffff:%d.%d.%d.%d", data[0], data[1], data[2], data[3]);
+          required = 1 + strlen(tmpbuf);
+        } else {
+          /* IPv6 format */
+          unsigned short us1=0, us2=0, us3=0, us4=0, us5=0, us6=0, us7=0, us8=0;
+          const char* data = &(in_socketAddress->data6.addrData[0]);
+          us1 = (data[0] << 8) + data[1];
+          us2 = (data[2] << 8) + data[3];
+          us3 = (data[4] << 8) + data[5];
+          us4 = (data[6] << 8) + data[7];
+          us5 = (data[8] << 8) + data[9];
+          us6 = (data[10] << 8) + data[11];
+          us7 = (data[12] << 8) + data[13];
+          us8 = (data[14] << 8) + data[15];
+          sprintf(tmpbuf, "%x:%x:%x:%x:%x:%x:%x:%x",
+                  us1, us2, us3, us4, us5, us6, us7, us8);
+          required = 1 + strlen(tmpbuf);
+        }
+        break;
+      }
+    }
+
+    if (!required) {
+      /* we didn't compose, break and return failed */
+      break;
+    }
+
+    if (available < required) {
+      *inout_len = required;
+      break;
+    }
+
+    memcpy(inout_strbuf, tmpbuf, required);
+    *inout_len = required;
+    ansiStatus = ANSI_OK;
+
+  } while(0);
+
+  return ansiStatus;
+}
+
+int AddrInfo_isV4mappable(const void *in_addrInfo)
+{
+  int ansiStatus = ANSI_FALSE;
+  const Addr_Info *addrInfo = (const Addr_Info *) in_addrInfo;
+
+  do {
+    if (NULL == addrInfo)
+      break;
+
+    switch (addrInfo->ai_family)
+    {
+      case AF_INET:
+      {
+        if (addrInfoTrace) {
+          printf("AddrInfo_isV4mappable TRUE because AF_INET\n");
+        }
+        ansiStatus = ANSI_TRUE;
+        break;
+      }
+
+      case AF_INET6:
+      {
+        SocketAddress *tmpSocketAddr = (SocketAddress*) (addrInfo->ai_addr);
+        ansiStatus = SocketAddress_isV4mappable(tmpSocketAddr);
+        break;
+      }
+    }
+  } while(0);
+
+  return ansiStatus;
+}
+
+int AddrInfo_convert(const void *in_addrInfo,
+                     SocketAddress **out_socketAddress, InetAddr **out_inetAddr)
+{
+  int ansiStatus = ANSI_FAILED;
+  SocketAddress *socketAddress = NULL;
+  InetAddr *inetAddr = NULL;
+
+  const Addr_Info *addrInfo = (const Addr_Info *) in_addrInfo;
+
+  do {
+    if ((NULL == addrInfo) ||
+        ((NULL == out_socketAddress) && (NULL == out_inetAddr)))
+    {
+      break;
+    }
+
+    int family = addrInfo->ai_family;
+
+    if (out_socketAddress) {
+      socketAddress = (SocketAddress*) safeMalloc31(sizeof(SocketAddress), "socketAddress");
+      memcpy(socketAddress, addrInfo->ai_addr, addrInfo->ai_addrlen);
+      *out_socketAddress = socketAddress;
+
+      if (addrInfoTrace) {
+        printf("AddrInfo_convert output SocketAddress len=%d family=%d\n",
+               (int) (socketAddress->length), (int) (socketAddress->family));
+        dumpbuffer((char*)socketAddress, socketAddress->length);
+      }
+    }
+
+    if (out_inetAddr) {
+      inetAddr = (InetAddr*) safeMalloc31(sizeof(InetAddr), "inetAddr");
+      inetAddr->type = addrInfo->ai_addr->family;
+      inetAddr->port = (int) addrInfo->ai_addr->port;
+      if (AF_INET6 == family) {
+        memcpy(&(inetAddr->data), &(addrInfo->ai_addr->data6), sizeof(addrInfo->ai_addr->data6));
+      } else {
+        memcpy(&(inetAddr->data), &(addrInfo->ai_addr->v4Address), sizeof(addrInfo->ai_addr->v4Address));
+      }
+      *out_inetAddr = inetAddr;
+
+      if (addrInfoTrace) {
+        printf("AddrInfo_convert output InetAddr family=%d port=%d\n",
+               inetAddr->type, inetAddr->port);
+        dumpbuffer((char*)inetAddr, sizeof(InetAddr));
+      }
+    }
+
+    ansiStatus = ANSI_OK;
+
+  } while(0);
+
+  return ansiStatus;
+}
+
+int AddrInfo_convert_IPv4(const void *in_addrInfo,
+                          SocketAddress **out_socketAddress, InetAddr **out_inetAddr)
+{
+  int ansiStatus = ANSI_FAILED;
+  SocketAddress *socketAddress = NULL;
+  InetAddr *inetAddr = NULL;
+
+  const Addr_Info *addrInfo = (const Addr_Info *) in_addrInfo;
+
+  do {
+    if ((NULL == addrInfo) ||
+        ((NULL == out_socketAddress) && (NULL == out_inetAddr)))
+    {
+      break;
+    }
+
+    if (ANSI_FALSE == AddrInfo_isV4mappable(addrInfo)) {
+      break;
+    }
+
+    char* sourceData = NULL;
+
+    switch(addrInfo->ai_family)
+    {
+      case AF_INET:
+      {
+        sourceData = &(addrInfo->ai_addr->v4Addr[0]);
+        if (addrInfoTrace) {
+          printf("AddrInfo_convert_IPv4 from AF_INET source data\n");
+        }
+        break;
+      }
+
+      case AF_INET6:
+      {
+        sourceData = &(addrInfo->ai_addr->data6.addrData[12]); //see data6_isV4mappable
+        if (addrInfoTrace) {
+          printf("AddrInfo_convert_IPv4 from AF_INET6 source data\n");
+        }
+        break;
+      }
+    }
+
+    if (NULL == sourceData)
+      break;
+
+    if (out_socketAddress) {
+      socketAddress = (SocketAddress*) safeMalloc31(sizeof(SocketAddress), "socketAddress");
+      socketAddress->length = 14; /* see SOCK_SIN#LEN in BPXYSOCK */
+      socketAddress->family = AF_INET;
+
+      memcpy(&(socketAddress->v4Addr[0]), sourceData, 4);
+
+      *out_socketAddress = socketAddress;
+
+      if (addrInfoTrace) {
+        printf("AddrInfo_convert_IPv4 output SocketAddress len=%d family=%d\n",
+               (int) (socketAddress->length), (int) (socketAddress->family));
+        dumpbuffer((char*)socketAddress, socketAddress->length);
+      }
+    }
+
+    if (out_inetAddr) {
+      inetAddr = (InetAddr*) safeMalloc31(sizeof(InetAddr), "inetAddr");
+      inetAddr->type = AF_INET;
+
+      memcpy(&(inetAddr->data.data4.addrBytes), sourceData, 4);
+
+      *out_inetAddr = inetAddr;
+
+      if (addrInfoTrace) {
+        printf("AddrInfo_convert_IPv4 output InetAddr family=%d port=%d\n",
+               inetAddr->type, inetAddr->port);
+        dumpbuffer((char*)inetAddr, sizeof(InetAddr));
+      }
+    }
+
+    ansiStatus = ANSI_OK;
+
+  } while(0);
+
+  return ansiStatus;
+}
+
+/**
+ * @brief       Count the AddrInfo entries in addrInfoList
+ *
+ * @detail      Walk the linked list to determine its length.
+ *              If addrInfoList is NULL, returns 0.
+ *              If addrInfoList is non-NULL, returns >= 1.
+ *              DO NOT pass an address that wasn't returned by getAddressInfoList.
+ *
+ * @param[in]     addrInfoList  A handle returned by getAddressInfoList
+ * @param[out]    v4mappable    The number of entries that are either AF_INET or
+ *                              mappable from AF_INET6 to AF_INET.
+ */
+int AddrInfoList_count(AddrInfoList addrInfoList, int *out_v4mappable)
+{
+  const int ADDRINFOLIST_COUNT_MAX = 100; /* prevent infinite loops */
+  int count = 0;
+  int v4mappable = 0;
+
+  do {
+    if (NULL == addrInfoList)
+      break; /* count = 0 */
+
+    count++; /* count = 1 */
+
+    Addr_Info *tmpAddrInfo = (Addr_Info*) addrInfoList;
+    if (AddrInfo_isV4mappable(tmpAddrInfo)) {
+      ++v4mappable;
+    }
+
+    while((NULL != tmpAddrInfo->ai_next) &&
+          (count < ADDRINFOLIST_COUNT_MAX))
+    {
+      ++count;
+      tmpAddrInfo = tmpAddrInfo->ai_next;
+      if (AddrInfo_isV4mappable(tmpAddrInfo)) {
+        ++v4mappable;
+      }
+    }
+
+  } while(0);
+
+  if (out_v4mappable) {
+    *out_v4mappable = v4mappable;
+  }
+
+  if (addrInfoTrace) {
+    printf("AddrInfoList_count returning %d (%d v4mappable) for AddrInfoList @ 0x%p\n",
+           count, v4mappable, addrInfoList);
+  }
+
+  return count;
+}
+
+/**
+ * @brief       Return the AddrInfo handle at the specified index
+ *
+ * @detail      Walk the linked list to the specified index, and return
+ *              the associated AddrInfo handle
+ *
+ * @param[in]     addrInfoList    A handle returned by getAddressInfoList
+ * @param[in]     index           A value between 0 and count-1 (see AddrInfoList_count)
+ * @param[in,out] out_AddrInto    A pointer to an opaque AddrInfo is returned in this location.
+ *
+ * @return      ANSI_OK if an entry was found/returned from the specified index.
+ *              ANSI_FAILED if the index was >= the number of items in the list.
+ */
+int AddrInfoList_getAtIndex(AddrInfoList addrInfoList, int index,
+                            void* *out_AddrInfo)
+{
+  int ansiStatus = ANSI_FAILED;
+  SocketAddress *socketAddress = NULL;
+  InetAddr *inetAddr = NULL;
+
+  do {
+    if (addrInfoTrace) {
+      printf("AddrInfoList_getAtIndex entry (addrInfoList=0x%p, index=%d, outAddrInfo=0x%p)\n",
+             addrInfoList, index, out_AddrInfo);
+    }
+
+    if ((NULL == addrInfoList) ||
+        (0 > index) ||
+        (NULL == out_AddrInfo))
+    {
+      break;
+    }
+
+    Addr_Info *firstAddrInfo = (Addr_Info*) addrInfoList;
+    Addr_Info *tmpAddrInfo = firstAddrInfo;
+    int count = 0;
+    int family = 0;
+
+    do {
+      if (index == count) {
+        family = tmpAddrInfo->ai_family;
+        if ((AF_INET6 == family) || (AF_INET == family)) {
+          ansiStatus = ANSI_OK;
+        }
+        break;
+      }
+      count++;
+      tmpAddrInfo = tmpAddrInfo->ai_next;
+    } while (NULL != tmpAddrInfo);
+
+    if (ANSI_OK != ansiStatus)
+      break;
+
+    *out_AddrInfo = tmpAddrInfo;
+
+  } while(0);
+
+  return ansiStatus;
+}
+
+
+void freeAddressInfoList(AddrInfoList addrInfoList)
+{
+  int rv=0, rc=0, rsn=0;
+  if (addrInfoList) {
+    BPXFAI(&addrInfoList,
+           &rv,
+           &rc,
+           &rsn);
+    if (addrInfoTrace) {
+      printf("BPXFAI returned rv:%d, rc: %d, rsn:0x%x\n", rv, rc, rsn);
+    }
+  }
+}
+
 int setSocketTrace(int toWhat) {
   int was = socketTrace;
 #ifndef METTLE
@@ -153,6 +794,7 @@ int setSocketTrace(int toWhat) {
 #endif
   return was;
 }
+
 
 unsigned int sleep(unsigned int seconds){
   int returnValue;
@@ -177,38 +819,58 @@ int socketInit(char *uniqueName){
   return 0;
 }
 
-SocketAddress *makeSocketAddr(InetAddr *addr, 
-			      unsigned short port){
-  SocketAddress *address = (SocketAddress*)safeMalloc31(sizeof(SocketAddress),"BPX SocketAddress");
+static SocketAddress *makeSocketAddrIPv4(InetAddr *addr,
+                                         unsigned short port){
+  SocketAddress *address = (SocketAddress*)safeMalloc31(sizeof(SocketAddress),"SocketAddress");
   memset(address,0,sizeof(SocketAddress));
-  address->length = 14;
+  if (socketTrace){
+    printf("socket address at 0x%x\n",address);
+  }
+  address->length = 14; /* see SOCK_SIN#LEN in BPXYSOCK */
   address->family = AF_INET;
   address->port = port;
   if (addr){
     address->v4Address = addr->data.data4.addrBytes;
-  } else{
-    address->v4Address = 0; /* 0.0.0.0 */
+  }
+  if (socketTrace){
+    printf("makeSocketAddrIPv4: returning socket address at 0x%x\n",address);
   }
   return address;
 }
 
+SocketAddress *makeSocketAddr(InetAddr *addr,
+                              unsigned short port)
+{
+  if ((NULL == addr) || (AF_INET == addr->type)) {
+    return makeSocketAddrIPv4(addr,port);
+  } else {
+    return makeSocketAddrIPv6(addr,port);
+  }
+}
+
 SocketAddress *makeSocketAddrIPv6(InetAddr *addr, unsigned short port){
-  SocketAddress *address = (SocketAddress*)safeMalloc31(sizeof(SocketAddress),"BPX SocketAddress");
+  SocketAddress *address = (SocketAddress*)safeMalloc31(sizeof(SocketAddress),"SocketAddress");
   memset(address,0,sizeof(SocketAddress));
   if (socketTrace){
-    printf("socket address at 0x%p\n",address);
+    printf("socket address at 0x%x\n",address);
   }
-  address->length = 26;
+  address->length = 0; /* BPXYSOCK: "Specifically for AF_INET6, SOCK_LEN can either be defined as zero or SOCK#LEN+SOCK_SIN6#LEN" */
   address->family = AF_INET6;
   address->port = port;
   if (addr){
-    address->data6 = addr->data.data6;
+    if (AF_INET != addr->type) {   /* Copy IPv6 address */
+      address->data6 = addr->data.data6;
+    } else {     /* Create IPv6 address from IPv4 address */
+      address->datamap.addrType = ADDR_TYPE_MAPPED;
+      address->datamap.addrData = addr->data.data4.addrBytes;
+    }
   }
   if (socketTrace){
-    printf("about to return socket address at 0x%p\n",address);
+    printf("makeSocketAddrIPv6: returning socket address at 0x%x\n",address);
   }
   return address;
 }
+
 
 /* SD or, on windows the handle */
 int getSocketDebugID(Socket *s){
@@ -1389,6 +2051,11 @@ void freeSocketAddr(SocketAddress *address){
   safeFree31((char*)address,sizeof(SocketAddress));
 }
 
+void freeInetAddr(InetAddr *inetAddr){
+  safeFree31((char*)inetAddr, sizeof(InetAddr));
+}
+
+
 void freeSocketSet(SocketSet *set){
   if (socketTrace){
     printf("freeSocketSet: NYI\n");
@@ -1508,32 +2175,75 @@ int extendedSelect(SocketSet *set,
 
 /*--5---10---15---20---25---30---35---40---45---50---55---60---65---70---75---*/
 
-/* doesn't support v6 yet, but could soon */
+InetAddr *getAddressByName(char *addressString)
+{
+  /* retain 'classic' behavior that only supported IPV4 */
+  return getAddressByName2(addressString, ANSI_TRUE);
+}
 
-InetAddr *getAddressByName(char *addressString){
-  int numericAddress = 0x7F123456;
+InetAddr *getAddressByName2(char* addressString, int ipv4only)
+{
+  AddrInfoList addrInfoList = NULL;
+  int rc=0, rsn=0;
+  InetAddr *inetAddr = NULL;
 
-  if (!isV4Numeric(addressString,&numericAddress)){
-    numericAddress = getV4HostByName(addressString);
-    if (socketTrace){
-      printf("Host name is DNS or non-numeric, %x\n",numericAddress);
+  int count = 0;
+  int numV4mappable = 0;
+  int ansiStatus = ANSI_OK;
+
+  do {
+    addrInfoList = getAddressInfoList(addressString,
+                                      NULL, /* serviceName */
+                                      NULL, /* ignore canonical name */
+                                      &rc, &rsn);
+    if (NULL == addrInfoList) {
+      break;
     }
-  } else{
-    if (socketTrace){
-      printf("Host name is numeric %x\n",numericAddress);
+
+    count = AddrInfoList_count(addrInfoList, &numV4mappable);
+    if ((0 == count) ||
+        ((ipv4only && (0 == numV4mappable))))
+    {
+      break;
     }
+
+    void* tmpAddrInfo = NULL;
+
+    if (!ipv4only){
+      ansiStatus = AddrInfoList_getAtIndex(addrInfoList, 0, &tmpAddrInfo);
+      if (ANSI_OK != ansiStatus) {
+        break;
+      }
+      ansiStatus = AddrInfo_convert(tmpAddrInfo, NULL, &inetAddr);
+      break;
+    }
+    if (ANSI_OK != ansiStatus)
+      break;
+
+    /* we must be in the ipv4only case */
+
+    /* iterate over the list to find the first V4-mappable entry,
+     * then extract it as an AF_INET InetAddr */
+    for (int index=0; index < count; index++)
+    {
+      ansiStatus = AddrInfoList_getAtIndex(addrInfoList, index, &tmpAddrInfo);
+      if (ANSI_OK != ansiStatus) {
+        break;
+      }
+      if(AddrInfo_isV4mappable(tmpAddrInfo)) {
+        ansiStatus = AddrInfo_convert_IPv4(tmpAddrInfo, NULL, &inetAddr);
+        break;
+      }
+      tmpAddrInfo = NULL;
+    }
+
+  } while(0);
+
+  if (addrInfoList) {
+    freeAddressInfoList(addrInfoList);
   }
-  
-  if (numericAddress != 0x7F123456){
-    InetAddr *addr = (InetAddr*)safeMalloc31(sizeof(InetAddr),"InetAddr");
-    memset(addr,0,sizeof(InetAddr));
-    addr->type = AF_INET;
-    addr->port = 0;
-    addr->data.data4.addrBytes = numericAddress;
-    return addr;
-  } else{
-    return NULL;
-  }
+
+  return inetAddr;
 }
 
 int getSocketName(

--- a/c/mtlskt.c
+++ b/c/mtlskt.c
@@ -63,6 +63,8 @@
 #pragma linkage(BPX4WRT,OS)
 #pragma linkage(BPX4FCT,OS)
 #pragma linkage(BPX4CLO,OS)
+#pragma linkage(BPX4GAI,OS)
+#pragma linkage(BPX4FAI,OS)
 
 #define BPXSOC BPX4SOC
 #define BPXCON BPX4CON
@@ -82,6 +84,8 @@
 #define BPXWRT BPX4WRT
 #define BPXFCT BPX4FCT
 #define BPXCLO BPX4CLO
+#define BPXGAI BPX4GAI
+#define BPXFAI BPX4FAI
 
 #else
 
@@ -103,6 +107,8 @@
 #pragma linkage(BPX1WRT,OS)
 #pragma linkage(BPX1FCT,OS)
 #pragma linkage(BPX1CLO,OS)
+#pragma linkage(BPX1GAI,OS)
+#pragma linkage(BPX1FAI,OS)
 
 #define BPXSOC BPX1SOC
 #define BPXCON BPX1CON
@@ -122,10 +128,633 @@
 #define BPXWRT BPX1WRT
 #define BPXFCT BPX1FCT
 #define BPXCLO BPX1CLO
+#define BPXGAI BPX1GAI
+#define BPXFAI BPX1FAI
 
 #endif
 
 static int socketTrace = 0;
+
+#ifndef Addr_Info
+
+#ifndef socklen_t
+typedef unsigned int socklen_t;
+#endif
+
+#ifndef AF_UNSPEC
+#define AF_UNSPEC       0       /* matches sys/socket.h */
+#endif
+
+/* confirmed applicability by looking at SYS1.MACLIB(EZBREHST) */
+typedef struct addrinfo
+{
+#define AI_PASSIVE      (1 << 0)
+#define AI_CANONNAMEOK  (1 << 1)
+#define AI_NUMERICHOST  (1 << 2)
+#define AI_NUMERICSERV  (1 << 3)
+#define AI_V4MAPPED     (1 << 4)
+#define AI_ALL          (1 << 5)
+#define AI_ADDRCONFIG   (1 << 6)
+#define AI_EXTFLAGS     (1 << 7)
+  int              ai_flags;     /* AI_PASSIVE, AI_CANONNAME */
+  int              ai_family;    /* PF_xxx */
+  int              ai_socktype;  /* SOCK_xxx */
+  int              ai_protocol;  /* 0 or IPPROTO_xxx */
+  socklen_t        ai_addrlen;   /* length of ai_addr */
+  int              __ai_reserved;/* reserved */
+  __pad31( __ai_canonname_r,4 )  /* 31-bit padding */
+  char            *ai_canonname; /* canonical name for hostname */
+  __pad31( __ai_addr_r,4 )       /* 31-bit padding */
+  struct socketAddr_tag *ai_addr; /* binary address consistent with sockaddr_in(6) */
+  __pad31( __ai_next_r,4 )       /* 31-bit padding */
+  struct addrinfo *ai_next;      /* next structure in list */
+  #if __EDC_TARGET >= __EDC_LE410C
+    int            ai_eflags;    /* source IP addr pref */
+  #endif  /* __EDC_TARGET >= __EDC_LE410C */
+} Addr_Info;
+
+#endif /* Addr_Info undefined */
+
+static int addrInfoTrace = 0;
+
+AddrInfoList getAddressInfoList(const char* nodeName, const char* serviceName,
+                                char** out_canonicalName,
+                                int *out_rc, int *out_rsn)
+{
+  Addr_Info *addrInfoList = NULL;
+  int rv = 0;
+  int nodeNameLen = 0;
+  int serviceNameLen = 0;
+  int canonicalNameLen = 0;
+  /* "To get the most useful set of IP addresses available for the
+   *  requested host name, applications that are enabled for IPv6
+   *  processing should specify AI_V4MAPPED, AI_ALL, and AI_ADDRCONFIG
+   *  in the ai_flags field; and AF_UNSPEC for the ai_family field in the
+   *  input Addr_Info structure pointed to by the Hints_Ptr parameter.
+   *
+   *  When the stack has IPv6 capability, requests that are coded with
+   *  AF_UNSPEC are treated as if the request is for AF_INET6, and all
+   *  addresses are returned using sock_inet6_sockaddr structures (with the
+   *  IPv4 addresses mapped appropriately, based on the AI_V4MAPPED setting).
+   *  If there is no IPv6 capability, IPv4 addresses are returned in
+   *  sock_inet_sockaddr structures.
+   *
+   *  This frees the application, to some extent, from having to decide what
+   *  format works for the stack." */
+  Addr_Info hints;
+  memset(&hints, 0x00, sizeof(Addr_Info));
+
+  hints.ai_flags = AI_V4MAPPED | AI_ALL | AI_ADDRCONFIG | AI_CANONNAMEOK;
+  hints.ai_family = AF_UNSPEC; /* AF_UNSPEC is defined to 0 in sys/socket.h */
+
+  Addr_Info *hintsPtr = &hints;
+
+  do {
+    if ((NULL == nodeName) && (NULL == serviceName)) {
+      break;
+    }
+    if (nodeName) {
+      nodeNameLen = strlen(nodeName);
+    }
+    if (serviceName) {
+      serviceNameLen = strlen(serviceName);
+    }
+
+    if (addrInfoTrace) {
+      printf("about to call BPXGAI...\n");
+    }
+
+    BPXGAI(nodeName,
+           &nodeNameLen,
+           serviceName,
+           &serviceNameLen,
+           &hintsPtr,
+           &addrInfoList,
+           &canonicalNameLen, /* length of ai_canonname in first returned list entry */
+           &rv,
+           out_rc,
+           out_rsn);
+    if (addrInfoTrace) {
+      printf("BPXGAI returned rv:%d, rc:%d, rsn:0x%x, ailist:0x%p, cnl=%d\n",
+             rv, *out_rc, *out_rsn, addrInfoList, canonicalNameLen);
+    }
+
+    if ((0 == *out_rc) && (0 < canonicalNameLen) && (NULL != out_canonicalName))
+    {
+      Addr_Info *firstAddrInfo = (Addr_Info*) addrInfoList;
+      char* name = (char*) safeMalloc(1 + canonicalNameLen, "name");
+      memcpy(name, firstAddrInfo->ai_canonname, canonicalNameLen);
+      name[canonicalNameLen] = '\0';
+      *out_canonicalName = name;
+      if (addrInfoTrace) {
+        printf("getAddressInfoList returning canonicalName: %s\n", name);
+      }
+    }
+
+  } while(0);
+
+  return (AddrInfoList) addrInfoList;
+}
+
+static int data6_isV4mappable(const struct ipV6Data in_data6)
+{
+  int ansiStatus = ANSI_FALSE;
+
+  do {
+    /**
+     *
+  Hinden                      Standards Track                    [Page 10]
+  RFC 4291              IPv6 Addressing Architecture         February 2006
+
+  2.5.5.2.  IPv4-Mapped IPv6 Address
+
+  A second type of IPv6 address that holds an embedded IPv4 address is
+  defined.  This address type is used to represent the addresses of
+  IPv4 nodes as IPv6 addresses.  The format of the "IPv4-mapped IPv6
+  address" is as follows:
+
+  |                80 bits               | 16 |      32 bits        |
+  +--------------------------------------+--------------------------+
+  |0000..............................0000|FFFF|    IPv4 address     |
+  +--------------------------------------+----+---------------------+
+     */
+    const unsigned char v4mappedPrefix[12] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                                              0x00, 0x00, 0xFF, 0xFF};
+    if (0 == memcmp(&(v4mappedPrefix[0]),
+                    &(in_data6.addrData[0]),
+                    sizeof(v4mappedPrefix)))
+    {
+      if (addrInfoTrace) {
+        printf("data6_isV4mappable TRUE because prefix matched addrData content\n");
+      }
+      ansiStatus = ANSI_TRUE;
+    }
+
+  } while(0);
+
+  return ansiStatus;
+}
+
+static int InetAddr_isV4mappable(const InetAddr *inetAddr)
+{
+  int ansiStatus = ANSI_FALSE;
+
+  do {
+    if (NULL == inetAddr)
+      break;
+
+    switch(inetAddr->type)
+    {
+      case AF_INET:
+      {
+        ansiStatus = ANSI_TRUE;
+        break;
+      }
+
+      case AF_INET6:
+      {
+        ansiStatus = data6_isV4mappable(inetAddr->data.data6);
+        break;
+      }
+    }
+  } while(0);
+
+  return ansiStatus;
+}
+
+static int SocketAddress_isV4mappable(const SocketAddress *socketAddress)
+{
+  int ansiStatus = ANSI_FALSE;
+
+  do {
+    if (NULL == socketAddress)
+      break;
+
+    int ifam = (int) socketAddress->family;
+    switch(ifam) {
+      case AF_INET:
+      {
+        ansiStatus = ANSI_TRUE;
+        break;
+      }
+
+      case AF_INET6:
+      {
+        ansiStatus = data6_isV4mappable(socketAddress->data6);
+        break;
+      }
+    }
+  } while(0);
+
+  return ansiStatus;
+}
+
+/**
+ * @brief       Output a string representation of an IP address to a caller-supplied buffer.
+ *
+ * @param[in]     socketAddress A handle returned by getAddressInfoList
+ * @param[in,out] strbuf        Caller-supplied output buffer
+ * @param[in,out] len           Pointer to caller-supplied int.
+ *                                On input, specify available size in inout_strbuf.
+ *                                On output:
+ *                                  If ANSI_OK, length of output including null terminator
+ *                                  If ANSI_FAILED due to insufficient space, required length
+ *
+ * @return      ANSI_OK if a string was composed and output to the buffer.
+ *              ANSI_FAILED if a string was not composed or the output space was too small.
+ */
+int SocketAddress_toString(const SocketAddress *in_socketAddress,
+                           char* inout_strbuf, int* inout_len)
+{
+  int ansiStatus = ANSI_FAILED;
+  /**
+   * As described in RFC 4291, the preferred form is "x:x:x:x:x:x:x:x", where
+   * Each x is a 16-bit section (dubbed a 'hextet') that can be represented
+   * using up to four hexadecimal digits, with the sections separated by colons.
+   *
+   * Longest form would be:
+   * "1234:5678:90ab:cdef:1234:5678:90ab:cdef[null]" so 40 bytes
+   *
+   * If we include a suffix for the port number (colon plus <=5 digits), the
+   * max length is 46 bytes.  64-byte buffer gives us some flexibility around
+   * formatting.
+   *
+   * Conventions for shortening:
+   * - omit leading zeroes from each hextet
+   * - omit hextets with all-zeroes
+   *    - double-colon "::" represents any continuuous string of
+   *      two or more hextets that are all zeroes, but this can
+   *      only be done once without ambiguous results
+   *
+   * For now, we'll ignore the shortening conventions and strive for
+   * accuracy of both AF_INET and AF_INET6 forms.
+   *
+   * One exception could be AF_INET6 addresses known to be V4-mapped. TBD.
+   */
+  do {
+    if ((NULL == in_socketAddress) || (NULL == inout_strbuf) || (NULL == inout_len)) {
+      break;
+    }
+    int available = *inout_len;
+    int required = 0;
+    char tmpbuf[64] = {0};
+    int ifam = (int) in_socketAddress->family;
+
+    switch(ifam)
+    {
+      case AF_INET:
+      {
+        const unsigned char* data = &(in_socketAddress->v4Addr[0]);
+        sprintf(tmpbuf, "%d.%d.%d.%d", data[0], data[1], data[2], data[3]);
+        required = 1 + strlen(tmpbuf);
+        break;
+      }
+
+      case AF_INET6:
+      {
+        if (SocketAddress_isV4mappable(in_socketAddress)) {
+          /* mapped V4 format - take bytes from indexes 12, 13, 14, 15 */
+          const unsigned char* data = &(in_socketAddress->data6.addrData[12]);
+          sprintf(tmpbuf, "::ffff:%d.%d.%d.%d", data[0], data[1], data[2], data[3]);
+          required = 1 + strlen(tmpbuf);
+        } else {
+          /* IPv6 format */
+          unsigned short us1=0, us2=0, us3=0, us4=0, us5=0, us6=0, us7=0, us8=0;
+          const char* data = &(in_socketAddress->data6.addrData[0]);
+          us1 = (data[0] << 8) + data[1];
+          us2 = (data[2] << 8) + data[3];
+          us3 = (data[4] << 8) + data[5];
+          us4 = (data[6] << 8) + data[7];
+          us5 = (data[8] << 8) + data[9];
+          us6 = (data[10] << 8) + data[11];
+          us7 = (data[12] << 8) + data[13];
+          us8 = (data[14] << 8) + data[15];
+          sprintf(tmpbuf, "%x:%x:%x:%x:%x:%x:%x:%x",
+                  us1, us2, us3, us4, us5, us6, us7, us8);
+          required = 1 + strlen(tmpbuf);
+        }
+        break;
+      }
+    }
+
+    if (!required) {
+      /* we didn't compose, break and return failed */
+      break;
+    }
+
+    if (available < required) {
+      *inout_len = required;
+      break;
+    }
+
+    memcpy(inout_strbuf, tmpbuf, required);
+    *inout_len = required;
+    ansiStatus = ANSI_OK;
+
+  } while(0);
+
+  return ansiStatus;
+}
+
+int AddrInfo_isV4mappable(const void *in_addrInfo)
+{
+  int ansiStatus = ANSI_FALSE;
+  const Addr_Info *addrInfo = (const Addr_Info *) in_addrInfo;
+
+  do {
+    if (NULL == addrInfo)
+      break;
+
+    switch (addrInfo->ai_family)
+    {
+      case AF_INET:
+      {
+        if (addrInfoTrace) {
+          printf("AddrInfo_isV4mappable TRUE because AF_INET\n");
+        }
+        ansiStatus = ANSI_TRUE;
+        break;
+      }
+
+      case AF_INET6:
+      {
+        SocketAddress *tmpSocketAddr = (SocketAddress*) (addrInfo->ai_addr);
+        ansiStatus = SocketAddress_isV4mappable(tmpSocketAddr);
+        break;
+      }
+    }
+  } while(0);
+
+  return ansiStatus;
+}
+
+int AddrInfo_convert(const void *in_addrInfo,
+                     SocketAddress **out_socketAddress, InetAddr **out_inetAddr)
+{
+  int ansiStatus = ANSI_FAILED;
+  SocketAddress *socketAddress = NULL;
+  InetAddr *inetAddr = NULL;
+
+  const Addr_Info *addrInfo = (const Addr_Info *) in_addrInfo;
+
+  do {
+    if ((NULL == addrInfo) ||
+        ((NULL == out_socketAddress) && (NULL == out_inetAddr)))
+    {
+      break;
+    }
+
+    int family = addrInfo->ai_family;
+
+    if (out_socketAddress) {
+      socketAddress = (SocketAddress*) safeMalloc31(sizeof(SocketAddress), "socketAddress");
+      memcpy(socketAddress, addrInfo->ai_addr, addrInfo->ai_addrlen);
+      *out_socketAddress = socketAddress;
+
+      if (addrInfoTrace) {
+        printf("AddrInfo_convert output SocketAddress len=%d family=%d\n",
+               (int) (socketAddress->length), (int) (socketAddress->family));
+        dumpbuffer((char*)socketAddress, socketAddress->length);
+      }
+    }
+
+    if (out_inetAddr) {
+      inetAddr = (InetAddr*) safeMalloc31(sizeof(InetAddr), "inetAddr");
+      inetAddr->type = addrInfo->ai_addr->family;
+      inetAddr->port = (int) addrInfo->ai_addr->port;
+      if (AF_INET6 == family) {
+        memcpy(&(inetAddr->data), &(addrInfo->ai_addr->data6), sizeof(addrInfo->ai_addr->data6));
+      } else {
+        memcpy(&(inetAddr->data), &(addrInfo->ai_addr->v4Address), sizeof(addrInfo->ai_addr->v4Address));
+      }
+      *out_inetAddr = inetAddr;
+
+      if (addrInfoTrace) {
+        printf("AddrInfo_convert output InetAddr family=%d port=%d\n",
+               inetAddr->type, inetAddr->port);
+        dumpbuffer((char*)inetAddr, sizeof(InetAddr));
+      }
+    }
+
+    ansiStatus = ANSI_OK;
+
+  } while(0);
+
+  return ansiStatus;
+}
+
+int AddrInfo_convert_IPv4(const void *in_addrInfo,
+                          SocketAddress **out_socketAddress, InetAddr **out_inetAddr)
+{
+  int ansiStatus = ANSI_FAILED;
+  SocketAddress *socketAddress = NULL;
+  InetAddr *inetAddr = NULL;
+
+  const Addr_Info *addrInfo = (const Addr_Info *) in_addrInfo;
+
+  do {
+    if ((NULL == addrInfo) ||
+        ((NULL == out_socketAddress) && (NULL == out_inetAddr)))
+    {
+      break;
+    }
+
+    if (ANSI_FALSE == AddrInfo_isV4mappable(addrInfo)) {
+      break;
+    }
+
+    char* sourceData = NULL;
+
+    switch(addrInfo->ai_family)
+    {
+      case AF_INET:
+      {
+        sourceData = &(addrInfo->ai_addr->v4Addr[0]);
+        if (addrInfoTrace) {
+          printf("AddrInfo_convert_IPv4 from AF_INET source data\n");
+        }
+        break;
+      }
+
+      case AF_INET6:
+      {
+        sourceData = &(addrInfo->ai_addr->data6.addrData[12]); //see data6_isV4mappable
+        if (addrInfoTrace) {
+          printf("AddrInfo_convert_IPv4 from AF_INET6 source data\n");
+        }
+        break;
+      }
+    }
+
+    if (NULL == sourceData)
+      break;
+
+    if (out_socketAddress) {
+      socketAddress = (SocketAddress*) safeMalloc31(sizeof(SocketAddress), "socketAddress");
+      socketAddress->length = 14; /* see SOCK_SIN#LEN in BPXYSOCK */
+      socketAddress->family = AF_INET;
+
+      memcpy(&(socketAddress->v4Addr[0]), sourceData, 4);
+
+      *out_socketAddress = socketAddress;
+
+      if (addrInfoTrace) {
+        printf("AddrInfo_convert_IPv4 output SocketAddress len=%d family=%d\n",
+               (int) (socketAddress->length), (int) (socketAddress->family));
+        dumpbuffer((char*)socketAddress, socketAddress->length);
+      }
+    }
+
+    if (out_inetAddr) {
+      inetAddr = (InetAddr*) safeMalloc31(sizeof(InetAddr), "inetAddr");
+      inetAddr->type = AF_INET;
+
+      memcpy(&(inetAddr->data.data4.addrBytes), sourceData, 4);
+
+      *out_inetAddr = inetAddr;
+
+      if (addrInfoTrace) {
+        printf("AddrInfo_convert_IPv4 output InetAddr family=%d port=%d\n",
+               inetAddr->type, inetAddr->port);
+        dumpbuffer((char*)inetAddr, sizeof(InetAddr));
+      }
+    }
+
+    ansiStatus = ANSI_OK;
+
+  } while(0);
+
+  return ansiStatus;
+}
+
+/**
+ * @brief       Count the AddrInfo entries in addrInfoList
+ *
+ * @detail      Walk the linked list to determine its length.
+ *              If addrInfoList is NULL, returns 0.
+ *              If addrInfoList is non-NULL, returns >= 1.
+ *              DO NOT pass an address that wasn't returned by getAddressInfoList.
+ *
+ * @param[in]     addrInfoList  A handle returned by getAddressInfoList
+ * @param[out]    v4mappable    The number of entries that are either AF_INET or
+ *                              mappable from AF_INET6 to AF_INET.
+ */
+int AddrInfoList_count(AddrInfoList addrInfoList, int *out_v4mappable)
+{
+  const int ADDRINFOLIST_COUNT_MAX = 100; /* prevent infinite loops */
+  int count = 0;
+  int v4mappable = 0;
+
+  do {
+    if (NULL == addrInfoList)
+      break; /* count = 0 */
+
+    count++; /* count = 1 */
+
+    Addr_Info *tmpAddrInfo = (Addr_Info*) addrInfoList;
+    if (AddrInfo_isV4mappable(tmpAddrInfo)) {
+      ++v4mappable;
+    }
+
+    while((NULL != tmpAddrInfo->ai_next) &&
+          (count < ADDRINFOLIST_COUNT_MAX))
+    {
+      ++count;
+      tmpAddrInfo = tmpAddrInfo->ai_next;
+      if (AddrInfo_isV4mappable(tmpAddrInfo)) {
+        ++v4mappable;
+      }
+    }
+
+  } while(0);
+
+  if (out_v4mappable) {
+    *out_v4mappable = v4mappable;
+  }
+
+  if (addrInfoTrace) {
+    printf("AddrInfoList_count returning %d (%d v4mappable) for AddrInfoList @ 0x%p\n",
+           count, v4mappable, addrInfoList);
+  }
+
+  return count;
+}
+
+/**
+ * @brief       Return the AddrInfo handle at the specified index
+ *
+ * @detail      Walk the linked list to the specified index, and return
+ *              the associated AddrInfo handle
+ *
+ * @param[in]     addrInfoList    A handle returned by getAddressInfoList
+ * @param[in]     index           A value between 0 and count-1 (see AddrInfoList_count)
+ * @param[in,out] out_AddrInto    A pointer to an opaque AddrInfo is returned in this location.
+ *
+ * @return      ANSI_OK if an entry was found/returned from the specified index.
+ *              ANSI_FAILED if the index was >= the number of items in the list.
+ */
+int AddrInfoList_getAtIndex(AddrInfoList addrInfoList, int index,
+                            void* *out_AddrInfo)
+{
+  int ansiStatus = ANSI_FAILED;
+  SocketAddress *socketAddress = NULL;
+  InetAddr *inetAddr = NULL;
+
+  do {
+    if (addrInfoTrace) {
+      printf("AddrInfoList_getAtIndex entry (addrInfoList=0x%p, index=%d, outAddrInfo=0x%p)\n",
+             addrInfoList, index, out_AddrInfo);
+    }
+
+    if ((NULL == addrInfoList) ||
+        (0 > index) ||
+        (NULL == out_AddrInfo))
+    {
+      break;
+    }
+
+    Addr_Info *firstAddrInfo = (Addr_Info*) addrInfoList;
+    Addr_Info *tmpAddrInfo = firstAddrInfo;
+    int count = 0;
+    int family = 0;
+
+    do {
+      if (index == count) {
+        family = tmpAddrInfo->ai_family;
+        if ((AF_INET6 == family) || (AF_INET == family)) {
+          ansiStatus = ANSI_OK;
+        }
+        break;
+      }
+      count++;
+      tmpAddrInfo = tmpAddrInfo->ai_next;
+    } while (NULL != tmpAddrInfo);
+
+    if (ANSI_OK != ansiStatus)
+      break;
+
+    *out_AddrInfo = tmpAddrInfo;
+
+  } while(0);
+
+  return ansiStatus;
+}
+
+
+void freeAddressInfoList(AddrInfoList addrInfoList)
+{
+  int rv=0, rc=0, rsn=0;
+  if (addrInfoList) {
+    BPXFAI(&addrInfoList,
+           &rv,
+           &rc,
+           &rsn);
+    if (addrInfoTrace) {
+      printf("BPXFAI returned rv:%d, rc: %d, rsn:0x%x\n", rv, rc, rsn);
+    }
+  }
+}
+
 
 void sleep(int seconds){
   int waitValue = seconds * 100; 
@@ -148,25 +777,34 @@ int socketInit(char *uniqueName){
   /* do nothing for now */
 }
 
-SocketAddress *makeSocketAddr(InetAddr *addr, 
-			      unsigned short port){
+
+static SocketAddress *makeSocketAddrIPv4(InetAddr *addr,
+                                         unsigned short port){
   SocketAddress *address = (SocketAddress*)safeMalloc31(sizeof(SocketAddress),"SocketAddress");
   memset(address,0,sizeof(SocketAddress));
   if (socketTrace){
     printf("socket address at 0x%x\n",address);
   }
-  address->length = 14;
+  address->length = 14; /* see SOCK_SIN#LEN in BPXYSOCK */
   address->family = AF_INET;
   address->port = port;
   if (addr){
     address->v4Address = addr->data.data4.addrBytes;
-  } else{
-    address->v4Address = 0; /* 0.0.0.0 */
   }
   if (socketTrace){
-    printf("about to return socket address at 0x%x\n",address);
+    printf("makeSocketAddrIPv4: returning socket address at 0x%x\n",address);
   }
   return address;
+}
+
+SocketAddress *makeSocketAddr(InetAddr *addr,
+                              unsigned short port)
+{
+  if ((NULL == addr) || (AF_INET == addr->type)) {
+    return makeSocketAddrIPv4(addr,port);
+  } else {
+    return makeSocketAddrIPv6(addr,port);
+  }
 }
 
 SocketAddress *makeSocketAddrIPv6(InetAddr *addr, unsigned short port){
@@ -175,14 +813,19 @@ SocketAddress *makeSocketAddrIPv6(InetAddr *addr, unsigned short port){
   if (socketTrace){
     printf("socket address at 0x%x\n",address);
   }
-  address->length = 26;
+  address->length = 0; /* BPXYSOCK: "Specifically for AF_INET6, SOCK_LEN can either be defined as zero or SOCK#LEN+SOCK_SIN6#LEN" */
   address->family = AF_INET6;
   address->port = port;
   if (addr){
-    address->data6 = addr->data.data6;
+    if (AF_INET != addr->type) {   /* Copy IPv6 address */
+      address->data6 = addr->data.data6;
+    } else {     /* Create IPv6 address from IPv4 address */
+      address->datamap.addrType = ADDR_TYPE_MAPPED;
+      address->datamap.addrData = addr->data.data4.addrBytes;
+    }
   }
   if (socketTrace){
-    printf("about to return socket address at 0x%x\n",address);
+    printf("makeSocketAddrIPv6: returning socket address at 0x%x\n",address);
   }
   return address;
 }
@@ -190,6 +833,10 @@ SocketAddress *makeSocketAddrIPv6(InetAddr *addr, unsigned short port){
 
 void freeSocketAddr(SocketAddress *address){
   safeFree31((char*)address,sizeof(SocketAddress));
+}
+
+void freeInetAddr(InetAddr *inetAddr){
+  safeFree31((char*)inetAddr, sizeof(InetAddr));
 }
 
 
@@ -1400,28 +2047,75 @@ int udpReceiveFrom(Socket *socket,
 
 /*--5---10---15---20---25---30---35---40---45---50---55---60---65---70---75---*/
 
-/* doesn't support v6 yet, but could soon */
+InetAddr *getAddressByName(char *addressString)
+{
+  /* retain 'classic' behavior that only supported IPV4 */
+  return getAddressByName2(addressString, ANSI_TRUE);
+}
 
-InetAddr *getAddressByName(char *addressString){
-  int numericAddress = 0x7F123456;
+InetAddr *getAddressByName2(char* addressString, int ipv4only)
+{
+  AddrInfoList addrInfoList = NULL;
+  int rc=0, rsn=0;
+  InetAddr *inetAddr = NULL;
 
-  if (!isV4Numeric(addressString,&numericAddress)){
-    numericAddress = getV4HostByName(addressString);
-    /* printf("Host names is DNS NAME (or crap), %x\n",numericAddress); */
-  } else{
-    /* printf("Host name is numeric %x\n",numericAddress); */
+  int count = 0;
+  int numV4mappable = 0;
+  int ansiStatus = ANSI_OK;
+
+  do {
+    addrInfoList = getAddressInfoList(addressString,
+                                      NULL, /* serviceName */
+                                      NULL, /* ignore canonical name */
+                                      &rc, &rsn);
+    if (NULL == addrInfoList) {
+      break;
+    }
+
+    count = AddrInfoList_count(addrInfoList, &numV4mappable);
+    if ((0 == count) ||
+        ((ipv4only && (0 == numV4mappable))))
+    {
+      break;
+    }
+
+    void* tmpAddrInfo = NULL;
+
+    if (!ipv4only){
+      ansiStatus = AddrInfoList_getAtIndex(addrInfoList, 0, &tmpAddrInfo);
+      if (ANSI_OK != ansiStatus) {
+        break;
+      }
+      ansiStatus = AddrInfo_convert(tmpAddrInfo, NULL, &inetAddr);
+      break;
+    }
+    if (ANSI_OK != ansiStatus)
+      break;
+
+    /* we must be in the ipv4only case */
+
+    /* iterate over the list to find the first V4-mappable entry,
+     * then extract it as an AF_INET InetAddr */
+    for (int index=0; index < count; index++)
+    {
+      ansiStatus = AddrInfoList_getAtIndex(addrInfoList, index, &tmpAddrInfo);
+      if (ANSI_OK != ansiStatus) {
+        break;
+      }
+      if(AddrInfo_isV4mappable(tmpAddrInfo)) {
+        ansiStatus = AddrInfo_convert_IPv4(tmpAddrInfo, NULL, &inetAddr);
+        break;
+      }
+      tmpAddrInfo = NULL;
+    }
+
+  } while(0);
+
+  if (addrInfoList) {
+    freeAddressInfoList(addrInfoList);
   }
-  
-  if (numericAddress != 0x7F123456){
-    InetAddr *addr = (InetAddr*)safeMalloc(sizeof(InetAddr),"Inet Address");
-    memset(addr,0,sizeof(InetAddr));
-    addr->type = AF_INET;
-    addr->port = 0;
-    addr->data.data4.addrBytes = numericAddress;
-    return addr;
-  } else{
-    return NULL;
-  }
+
+  return inetAddr;
 }
 
 int getSocketName(

--- a/h/bpxnet.h
+++ b/h/bpxnet.h
@@ -55,9 +55,20 @@ struct ipV6Data{
   int scopeId;
 };
 
+struct ipV4toipV6Data{
+  int flowInfo;
+  char addrZero[10];            /* Must be 0's         */
+  short int addrType;           /* Set to -1           */
+  int  addrData;                /* Set to IPv4 address */
+  int scopeId;
+};
+
+#define ADDR_TYPE_MAPPED -1
+
 union ipAddrData{
   struct ipV4Data data4;
   struct ipV6Data data6;
+  struct ipV4toipV6Data datamap;
 };
 
 typedef struct inetAddr_tag{
@@ -79,13 +90,22 @@ typedef struct socketAddr_tag{
       char reserved1[8];
     };
     struct {
+      char v4Addr[4];
+    };
+    struct {
       struct ipV6Data data6;
+    };
+    struct {
+      struct ipV4toipV6Data datamap;
     };
   };
 } SocketAddress;
 
 #define GET_V4_ADDR_FOR_SOCKET_AS_INT(SOCKET) \
   ((SOCKET).v4Address)
+
+#define GET_V4_ADDR_FOR_SOCKET(SOCKET) \
+  (SOCKET).v4Address
 
 
 ZOWE_PRAGMA_PACK_RESET
@@ -286,6 +306,133 @@ typedef struct hostent_tag{
 /* Set socket tracing; returns prior value */
 int setSocketTrace(int toWhat); 
 
+#ifndef __RKT_OS_WINDOWS
+
+typedef void * AddrInfoList;
+
+/**
+ * @brief       Retrieve an opaque AddrInfoList for a host and/or service
+ *
+ * @detail      Calls the BPXnGAI service in a way that returns all available
+ *              address information for the specified host and/or service.
+ *
+ *              In environments that support IPv6, the AddrInfoList may
+ *              contain both IPv4 and IPv6 address information.
+ *
+ *              If a non-NULL destination address is passed in canonicalName
+ *              and the resolver returns a canonical name for the host,
+ *              a C-string copy is allocated in the caller's address space
+ *              and the copy's address is returned in canonicalName.
+ *
+ * @param[in]     nodeName        Host name or IP address as EBCDIC string
+ * @param[in]     serviceName     Service name or port number as EBCDIC string
+ * @param[in,out] canonicalName   Canonical hostname (optional)
+ * @param[out]    out_rc          Return code from BPXnGAI service
+ * @param[out]    out_rsn         Reason code from BPXnGAI service
+ *
+ * @return      A valid address on success, or NULL on failure
+ */
+AddrInfoList getAddressInfoList(const char* nodeName, const char* serviceName,
+                                char** out_canonicalName,
+                                int *out_rc, int *out_rsn);
+
+/**
+ * @brief       Count the AddrInfo entries in addrInfoList
+ *
+ * @detail      Walk the linked list to determine its length.
+ *              If addrInfoList is NULL, returns 0.
+ *              If addrInfoList is non-NULL, returns >= 1.
+ *              DO NOT pass an address that wasn't returned by getAddressInfoList.
+ *
+ * @param[in]     addrInfoList  A handle returned by getAddressInfoList
+ * @param[out]    v4mappable    The number of entries that are either AF_INET or
+ *                              mappable from AF_INET6 to AF_INET.
+ */
+int AddrInfoList_count(AddrInfoList addrInfoList, int *out_v4mappable);
+
+/**
+ * @brief       Return the AddrInfo handle at the specified index
+ *
+ * @detail      Walk the linked list to the specified index, and return
+ *              the associated AddrInfo handle
+ *
+ * @param[in]     addrInfoList    A handle returned by getAddressInfoList
+ * @param[in]     index           A value between 0 and count-1 (see AddrInfoList_count)
+ * @param[in,out] out_AddrInto    A pointer to an opaque AddrInfo is returned in this location.
+ *
+ * @return      ANSI_OK if an entry was found/returned from the specified index.
+ *              ANSI_FAILED if the index was >= the number of items in the list.
+ */
+int AddrInfoList_getAtIndex(AddrInfoList addrInfoList, int index,
+                            void* *out_AddrInfo);
+
+/**
+ * @brief       Convert an opaque AddrInfo handle to SocketAddress and/or InetAddr.
+ *              The returned SocketAddress and/or InetAddr could be AF_INET or AF_INET6.
+ *
+ * @param[in]     in_addrInfo       A handle output by AddrInfoList_getAtIndex
+ * @param[in/out] out_socketAddress If specified, a pointer to a new SocketAddress is output here.
+ * @param[in/out] out_inetAddr      If specified, a pointer to a new InetAddr is output here.
+ *
+ * @return      ANSI_OK if the handle was converted to at least one output.
+ *              ANSI_FAILED if handle is bad, validation fails, or no output specified.
+ */
+int AddrInfo_convert(const void *in_addrInfo,
+                     SocketAddress **out_socketAddress, InetAddr **out_inetAddr);
+
+/**
+ * @brief       Convert an AddrInfo to an AF_INET SocketAddress and/or InetAddr, if possible.
+ *
+ * @detail      See description of AddrInfo_convert.
+ *              If the specified AddrInfo is determined to be V4-mappable, any output
+ *              SocketAddress or InetAddr will be consistent with AF_INET format, even
+ *              if the source AddrInfo used AF_INET6 format internally.
+ *
+ * @return      ANSI_OK if the handle was V4-mappable and converted to at least one output.
+ *              ANSI_FAILED if handle is bad, not V4-mappable, or no output specified.
+ */
+int AddrInfo_convert_IPv4(const void *in_addrInfo,
+                          SocketAddress **out_socketAddress, InetAddr **out_inetAddr);
+
+
+/**
+ * @brief       Test whether an opaque AddrInfo can be used with AddrInfo_convert_IPv4
+ *
+ * @return      ANSI_FALSE if the AddrInfo is AF_INET6 and cannot be mapped.
+ *              ANSI_TRUE if the AddrInfo is AF_INET, or mappable from AF_INET6 to AF_INET.
+ */
+int AddrInfo_isV4mappable(const void *in_addrInfo);
+
+/**
+ * @brief       Free an AddrInfoList returned by getAddressInfoList
+ *
+ * @detail      Calls the BPXnFAI service
+ *
+ * @param[in]   addrInfoList    A handle returned by getAddressInfoList
+ */
+void freeAddressInfoList(AddrInfoList addrInfoList);
+
+/**
+ * @brief       Output a string representation of an IP address to a caller-supplied buffer.
+ *
+ * @param[in]     socketAddress A handle returned by getAddressInfoList
+ * @param[in,out] strbuf        Caller-supplied output buffer
+ * @param[in,out] len           Pointer to caller-supplied int.
+ *                                On input, specify available size in inout_strbuf.
+ *                                On output:
+ *                                  If ANSI_OK, length of output including null terminator
+ *                                  If ANSI_FAILED due to insufficient space, required length
+ *
+ * @return      ANSI_OK if a string was composed and output to the buffer.
+ *              ANSI_FAILED if a string was not composed or the output space was too small.
+ */
+int SocketAddress_toString(const SocketAddress *in_socketAddress,
+                           char* inout_strbuf, int* inout_len);
+
+#endif /* not Windows */
+
+
+
 int socketInit(char *uniqueName);
 
 /* handles named and numeric */
@@ -301,6 +448,11 @@ InetAddr* getLocalHostAddress(int *returnCode, int *reasonCode); /* AKA gethosti
 
 /* zero-terminated */
 InetAddr *getAddressByName(char *addressString);
+#ifndef __RKT_OS_WINDOWS 
+InetAddr *getAddressByName2(char* addressString, int ipv4only);
+void freeSocketAddr(SocketAddress *address);
+void freeInetAddr(InetAddr *inetAddr);
+#endif
 
 int getSocketName(Socket *socket, SocketAddress *socketAddress); /* AKA getsockname */
 int getSocketName2(Socket *socket, SocketAddress *socketAddress); /* AKA getpeername */


### PR DESCRIPTION
This PR adds new functions for handling ipv6 ips. It is backwards compatible in that functions like getAddressByName() are unchanged, calling getAddressByName2() which has a boolean for declaring whether to consider ipv6 or not.