### PR TITLE
Fix memory leak in safeFree64Internal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## `3.3.0`
 - Enhancement: add a `copyConfigurationAndDeleteKey` API to configmgr (#524)
 - Enhancement: configmgr path elements of type PARMLIB can now contain a member name, in the format of "PARMLIB(DATA.SET(member))", as an alternative to the older format of "PARMLIB(DATA.SET)" with the member name being specified in a separate argument. This enhancement allows use of multiple members with different names within the same PARMLIB dataset. The older format can still be used as desired. (#522)
+- Bugfix: Fix a leak in the safeFree64Internal by adding free(). (#540)
 
 ## `3.2.0`
 - Bugfix: allocate storage to be executed with EXECUTABLE=YES (#507)

--- a/c/alloc.c
+++ b/c/alloc.c
@@ -601,7 +601,7 @@ static void safeFree64Internal(char *data, int size, long long token){
 #if defined(METTLE) && defined(_LP64)
   freemain64(data,NULL,NULL);
 #else
-  /* do nothing - because 64 bit allocation in LE is not ready */
+  free(data);
 #endif
 }
 

--- a/c/alloc.c
+++ b/c/alloc.c
@@ -600,8 +600,12 @@ static void safeFree64Internal(char *data, int size, long long token){
 
 #if defined(METTLE) && defined(_LP64)
   freemain64(data,NULL,NULL);
-#else
+#elif defined(_LP64) /* LE case */
   free(data);
+#elif defined(_MSC_VER) && defined(_M_X64) /* Windows 64 case */
+  free(data);
+#else
+  /* Do nothing - because safeMalloc64Internal returns NULL for 31-bit */
 #endif
 }
 


### PR DESCRIPTION
Related to issue: https://github.com/zowe/zss/issues/777

This bug was found when uploading large Unix file contents in chunks. With every chunk, the content memory was allocated SLH. But after processing it was not released and memory kept increasing with every chunk.

This free() stops the leak for every chunk.

Before fix:
======
Here the PRIVATE-64 will keep increasing with every chunk
<img width="1550" height="713" alt="Before_fix" src="https://github.com/user-attachments/assets/540818fd-230e-472c-a43e-bb242b57c849" />

After Fix:
======
Will increase only initially to create the working memory if you can call it like that. Because this memory will be reused for the upcoming chunks.
<img width="1473" height="632" alt="After_upload" src="https://github.com/user-attachments/assets/0e18b691-efcd-47c1-8988-be73beff1b56" />

Note:
====
The current behavior is such that we don't see increase the memory till the chunk size is equal to or less than the one used initially. That is, it is advisable to use the same chunk size for all the chunks.
