### PR TITLE
[DO NOT MERGE] Allocating fixed size for upload chunk content

### DIFF
--- a/c/httpserver.c
+++ b/c/httpserver.c
@@ -2327,7 +2327,15 @@ int processHttpFragment(HttpRequestParser *parser, char *data, int len){
         } else{
           zowelog(NULL, LOG_COMP_HTTPSERVER, ZOWE_LOG_DEBUG3, "_____ END OF MESSAGE HEADER _________\n");
           parser->state = HTTP_STATE_READING_FIXED_BODY;
-          parser->content = SLHAlloc(parser->slh,parser->specifiedContentLength);
+          // To keep the working memory same for all of the 'upload' chunks
+          if (parser->specifiedContentLength <= HTTP_MAX_UPLOAD_CHUNK_CONTENT_LENGTH) {
+            parser->content = SLHAlloc(parser->slh, HTTP_MAX_UPLOAD_CHUNK_CONTENT_LENGTH);
+          }
+          else {
+            zowelog(NULL, LOG_COMP_HTTPSERVER, ZOWE_LOG_DEBUG3, "MAX UPLOAD CHUNK SIZE OF 6MB EXCEEDED\n");
+            parser->httpReasonCode = HTTP_STATUS_BAD_REQUEST;
+            return 0;
+          }
           parser->remainingContentLength = parser->specifiedContentLength;
         }
       } else{

--- a/h/httpserver.h
+++ b/h/httpserver.h
@@ -68,6 +68,8 @@
 #define HTTP_REQUEST_HEAP_MIN_BLOCKS 100
 #define HTTP_REQUEST_HEAP_MAX_BLOCKS 4096
 
+#define HTTP_MAX_UPLOAD_CHUNK_CONTENT_LENGTH 6291456 // 6mb - randomnly chosen
+
 typedef struct BigBuffer_tag{
   ShortLivedHeap *slh;  /* can be null */
   char *data;


### PR DESCRIPTION
## Issue
While https://github.com/zowe/zowe-common-c/pull/540 did resolve the memory leak for 64bit, the PR had this note
`The current behavior is such that we don't see increase the memory till the chunk size is equal to or less than the one used initially. That is, it is advisable to use the same chunk size for all the chunks.`

## Proposed changes
This PR will be used to discuss the possibility of using a fixed size buffer irrespective of the content length, with this in the increase in memory is seen only initially. Varying content size causes no further increase. The Fixed memory size is set to 6MB for testing

This PR addresses Issue:  https://github.com/zowe/zss/issues/777


## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Change in a documentation
- [ ] Refactor the code 
- [ ] Chore, repository cleanup, updates the dependencies.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## PR Checklist
Please delete options that are not relevant.
- [ ] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [ ] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zss/blob/v2.x/master/CONTRIBUTING.md))
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] video or image is included if visual changes are made
- [ ] Relevant update to CHANGELOG.md
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works, or describe a test method below

## Testing
Upload chunks less than 6MB

## Further comments
Needs discussion with the squad. 
There are other places that process this chunk and allocate memory for ex https://github.com/zowe/zowe-common-c/blob/8a8a15103febc1f461dadb8ba9bb09c1d4376064/c/httpfileservice.c#L897 

Start up:
<img width="1480" height="674" alt="working_Mem_start" src="https://github.com/user-attachments/assets/7e63c984-a910-44f6-81e7-db55a2b80f4c" />

Without fix the PRIVATE-64 value can be seen increasing to 1GB for large files.

With fix, after upload:
<img width="1491" height="663" alt="working_Mem_after" src="https://github.com/user-attachments/assets/a8e8fb0f-c40b-47e8-86f1-2ffcf6180bd0" />



