### PR TITLE
Protect against rexx variable changes in addConfig

### DIFF
--- a/c/configmgr.c
+++ b/c/configmgr.c
@@ -763,7 +763,9 @@ CFGConfig *cfgAddConfig(ConfigManager *mgr, const char *configName){
   }
   CFGConfig *newConfig = (CFGConfig*)safeMalloc(sizeof(CFGConfig),"CFGConfig");
   memset(newConfig,0,sizeof(CFGConfig));
-  newConfig->name = configName;
+  char *copyName = safeMalloc(strlen(configName)+1, "configName");
+  strcpy(copyName, configName);
+  newConfig->name = copyName;
   if (mgr->firstConfig){
     mgr->lastConfig->next = newConfig;
     mgr->lastConfig = newConfig;


### PR DESCRIPTION
A problem was identified when https://github.com/zowe/zowe-common-c/pull/540 was added that `zwegener` and `zwegen00` would fail when using `cfgrxcfg`.
I now think that PR 540 had nothing to do with it.
I traced with @JoeNemo and found that the REXX calls to `addConfig(name)` and `getConfig(name)` would have the pointer of name having contents change.
I did not investigate why this is, such as if there was a change in the REXX code of `zwegen00`, or if rexx does mysterious things, but to insulate configmgr from that, instead of holding onto the pointer, this creates a copy of the string so that configmgr is the owner of that string.