### PR TITLE
Add semantic validation for user, group, file and directory

### DIFF
--- a/build/build_cmgr_xlclang.sh
+++ b/build/build_cmgr_xlclang.sh
@@ -163,6 +163,7 @@ xlclang \
   ${COMMON}/c/yaml2json.c \
   ${COMMON}/c/zos.c \
   ${COMMON}/c/zosfile.c \
+  ${COMMON}/c/zosaccounts.c \
   ${GSKDIR}/lib/GSKSSL64.x \
   ${GSKDIR}/lib/GSKCMS64.x
 rc=$?

--- a/c/configmgr.c
+++ b/c/configmgr.c
@@ -40,6 +40,8 @@
 #include <stdint.h> 
 #include <stdbool.h> 
 #include <errno.h>
+#include <grp.h>
+#include <pwd.h>
 #include <math.h>
 
 #endif
@@ -64,6 +66,7 @@
 #include "configmgr.h"
 #ifdef __ZOWE_OS_ZOS
 #include "pdsutil.h"
+#include "zosaccounts.h"
 #endif 
 
 #ifdef __ZOWE_OS_WINDOWS
@@ -1583,10 +1586,58 @@ static void copyValidityException(JsonBuilder *b, Json *parent, char *key, Valid
   }
 }
 
+/* Semantic validator: checks that a string property value refers to an existing file.
+   Returns true if the path exists as a file (or directory), false otherwise. */
+static bool validateFileExists(const char *path){
+  struct stat st;
+  return (stat(path, &st) == 0);
+}
+
+/* Semantic validator: checks that a string property value refers to an existing directory.
+   Returns true if the path exists and is a directory, false otherwise. */
+static bool validateDirectoryExists(const char *path){
+  struct stat st;
+  return (stat(path, &st) == 0) && S_ISDIR(st.st_mode);
+}
+
+#ifdef __ZOWE_OS_ZOS
+/* Semantic validator: checks that a string property value is a valid z/OS user ID.
+   Returns true if the user exists in the system security database, false otherwise. */
+static bool validateUserExists(const char *userName){
+  int returnCode = 0;
+  int reasonCode = 0;
+  return (userIdGet((char *)userName, &returnCode, &reasonCode) != -1);
+}
+
+/* Semantic validator: checks that a string property value is a valid z/OS group name.
+   Returns true if the group exists in the system security database, false otherwise. */
+static bool validateGroupExists(const char *groupName){
+  int returnCode = 0;
+  int reasonCode = 0;
+  return (groupIdGet((char *)groupName, &returnCode, &reasonCode) != -1);
+}
+#else
+/* Semantic validator: checks that a string property value is a valid user name.
+   Returns true if the user exists in the system user database, false otherwise. */
+static bool validateUserExists(const char *userName){
+  return (getpwnam(userName) != NULL);
+}
+
+/* Semantic validator: checks that a string property value is a valid group name.
+   Returns true if the group exists in the system group database, false otherwise. */
+static bool validateGroupExists(const char *groupName){
+  return (getgrnam(groupName) != NULL);
+}
+#endif
+
 static int validateWrapper(ConfigManager *mgr, EJSNativeInvocation *invocation){
   const char *configName = NULL;
   ejsStringArg(invocation,0,&configName);
   JsonValidator *validator = makeJsonValidator();
+  validator->fileExistsValidator = validateFileExists;
+  validator->directoryExistsValidator = validateDirectoryExists;
+  validator->groupExistsValidator = validateGroupExists;
+  validator->userExistsValidator = validateUserExists;
   EmbeddedJS *ejs = ejsGetEnvironment(invocation);
   JsonBuilder *builder = ejsMakeJsonBuilder(ejs);
   validator->traceLevel = mgr->traceLevel;
@@ -1862,6 +1913,10 @@ static int simpleMain(int argc, char **argv){
     trace(mgr,INFO,"about to validate merged yamls as\n");
     jsonPrettyPrint(mgr,cfgGetConfigData(mgr,configName));
     JsonValidator *validator = makeJsonValidator();
+    validator->fileExistsValidator = validateFileExists;
+    validator->directoryExistsValidator = validateDirectoryExists;
+    validator->groupExistsValidator = validateGroupExists;
+    validator->userExistsValidator = validateUserExists;
     validator->traceLevel = mgr->traceLevel;
     trace(mgr,DEBUG,"Before Validate\n");
     int validateStatus = cfgValidate(mgr,validator,configName);

--- a/c/jsonschema.c
+++ b/c/jsonschema.c
@@ -189,6 +189,8 @@ typedef struct JSValueSpec_tag {
   char *pattern;
   regex_t *compiledPattern;
   int      regexCompilationError;
+  /* Zowe semantic validation keyword, e.g. "fileExists" */
+  char *zoweValidate;
 
   /* back/up pointer */
   struct JSValueSpec_tag *parent;
@@ -824,6 +826,49 @@ static VResult validateJSONString(JsonValidator *validator,
                                                validityMessage(validator,
                                                                "string pattern match fail s='%s', pat='%s', at %s",
                                                                s,valueSpec->pattern,validatorAccessPath(validator))));
+      }
+    }
+  }
+  if (valueSpec->zoweValidate != NULL){
+    if (strcmp(valueSpec->zoweValidate,"fileExists") == 0){
+      if (validator->fileExistsValidator != NULL){
+        if (!validator->fileExistsValidator(s)){
+          addValidityChild(pendingException,
+                           makeValidityException(validator,
+                                                 validityMessage(validator,
+                                                                 "file does not exist: '%s' at %s",
+                                                                 s,validatorAccessPath(validator))));
+        }
+      }
+    } else if (strcmp(valueSpec->zoweValidate,"directoryExists") == 0){
+      if (validator->directoryExistsValidator != NULL){
+        if (!validator->directoryExistsValidator(s)){
+          addValidityChild(pendingException,
+                           makeValidityException(validator,
+                                                 validityMessage(validator,
+                                                                 "directory does not exist: '%s' at %s",
+                                                                 s,validatorAccessPath(validator))));
+        }
+      }
+    } else if (strcmp(valueSpec->zoweValidate,"userExists") == 0){
+      if (validator->userExistsValidator != NULL){
+        if (!validator->userExistsValidator(s)){
+          addValidityChild(pendingException,
+                           makeValidityException(validator,
+                                                 validityMessage(validator,
+                                                                 "user does not exist: '%s' at %s",
+                                                                 s,validatorAccessPath(validator))));
+        }
+      }
+    } else if (strcmp(valueSpec->zoweValidate,"groupExists") == 0){
+      if (validator->groupExistsValidator != NULL){
+        if (!validator->groupExistsValidator(s)){
+          addValidityChild(pendingException,
+                           makeValidityException(validator,
+                                                 validityMessage(validator,
+                                                                 "group does not exist: '%s' at %s",
+                                                                 s,validatorAccessPath(validator))));
+        }
       }
     }
   }
@@ -2027,6 +2072,7 @@ static JSValueSpec *build(JsonSchemaBuilder *builder, JSValueSpec *parent, Json 
               stringSpec->validatorFlags |= JS_VALIDATOR_MIN_LENGTH;
             }
             stringSpec->pattern = getString(builder,object,"pattern",NULL); // hard to support on ANSI C
+            stringSpec->zoweValidate = getString(builder,object,"zoweValidate",NULL);
           }
           break;
         case JSTYPE_NULL:

--- a/h/jsonschema.h
+++ b/h/jsonschema.h
@@ -94,6 +94,10 @@ typedef struct ValidityException_tag {
 
 #define MAX_VALIDATOR_MATCHES 8
 
+/* Semantic validator function pointer type used for custom Zowe validation rules.
+   Returns true if the value is considered valid, false otherwise. */
+typedef bool (*ZoweSemanticValidator)(const char *value);
+
 typedef struct JsonValidator_tag {
   JsonSchema  *topSchema;
   /* Other schemas that are referred to by the top and each other can be loaded into
@@ -118,6 +122,14 @@ typedef struct JsonValidator_tag {
   jmp_buf     recoveryData;
   ShortLivedHeap *evalHeap;
   bool        allowStringToBeNull;
+  /* Optional semantic validator called when a string property has "zoweValidate": "fileExists" */
+  ZoweSemanticValidator fileExistsValidator;
+  /* Optional semantic validator called when a string property has "zoweValidate": "directoryExists" */
+  ZoweSemanticValidator directoryExistsValidator;
+  /* Optional semantic validator called when a string property has "zoweValidate": "userExists" */
+  ZoweSemanticValidator userExistsValidator;
+  /* Optional semantic validator called when a string property has "zoweValidate": "groupExists" */
+  ZoweSemanticValidator groupExistsValidator;
 } JsonValidator;
 
 #define JSON_SCHEMA_DRAFT_4 400


### PR DESCRIPTION
For discussion.

This PR allows one to add "zoweValidate" to a json schema with values like "directoryExists".
This makes configmgr perform existence checks on the YAML value backed by the schema.

This is implemented by having function pointers in jsonschema.c which may be implemented, in this case, by configmgr.c
If jsonschema.c encounters a value for zoweValidate which nobody has implemented, it ignores it.
That is, it checks the schema as it would have without this PR.
But for any validator it does have, it calls the function and uses the boolean to determine if it should give an error or not.

<img width="3484" height="2104" alt="image" src="https://github.com/user-attachments/assets/01d763e1-4b5e-48a1-bb5f-11e6447a4910" />
