### PR TITLE
Reinstate Fix memory leak in safeFree64Internal (#540)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## `3.3.0`
 - Enhancement: add a `copyConfigurationAndDeleteKey` API to configmgr (#524)
 - Enhancement: configmgr path elements of type PARMLIB can now contain a member name, in the format of "PARMLIB(DATA.SET(member))", as an alternative to the older format of "PARMLIB(DATA.SET)" with the member name being specified in a separate argument. This enhancement allows use of multiple members with different names within the same PARMLIB dataset. The older format can still be used as desired. (#522)
+- Bugfix: Fix a leak in the safeFree64Internal by adding free(). (#540)
 
 ## `3.2.0`
 - Bugfix: allocate storage to be executed with EXECUTABLE=YES (#507)

--- a/c/alloc.c
+++ b/c/alloc.c
@@ -600,8 +600,12 @@ static void safeFree64Internal(char *data, int size, long long token){
 
 #if defined(METTLE) && defined(_LP64)
   freemain64(data,NULL,NULL);
+#elif defined(_LP64) /* LE case */
+  free(data);
+#elif defined(_MSC_VER) && defined(_M_X64) /* Windows 64 case */
+  free(data);
 #else
-  /* do nothing - because 64 bit allocation in LE is not ready */
+  /* Do nothing - because safeMalloc64Internal returns NULL for 31-bit */
 #endif
 }
 


### PR DESCRIPTION
https://github.com/zowe/zowe-common-c/pull/545 appears to fix what issue was seen when https://github.com/zowe/zowe-common-c/pull/540 was added, so with it then this PR could be used to add 540 back.