### PR TITLE
Allocate more for list of `enum` values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Zowe Common C Changelog
 
+## `3.5.0`
+- Bugfix: Schema validation error is not properly formatted for enumerate type. [(#562)](https://github.com/zowe/zowe-common-c/pull/562)
+
 ## `3.4.0`
 - Enhancement: The tcpServer, tcpClient, httpServer and httpClient family of functions now detect and allow use of IPv6 addresses [(#554)](https://github.com/zowe/zowe-common-c/pull/554) [(#539)](https://github.com/zowe/zowe-common-c/pull/539)
 

--- a/c/jsonschema.c
+++ b/c/jsonschema.c
@@ -1344,10 +1344,9 @@ static VResult validateJSON(JsonValidator *validator,
       }
     }
 
-    unsigned int validValuesMaxSize = (valueSpec->enumeratedValuesCount * (sizeof(Json*) + 3)) + 1;
-    char *validValues = SLHAlloc(validator->evalHeap, validValuesMaxSize);
+	char *validValues = SLHAlloc(validator->evalHeap, MAX_VALIDITY_EXCEPTION_MSG);
     if (validValues) {
-      memset(validValues, 0, validValuesMaxSize);
+      memset(validValues, 0, MAX_VALIDITY_EXCEPTION_MSG);
     }
 
     Json *whichValue = nullToString == true ? emptyStringJson : value;


### PR DESCRIPTION
Fixes #561.

## Problem:
https://github.com/zowe/zowe-common-c/blob/8cf887c8c9959e3e6a0bd2544f87159dc98b4c91/c/jsonschema.c#L1347
Set the buffer for `enum` values, but `sizeof(Json*)` is 8 and does not correspond to the content.
There is no problem, if the strings are in average 11 chars. 

### Luckily ok
* `"enum": ["RACF", "ACF2", "TSS"]`

### Not ok
* `"enum": ["JCEKS", "JCECCAKS", "JCERACFKS", "JCECCARACFKS", "JCEHYBRIDRACFKS"]`
* `"enum": ["httpBasicPassTicket", "zosmf"]`

## Solution

This solution is easy, but far away from being perfect. **It will allocate 1024 each time.** Otherwise we have to loop ever the enum values and compute the length.

### Without fix
```
no matching enum value at /zowe/setup/certificate/type;
expecting one of values '[JCEKS, JCECCAKS, JCERACFKS, JCECCARACFKS, JCEHYBRIDRACFKno matching enum value at /zowe/setup/certificate/type; expecting one of values '[]' of type 'integer'

no matching enum value at /zOSMF/authentication/scheme;
expecting one of values '[httpBasicPassTicket, zosno matching enum value at /zOSMF/authentication/scheme; expecting one of values '[]' of type 'string'
```

### With fix
```
no matching enum value at /zowe/setup/certificate/type;
expecting one of values '[JCEKS, JCECCAKS, JCERACFKS, JCECCARACFKS, JCEHYBRIDRACFKS]' of type 'integer'

no matching enum value at /zOSMF/authentication/scheme;
expecting one of values '[httpBasicPassTicket, zosmf]' of type 'string'
```

#### Very long enum
Shows just the first 1024 characters:
```
no matching enum value at /zOSMF/authentication/scheme; expecting one of values '[httpBasicPassTicket, zosmf,
ABCDEFGHIJKLMNOPQRSTUVWXYZ, ABCDEFGHIJKLMNOPQRSTUVWXYZ, ABCDEFGHIJKLMNOPQRSTUVWXYZ,
ABCDEFGHIJKLMNOPQRSTUVWXYZ, ABCDEFGHIJKLMNOPQRSTUVWXYZ, ABCDEFGHIJKLMNOPQRSTUVWXYZ,
ABCDEFGHIJKLMNOPQRSTUVWXYZ, ABCDEFGHIJKLMNOPQRSTUVWXYZ, ABCDEFGHIJKLMNOPQRSTUVWXYZ,
ABCDEFGHIJKLMNOPQRSTUVWXYZ, ABCDEFGHIJKLMNOPQRSTUVWXYZ, ABCDEFGHIJKLMNOPQRSTUVWXYZ,
ABCDEFGHIJKLMNOPQRSTUVWXYZ, ABCDEFGHIJKLMNOPQRSTUVWXYZ, ABCDEFGHIJKLMNOPQRSTUVWXYZ,
ABCDEFGHIJKLMNOPQRSTUVWXYZ, ABCDEFGHIJKLMNOPQRSTUVWXYZ, ABCDEFGHIJKLMNOPQRSTUVWXYZ,
ABCDEFGHIJKLMNOPQRSTUVWXYZ, ABCDEFGHIJKLMNOPQRSTUVWXYZ, ABCDEFGHIJKLMNOPQRSTUVWXYZ,
ABCDEFGHIJKLMNOPQRSTUVWXYZ, ABCDEFGHIJKLMNOPQRSTUVWXYZ, ABCDEFGHIJKLMNOPQRSTUVWXYZ,
ABCDEFGHIJKLMNOPQRSTUVWXYZ, ABCDEFGHIJKLMNOPQRSTUVWXYZ, ABCDEFGHIJKLMNOPQRSTUVWXYZ,
ABCDEFGHIJKLMNOPQRSTUVWXYZ, ABCDEFGHIJKLMNOPQRSTUVWXYZ, ABCDEFGHIJKLMNOPQRSTUVWXYZ,
ABCDEFGHIJKLMNOPQRSTUVWXYZ, ABCDEFGHIJKLMNOPQRSTUVWXYZ, ABCDEFGHIJKLMNOPQ
```