### PR TITLE
Improved peer hint when schema invalid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Bugfix: Schema validation error is not properly formatted for enumerate type. [(#562)](https://github.com/zowe/zowe-common-c/pull/562)
 - Bugfix: fix a typo in the cross-memory server's help text (#565)
 - Enhancement: Move to later version of quickjs (#573)
+- Enhancement: configmgr validation errors now use dot-formatted paths and can detect if a property that's unknown is likely to be at the wrong level of indentation [(#577)](https://github.com/zowe/zowe-common-c/pull/577)
 
 ## `3.4.0`
 - Enhancement: The tcpServer, tcpClient, httpServer and httpClient family of functions now detect and allow use of IPv6 addresses [(#554)](https://github.com/zowe/zowe-common-c/pull/554) [(#539)](https://github.com/zowe/zowe-common-c/pull/539)

--- a/c/jsonschema.c
+++ b/c/jsonschema.c
@@ -213,15 +213,10 @@ static char *fillAccessPathString(char *buffer, int bufferLen, AccessPath *path)
   memset(buffer,0,bufferLen);
   int pos = 0;
   for (int i=0; i<path->currentSize; i++){
-    if (pos + 100 >= bufferLen){
-      sprintf(buffer+pos,"...");
-      break;
-    }
-    if (path->elements[i].isName){
-      pos += sprintf(buffer+pos,"/%s",path->elements[i].key.name);
-    } else {
-      pos += sprintf(buffer+pos,"/%d",path->elements[i].key.index);
-    }
+    pos = appendPathSegment(buffer, pos,
+                            path->elements[i].isName,
+                            path->elements[i].key.name,
+                            path->elements[i].key.index);
   }
   return buffer;
 }
@@ -583,12 +578,32 @@ static bool hasBeenEvaluated(EvalSet *evalSet, JsonObject *object, char *propert
 static VResult validateJSON(JsonValidator *validator, Json *value, JSValueSpec *valueSpec, int depth,
                             EvalSet *evalSetList);
 
+/* Appends one dot-separated path segment to buf at position pos, returning
+   the updated position.  A leading dot is only written when pos > 0. */
+static int appendPathSegment(char *buf, int pos, bool isName, char *name, int index){
+  if (pos + 100 >= MAX_ACCESS_PATH){
+    return pos + snprintf(buf + pos, MAX_ACCESS_PATH - pos, "...");
+  }
+  const char *sep = (pos == 0) ? "" : ".";
+  if (isName){
+    return pos + snprintf(buf + pos, MAX_ACCESS_PATH - pos, "%s%s", sep, name);
+  } else {
+    return pos + snprintf(buf + pos, MAX_ACCESS_PATH - pos, "%s%d", sep, index);
+  }
+}
+
 /*
   Checks whether a property that was not found in the current schema spec exists
   as a property in the *parent* spec (i.e., is a peer of the current container).
-  When such a peer is found, returns a hint string reminding the user that the
-  property might have been misindented.  Returns an empty string otherwise so
-  callers can always use "%s" without a NULL check.
+  When such a peer is found, returns a hint string showing the full correct path
+  vs the full incorrect path so the user can immediately see what change to make.
+  Returns an empty string otherwise so callers can always use "%s" without a NULL
+  check.
+
+  Example: if the access path is zowe.setup.certificate.truststore.keystore and
+  'keystore' is a peer of 'truststore' in the schema, the hint will read:
+      ; did you mean 'zowe.setup.certificate.keystore'
+        instead of 'zowe.setup.certificate.truststore.keystore'?
 */
 static char *makePeerHint(JsonValidator *validator,
                           JSValueSpec *valueSpec,
@@ -601,10 +616,36 @@ static char *makePeerHint(JsonValidator *validator,
       /* accessPath->elements[pathSize-1] is the just-pushed propertyName;
          elements[pathSize-2] is the name of the container object we are inside. */
       if (pathSize >= 2 && accessPath->elements[pathSize-2].isName){
-        char *containerName = accessPath->elements[pathSize-2].key.name;
+
+        /* Build the full "incorrect" path (all elements including the
+           accidental container and the misplaced key). */
+        char incorrectPath[MAX_ACCESS_PATH];
+        memset(incorrectPath, 0, MAX_ACCESS_PATH);
+        int ipos = 0;
+        for (int i = 0; i < pathSize; i++){
+          ipos = appendPathSegment(incorrectPath, ipos,
+                                   accessPath->elements[i].isName,
+                                   accessPath->elements[i].key.name,
+                                   accessPath->elements[i].key.index);
+        }
+
+        /* Build the "correct" path: all elements except the accidental
+           container (pathSize-2) and the misplaced key (pathSize-1),
+           then append propertyName directly under the grandparent. */
+        char correctPath[MAX_ACCESS_PATH];
+        memset(correctPath, 0, MAX_ACCESS_PATH);
+        int cpos = 0;
+        for (int i = 0; i < pathSize - 2; i++){
+          cpos = appendPathSegment(correctPath, cpos,
+                                   accessPath->elements[i].isName,
+                                   accessPath->elements[i].key.name,
+                                   accessPath->elements[i].key.index);
+        }
+        cpos = appendPathSegment(correctPath, cpos, true, propertyName, 0);
+
         return validityMessage(validator,
-                               "; did you mean to place '%s' as a peer of '%s' rather than inside it?",
-                               propertyName, containerName);
+                               "; did you mean '%s' instead of '%s'?",
+                               correctPath, incorrectPath);
       }
     }
   }

--- a/c/jsonschema.c
+++ b/c/jsonschema.c
@@ -583,6 +583,34 @@ static bool hasBeenEvaluated(EvalSet *evalSet, JsonObject *object, char *propert
 static VResult validateJSON(JsonValidator *validator, Json *value, JSValueSpec *valueSpec, int depth,
                             EvalSet *evalSetList);
 
+/*
+  Checks whether a property that was not found in the current schema spec exists
+  as a property in the *parent* spec (i.e., is a peer of the current container).
+  When such a peer is found, returns a hint string reminding the user that the
+  property might have been misindented.  Returns an empty string otherwise so
+  callers can always use "%s" without a NULL check.
+*/
+static char *makePeerHint(JsonValidator *validator,
+                          JSValueSpec *valueSpec,
+                          char *propertyName,
+                          AccessPath *accessPath){
+  if (valueSpec->parent != NULL && valueSpec->parent->properties != NULL){
+    JSValueSpec *peerSpec = (JSValueSpec*)htGet(valueSpec->parent->properties, propertyName);
+    if (peerSpec != NULL){
+      int pathSize = accessPath->currentSize;
+      /* accessPath->elements[pathSize-1] is the just-pushed propertyName;
+         elements[pathSize-2] is the name of the container object we are inside. */
+      if (pathSize >= 2 && accessPath->elements[pathSize-2].isName){
+        char *containerName = accessPath->elements[pathSize-2].key.name;
+        return validityMessage(validator,
+                               "; did you mean to place '%s' as a peer of '%s' rather than inside it?",
+                               propertyName, containerName);
+      }
+    }
+  }
+  return "";
+}
+
 static VResult validateJSONObject(JsonValidator *validator,
                                   JsonObject *object,
                                   JSValueSpec *valueSpec,
@@ -638,11 +666,13 @@ static VResult validateJSONObject(JsonValidator *validator,
       }
     } else {
       if (valueSpec->additionalProperties == false){
+        char *peerHint = makePeerHint(validator, valueSpec, propertyName, accessPath);
         addValidityChild(pendingException,
                          makeValidityException(validator,
                                                validityMessage(validator,
-                                                               "unspecified additional property not allowed: '%s' at '%s'",
-                                                               propertyName,validatorAccessPath(validator))));
+                                                               "unspecified additional property not allowed: '%s' at '%s'%s",
+                                                               propertyName,validatorAccessPath(validator),
+                                                               peerHint)));
       } else if (valueSpec->unevaluatedProperties == false){
         if (validator->traceLevel >= 1){
           trace(validator,depth,"Is '%s' in the following eval sets for obj=0x%p myEvalSet=0x%p\n",propertyName,object,evalSetList);
@@ -655,11 +685,13 @@ static VResult validateJSONObject(JsonValidator *validator,
           if (validator->traceLevel >= 1){
             trace(validator,depth,"Invalid object on unevaluated property '%s'\n",propertyName);
           }
+          char *peerHint = makePeerHint(validator, valueSpec, propertyName, accessPath);
           addValidityChild(pendingException,
                            makeValidityException(validator,
                                                  validityMessage(validator,
-                                                                 "unevaluated property not allowed: '%s' at '%s'",
-                                                                 propertyName,validatorAccessPath(validator))));
+                                                                 "unevaluated property not allowed: '%s' at '%s'%s",
+                                                                 propertyName,validatorAccessPath(validator),
+                                                                 peerHint)));
         }
       } else if (validator->flags && VALIDATOR_WARN_ON_UNDEFINED_PROPERTIES){
         trace(validator,depth,"*WARNING* unspecified property seen, '%s', and checking code is not complete, vspec->props=0x%p\n",

--- a/c/jsonschema.c
+++ b/c/jsonschema.c
@@ -198,6 +198,10 @@ typedef struct AccessPathUnion_tag {
   int dummy;
 } AccessPathUnion;
 
+
+//forward declaration
+static int appendPathSegment(char *buf, int pos, bool isName, char *name, int index);
+
 static void printAccessPath(FILE *out, AccessPath *path){
   for (int i=0; i<path->currentSize; i++){
     if (path->elements[i].isName){
@@ -241,8 +245,6 @@ static void accessPathPop(AccessPath *accessPath){
     accessPath->currentSize--;
   }
 }
-
-
 
 #define ERROR_MAX 1024
 
@@ -644,8 +646,8 @@ static char *makePeerHint(JsonValidator *validator,
         cpos = appendPathSegment(correctPath, cpos, true, propertyName, 0);
 
         return validityMessage(validator,
-                               "; did you mean '%s' instead of '%s'?",
-                               correctPath, incorrectPath);
+                               "; did you mean '%s' instead?",
+                               correctPath);
       }
     }
   }


### PR DESCRIPTION
Alternative slighty more complex PR to https://github.com/zowe/zowe-common-c/pull/576

This additionally
1) has better output to give you an example of what you may do to correct the situation
2) changes all output slashes to dots and gets rid of the leading one. configmgr validation errors will now match how we reference YAML properties to users.

Output preview:

<img width="1095" height="69" alt="image" src="https://github.com/user-attachments/assets/6b7bc305-cdb4-42d3-847d-9b64e0a66944" />

