### PR TITLE
Optional flags for xlclang

### DIFF
--- a/build/build_cmgr_xlclang.sh
+++ b/build/build_cmgr_xlclang.sh
@@ -59,6 +59,7 @@ echo "Compiling libraries"
 
 xlclang \
   -c \
+  ${ZWE_XLCLANG_FLAGS} \
   -q64 \
   -qascii \
   "-Wc,float(ieee),longname,langlvl(extc99),gonum,goff,ASM,asmlib('CEE.SCEEMAC','SYS1.MACLIB','SYS1.MODGEN')" \
@@ -103,6 +104,7 @@ echo "Building configmgr"
 #   "-Wl,list,xref" \
 
 xlclang \
+  ${ZWE_XLCLANG_FLAGS} \
   -q64 \
   "-Wc,float(ieee),longname,langlvl(extc99),gonum,goff,ASM,asmlib('CEE.SCEEMAC','SYS1.MACLIB','SYS1.MODGEN')" \
   -D_OPEN_SYS_FILE_EXT=1 \

--- a/build/build_getesm.sh
+++ b/build/build_getesm.sh
@@ -21,6 +21,7 @@ mkdir -p "${TMP_DIR}" && cd "${TMP_DIR}"
 rm -f "${COMMON}/bin/getesm"
 
 xlclang \
+  ${ZWE_XLCLANG_FLAGS} \
   -q64 \
   "-Wc,float(ieee),longname,langlvl(extc99),gonum,goff,ASM,asmlib('SYS1.MACLIB')" \
   -D_OPEN_SYS_FILE_EXT=1 \

--- a/build/build_rexxcmgr.sh
+++ b/build/build_rexxcmgr.sh
@@ -41,6 +41,7 @@ VERSION="\"${MAJOR}.${MINOR}.${PATCH}\""
 
 xlclang \
   -c \
+  ${ZWE_XLCLANG_FLAGS} \
   -q64 \
   -qascii \
   "-Wc,float(ieee),longname,langlvl(extc99),gonum,goff,ASM,asmlib('CEE.SCEEMAC','SYS1.MACLIB','SYS1.MODGEN')" \
@@ -80,6 +81,7 @@ xlclang \
 
 xlclang \
   -c \
+  ${ZWE_XLCLANG_FLAGS} \
   -q64 \
   "-Wc,float(ieee),longname,langlvl(extc99),gonum,goff,ASM,asmlib('CEE.SCEEMAC','SYS1.MACLIB','SYS1.MODGEN')" \
   -DYAML_VERSION_MAJOR=${YAML_MAJOR} \


### PR DESCRIPTION
This PR adds env var ZWE_XLCLANG_FLAGS in the compile for xlclang, so that if you have environmental needs different from others, you can just set that during your compiles.

In particular, I was using this to add the -F flag.