### PR TITLE
Report symlink state in unix file API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Bugfix: fix a typo in the cross-memory server's help text (#565)
 - Enhancement: Move to later version of quickjs (#573)
 - Enhancement: configmgr validation errors now use dot-formatted paths and can detect if a property that's unknown is likely to be at the wrong level of indentation [(#577)](https://github.com/zowe/zowe-common-c/pull/577)
+- Enhancement: file API now returns the boolean "symlink" to state if a file is a symbolic link or not. [(#579)](https://github.com/zowe/zowe-common-c/pull/579)
 
 ## `3.4.0`
 - Enhancement: The tcpServer, tcpClient, httpServer and httpClient family of functions now detect and allow use of IPv6 addresses [(#554)](https://github.com/zowe/zowe-common-c/pull/554) [(#539)](https://github.com/zowe/zowe-common-c/pull/539)

--- a/c/httpserver.c
+++ b/c/httpserver.c
@@ -5001,6 +5001,7 @@ int makeJSONForDirectory(HttpResponse *response, char *dirname, int includeDotte
               jsonAddUnterminatedString(out, "name", name, nameLength);
               jsonAddString(out, "path", path);
               jsonAddBoolean(out, "directory", fileInfoIsDirectory(&info));
+              jsonAddBoolean(out, "symlink", fileInfoIsSymbolicLink(&info));
               jsonAddInt64(out, "size", fileInfoSize(&info));
               jsonAddInt(out, "ccsid", fileInfoCCSID(&info));
               jsonAddString(out, "createdAt", timeStamp.data);


### PR DESCRIPTION
This PR adds another boolean to the file info api which states if the object is a symlink or not. It already said if an object was a directory, so by checking if it's a symlink or a directory, you'll know if its a file.

<img width="1996" height="880" alt="image" src="https://github.com/user-attachments/assets/1654d0b9-6b47-4776-b493-8c92cea94459" />
