### PR TITLE
Fix a typo in cross-memory help text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## `3.5.0`
 - Bugfix: Schema validation error is not properly formatted for enumerate type. [(#562)](https://github.com/zowe/zowe-common-c/pull/562)
+- Bugfix: fix a typo in the cross-memory server's help text (#565)
 
 ## `3.4.0`
 - Enhancement: The tcpServer, tcpClient, httpServer and httpClient family of functions now detect and allow use of IPv6 addresses [(#554)](https://github.com/zowe/zowe-common-c/pull/554) [(#539)](https://github.com/zowe/zowe-common-c/pull/539)

--- a/c/crossmemory.c
+++ b/c/crossmemory.c
@@ -4626,7 +4626,7 @@ static void printServerReadyMessage(CrossMemoryServer *srv) {
       "           DISPLAY [OPTION_NAME]- Print service information\n"
       "             OPTION_NAME:\n"
       "               CONFIG - Print server configuration information (default)\n"
-      "               MODREG - Print module registry informatio\n"
+      "               MODREG - Print module registry information\n"
       "           FLUSH - Print all pending log messages\n"
       "           LOG <COMP_ID> <LOG_LEVEL> - Set log level\n"
       "             COMP_ID:\n"


### PR DESCRIPTION
<!-- Thank you for submitting a PR to Zowe! To help us understand, test, and give feedback on your code, please fill in the details below. -->

## Proposed changes

A type has been reported in the help text that the cross-memory prints to SYSPRINT; this PR fixes the typo.

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zss/blob/v2.x/master/CONTRIBUTING.md))
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings

## Testing
Make sure the updated text looks correct in SYSPRINT of ZIS.
