### PR TITLE
Set IO error flag in jsonConvertAndWriteBuffer on conversion failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Zowe Common C Changelog
 
 ## `3.5.0`
+- Bugfix: Set IO error flag in `jsonConvertAndWriteBuffer()` when character conversion or write operations fail, allowing callers to detect and stop processing early. (#590)
 - Bugfix: Schema validation error is not properly formatted for enumerate type. [(#562)](https://github.com/zowe/zowe-common-c/pull/562)
 - Bugfix: fix a typo in the cross-memory server's help text (#565)
 - Enhancement: Move to later version of quickjs (#573)

--- a/c/json.c
+++ b/c/json.c
@@ -400,6 +400,7 @@ void jsonConvertAndWriteBuffer(jsonPrinter *p, char *text, size_t len,
       if (newLen < 0) {
         JSONERROR("jsonConvertAndWriteBuffer() error: newLen = %d\n",
                   (int)newLen);
+        jsonSetIOErrorFlag(p);
         return;
       }
       JSON_DEBUG("utf8, len %d:\n", newLen);
@@ -412,6 +413,7 @@ void jsonConvertAndWriteBuffer(jsonPrinter *p, char *text, size_t len,
       if (bytesWritten < 0){
         JSONERROR("jsonConvertAndWriteBuffer() error: bytesWritten = %zd\n",
                 bytesWritten);
+        jsonSetIOErrorFlag(p);
         return;
       }
     } else {


### PR DESCRIPTION
Proposed changes:

When jsonConvertAndWriteBuffer() encounters a conversion failure (e.g., EBCDIC-to-UTF8 producing newLen = -1) or a write failure (bytesWritten < 0), it logs an error and returns — but never sets the IO error flag on the jsonPrinter. This means callers that check jsonCheckIOErrorFlag() have no way to know the printer is in a bad state, and they continue feeding data into a broken conversion pipeline.

This PR adds jsonSetIOErrorFlag(p) at both error return paths in jsonConvertAndWriteBuffer(), so that upstream code (such as dataset streaming loops) can detect the failure and stop processing early.

Type of change: Bug fix

