### PR TITLE
Rename F_LOCK struct to avoid standard library conflict

### DIFF
--- a/c/zosfile.c
+++ b/c/zosfile.c
@@ -1863,14 +1863,14 @@ int fileSetLock(UnixFile *file, int *returnCode, int *reasonCode) {
 #endif
 
   int action = F_SET_LOCK;
-  F_LOCK flockdata;
+  FLock flockdata;
   flockdata.l_type = F_WRITE_LOCK;
   flockdata.l_whence = F_SEEK_SET;
   flockdata.l_start = 0;
   flockdata.l_len = F_WHENCE_TO_END;
   flockdata.l_pid = 0;
 
-  F_LOCK *fnctl_ptr = &flockdata;
+  FLock *fnctl_ptr = &flockdata;
 
   BPXFCT(&file->fd,
          &action,
@@ -1898,14 +1898,14 @@ int fileGetLock(UnixFile *file, int *returnCode, int *reasonCode, int *isLocked)
 #endif
 
   int action = F_GET_LOCK;
-  F_LOCK flockdata;
+  FLock flockdata;
   flockdata.l_type = F_WRITE_LOCK;
   flockdata.l_whence = F_SEEK_SET;
   flockdata.l_start = 0;
   flockdata.l_len = F_WHENCE_TO_END;
   flockdata.l_pid = 0;
 
-  F_LOCK *fnctl_ptr = &flockdata;
+  FLock *fnctl_ptr = &flockdata;
 
   BPXFCT(&file->fd,
          &action,
@@ -1937,14 +1937,14 @@ int fileUnlock(UnixFile *file, int *returnCode, int *reasonCode) {
 #endif
 
   int action = F_SET_LOCK;
-  F_LOCK flockdata;
+  FLock flockdata;
   flockdata.l_type = F_UNLOCK;
   flockdata.l_whence = F_SEEK_SET;
   flockdata.l_start = 0;
   flockdata.l_len = F_WHENCE_TO_END;
   flockdata.l_pid = 0;
 
-  F_LOCK *fnctl_ptr = &flockdata;
+  FLock *fnctl_ptr = &flockdata;
 
   BPXFCT(&file->fd,
          &action,

--- a/h/unixfile.h
+++ b/h/unixfile.h
@@ -473,13 +473,13 @@ typedef struct F_CVT_tag {
 /* Length Values */
 #define F_WHENCE_TO_END  0            /* Locked file is from whence to end of the file */
 
-typedef struct F_LOCK_TAG {
+typedef struct FLock_tag {
   short l_type;
   short l_whence;
   int64 l_start;
   int64 l_len;
   unsigned int l_pid;
-} F_LOCK;
+} FLock;
 
 int fileDisableConversion(UnixFile *file, int *returnCode, int *reasonCode);
 int fileSetLock(UnixFile *file, int *returnCode, int *reasonCode);


### PR DESCRIPTION
The F_LOCK struct we have collides with <unistd.h>, but I guess not many people were using it in the past so we did not notice.

After discussion with Joe, we agreed to rename it to FLock.