### PR TITLE
Add dual cert support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Zowe Common C Changelog
 
 ## `3.5.0`
+- Enhancement: `TlsSettings` now supports a `clientLabel` field. When set, `tlsSocketInit` uses this label for outbound (client) TLS connections instead of `label`, allowing a separate certificate with a client-only EKU to be used. When `clientLabel` is NULL, `label` continues to be used for both server and client connections as before. [(#590)](https://github.com/zowe/zowe-common-c/pull/590)
 - Bugfix: Set IO error flag in `jsonConvertAndWriteBuffer()` when character conversion or write operations fail, allowing callers to detect and stop processing early. (#590)
 - Bugfix: Schema validation error is not properly formatted for enumerate type. [(#562)](https://github.com/zowe/zowe-common-c/pull/562)
 - Bugfix: fix a typo in the cross-memory server's help text (#565)

--- a/c/tls.c
+++ b/c/tls.c
@@ -221,7 +221,11 @@ int tlsSocketInit(TlsEnvironment *env, TlsSocket **outSocket, int fd, bool isSer
   if (!socket) {
     return TLS_ALLOC_ERROR;
   }
-  char *label = env->settings->label;
+  /* Use clientLabel for outbound (client) connections when it is configured,
+     so that a dedicated client certificate with the appropriate EKU is used. */
+  char *label = (!isServer && env->settings->clientLabel)
+                  ? env->settings->clientLabel
+                  : env->settings->label;
   char *ciphers = env->settings->ciphers;
   char *keyshares = env->settings->keyshares;
   rc = rc || gsk_secure_socket_open(env->envHandle, &socket->socketHandle);

--- a/h/tls.h
+++ b/h/tls.h
@@ -136,6 +136,8 @@ typedef struct TlsSettings_tag {
   */
   char *maxTls;
   char *minTls;
+  // certificate label for client connections; when NULL, label is used for both server and client
+  char *clientLabel;
 } TlsSettings;
 
 typedef struct TlsEnvironment_tag {


### PR DESCRIPTION
<!-- Thank you for submitting a PR to Zowe! To help us understand, test, and give feedback on your code, please fill in the details below. -->

## Proposed changes

Add support for a dedicated client certificate label in the TLS layer, allowing `tlsSocketInit()` to use a separate certificate for outbound (client) TLS connections versus inbound (server) connections. This enables consumers to split a dual-purpose certificate into two single-purpose certificates — one with server-only EKU for the HTTP server and one with client-only EKU for outbound connections to other services.

When `clientLabel` is set on the `TlsSettings` struct, `tlsSocketInit()` uses it for client sockets (`isServer == false`). When `clientLabel` is NULL, `label` continues to be used for both, preserving full backward compatibility.

This PR is depended upon by: zowe/zss#820

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## PR Checklist

- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zowe-common-c/blob/master/CONTRIBUTING.md))
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] video or image is included if visual changes are made
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works, or describe a test method below

## Testing

**Code review verification:**

1. Inspect `h/tls.h` — confirm `clientLabel` is added at the end of the `TlsSettings` struct, avoiding any ABI compatibility issues with struct offset.
2. Inspect `c/tls.c` — confirm `tlsSocketInit()` correctly:
   - Selects `clientLabel` for client sockets when it is non-NULL
   - Falls back to `label` when `clientLabel` is NULL or for server sockets
   - Passes the selected label to `gsk_attribute_set_buffer()` with `GSK_KEYRING_LABEL`

**Integration testing:**

ZSS integration tests (see zowe/zss#820) will exercise the TLS selection logic end-to-end.

## Further comments

The `clientLabel` field is placed at the end of the `TlsSettings` struct to avoid any binary compatibility issues. Existing code that initializes the struct by position or zero-initialization will continue to set `clientLabel` to NULL, maintaining the legacy behavior (use `label` for both server and client).

The enforcement happens at a single point in `tlsSocketInit()`: a ternary expression selects which label to use based on the `isServer` flag and the presence of `clientLabel`. This ensures all consumers automatically inherit the correct behavior without modification.

**Files changed:**
- `h/tls.h` — added `clientLabel` field at end of `TlsSettings` struct
- `c/tls.c` — updated `tlsSocketInit()` to select the correct label based on `isServer` and `clientLabel`
