### PR TITLE
Read symlink targets and return them in file api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Enhancement: Move to later version of quickjs (#573)
 - Enhancement: configmgr validation errors now use dot-formatted paths and can detect if a property that's unknown is likely to be at the wrong level of indentation [(#577)](https://github.com/zowe/zowe-common-c/pull/577)
 - Enhancement: file API now returns the boolean "symlink" to state if a file is a symbolic link or not. [(#579)](https://github.com/zowe/zowe-common-c/pull/579)
+- Enhancement: file API now includes the target path of a symlink in the field "symlinkTarget". [(#580)](https://github.com/zowe/zowe-common-c/pull/580)
+- Enhancement: file API's "directory" value for symlinks now corresponds to whether the target is a directory or not. [(#580)](https://github.com/zowe/zowe-common-c/pull/580)
 
 ## `3.4.0`
 - Enhancement: The tcpServer, tcpClient, httpServer and httpClient family of functions now detect and allow use of IPv6 addresses [(#554)](https://github.com/zowe/zowe-common-c/pull/554) [(#539)](https://github.com/zowe/zowe-common-c/pull/539)

--- a/c/httpserver.c
+++ b/c/httpserver.c
@@ -4996,12 +4996,39 @@ int makeJSONForDirectory(HttpResponse *response, char *dirname, int includeDotte
           trimRight(group, GROUP_NAME_LEN);
           
           /*          if(status == 0) { */
+            int isSymlink = fileInfoIsSymbolicLink(&info);
+            char symlinkTarget[USS_MAX_PATH_LENGTH + 1] = {0};
+            int isDirectory = FALSE;
+            if (isSymlink) {
+              int linkLen = fileReadLink(path, symlinkTarget, USS_MAX_PATH_LENGTH, &returnCode, &reasonCode);
+              if (linkLen < 0) {
+                zowelog(NULL, LOG_COMP_HTTPSERVER, ZOWE_LOG_DEBUG,
+                        "fileReadLink (%s) FAILED: returnCode: %d, reasonCode: 0x%08x\n",
+                        path, returnCode, reasonCode);
+                symlinkTarget[0] = '\0';
+              } else if (symlinkTarget[0] != '\0') {
+                FileInfo targetInfo = {0};
+                if (fileInfo(symlinkTarget, &targetInfo, &returnCode, &reasonCode) == 0) {
+                  isDirectory = fileInfoIsDirectory(&targetInfo);
+                } else {
+                  zowelog(NULL, LOG_COMP_HTTPSERVER, ZOWE_LOG_DEBUG,
+                          "fileInfo on symlink target (%s) FAILED: returnCode: %d, reasonCode: 0x%08x\n",
+                          symlinkTarget, returnCode, reasonCode);
+                }
+              }
+            } else {
+              isDirectory = fileInfoIsDirectory(&info);
+            }
+
             jsonStartObject(out, NULL);
             {
               jsonAddUnterminatedString(out, "name", name, nameLength);
               jsonAddString(out, "path", path);
-              jsonAddBoolean(out, "directory", fileInfoIsDirectory(&info));
-              jsonAddBoolean(out, "symlink", fileInfoIsSymbolicLink(&info));
+              jsonAddBoolean(out, "directory", isDirectory);
+              jsonAddBoolean(out, "symlink", isSymlink);
+              if (isSymlink) {
+                jsonAddString(out, "symlinkTarget", symlinkTarget);
+              }
               jsonAddInt64(out, "size", fileInfoSize(&info));
               jsonAddInt(out, "ccsid", fileInfoCCSID(&info));
               jsonAddString(out, "createdAt", timeStamp.data);

--- a/c/zosfile.c
+++ b/c/zosfile.c
@@ -54,6 +54,7 @@
 #pragma linkage(BPX4LST,OS)
 #pragma linkage(BPX4GGN,OS)
 #pragma linkage(BPX4GPN,OS)
+#pragma linkage(BPX4RDL,OS)
 
 #define BPXRED BPX4RED
 #define BPXOPN BPX4OPN
@@ -75,6 +76,7 @@
 #define BPXLST BPX4LST
 #define BPXGGN BPX4GGN
 #define BPXGPN BPX4GPN
+#define BPXRDL BPX4RDL
 
 #else
 
@@ -98,6 +100,7 @@
 #pragma linkage(BPX1LST,OS)
 #pragma linkage(BPX1GGN,OS)
 #pragma linkage(BPX1GPN,OS)
+#pragma linkage(BPX1RDL,OS)
 
 #define BPXRED BPX1RED
 #define BPXOPN BPX1OPN
@@ -119,6 +122,7 @@
 #define BPXLST BPX1LST
 #define BPXGGN BPX1GGN
 #define BPXGPN BPX1GPN
+#define BPXRDL BPX1RDL
 #endif
 
 /* Better compilers need these symbols to be declared as functions */
@@ -142,6 +146,7 @@ int BPXFCT();
 int BPXLST();
 int BPXGGN();
 int BPXGPN();
+int BPXRDL();
 
 #define MAX_ENTRY_BUFFER_SIZE 2550
 #define MAX_NUM_ENTRIES       1000
@@ -905,6 +910,54 @@ int symbolicFileInfo(const char *filename, BPXYSTAT *stats, int *returnCode, int
     *returnCode = 0;
     *reasonCode = 0;
   }
+  return returnValue;
+}
+
+int fileReadLink(char *fileName, char *buffer, int bufferSize, int *returnCode, int *reasonCode) {
+  int nameLength = strlen(fileName);
+  int *reasonCodePtr;
+  int returnValue = 0;
+
+#ifndef _LP64
+  reasonCodePtr = (int*) (0x80000000 | ((int)reasonCode));
+#else
+  reasonCodePtr = reasonCode;
+#endif
+
+  BPXRDL(&nameLength,
+         fileName,
+         &bufferSize,
+         &buffer,
+         &returnValue,
+         returnCode,
+         reasonCodePtr);
+
+  if (fileTrace) {
+    if (returnValue == -1) {
+#ifdef METTLE
+      zowelog(NULL, LOG_COMP_ZOS, ZOWE_LOG_DEBUG, "BPXRDL (%s) FAILED: returnValue: %d, returnCode: %d, reasonCode: 0x%08x\n",
+             fileName, returnValue, *returnCode, *reasonCode);
+#else
+      zowelog(NULL, LOG_COMP_ZOS, ZOWE_LOG_DEBUG, "BPXRDL (%s) FAILED: returnValue: %d, returnCode: %d, reasonCode: 0x%08x, strError: (%s)\n",
+             fileName, returnValue, *returnCode, *reasonCode, strerror(*returnCode));
+#endif
+    }
+    else {
+      zowelog(NULL, LOG_COMP_ZOS, ZOWE_LOG_DEBUG, "BPXRDL (%s) OK: returnVal: %d\n", fileName, returnValue);
+    }
+  }
+
+  if (returnValue == -1) {
+    return -1;
+  }
+
+  /* Null-terminate the result; returnValue is the number of bytes written */
+  if (returnValue < bufferSize) {
+    buffer[returnValue] = '\0';
+  }
+
+  *returnCode = 0;
+  *reasonCode = 0;
   return returnValue;
 }
 

--- a/h/unixfile.h
+++ b/h/unixfile.h
@@ -439,6 +439,11 @@ int fileInfo(const char *filename, FileInfo *fileInfo, int *returnCode, int *rea
 /* Same as fileInfo but does not follow symbolic link */
 int symbolicFileInfo(const char *filename, FileInfo *fileInfo, int *returnCode, int *reasonCode);
 
+/* Reads the target of a symbolic link into buffer.
+   Returns the number of bytes written to buffer (not null-terminated by BPX service,
+   but this wrapper adds a null terminator), or -1 on error. */
+int fileReadLink(char *fileName, char *buffer, int bufferSize, int *returnCode, int *reasonCode);
+
 #ifdef __ZOWE_OS_ZOS
 int fileChangeTag(const char *fileName, int *returnCode, int *reasonCode, int ccsid);
 


### PR DESCRIPTION
This changes the file API such that if we detect an object is a symlink, we dig deeper to return the path of the target in a new field "symlinkTarget".
Additionally, the "directory" boolean is now the value of the symlink target rather than the symlink. This is opinionated but my opinion is it allows existing code to 'do the right thing' without code changes on their end - if a symlink target is a directory, programs should act like the symlink itself is a directory.

the api, and results of fixing this directory behavior, are seen in this screenshot
<img width="2444" height="1094" alt="symlink-target" src="https://github.com/user-attachments/assets/2587eebb-57ab-415d-af24-8e16d5f9ce18" />


The old behavior where the editor did not know a symlink was a directory was not so good...
<img width="1168" height="686" alt="symlink-broken" src="https://github.com/user-attachments/assets/dbb6100e-6983-4e50-8339-f5b3a39d10fc" />

