### PR TITLE
Improved dbcs file api handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Zowe Common C Changelog
 
 ## `3.6.0`
-- Bugfix: USS file content served via `respondWithUnixFile2()` now selects the HTTP target encoding based on the source file's CCSID rather than a compile-time OS constant. Single-byte source CCSIDs (e.g. IBM-1047) continue to produce ISO-8859-1 output; multi-byte source CCSIDs (UTF-8 / UTF-16 / EBCDIC MIX) now produce UTF-8 output, preserving characters that ISO-8859-1 cannot represent. Previously, all files on z/OS were converted to ISO-8859-1 regardless of their tagged encoding, corrupting non-Latin-1 content. 
-- Enhancement: Added `isMultiByteCCSID(int ccsid)` to `charsets.h`/`charsets.c`. Returns `TRUE` for UTF-8 (1208), UTF-16 (1200/1201/1202), and EBCDIC MIX code pages (930, 933, 935, 937, 939, 1364, 1388, 1390, 1399); `FALSE` for single-byte encodings and unknown values. Available on z/OS, Linux, and AIX. 
+- Bugfix: USS file content served via `respondWithUnixFile2()` now selects the HTTP target encoding based on the source file's CCSID rather than a compile-time OS constant. Single-byte source CCSIDs (e.g. IBM-1047) continue to produce ISO-8859-1 output; multi-byte source CCSIDs (UTF-8 / UTF-16 / EBCDIC MIX) now produce UTF-8 output, preserving characters that ISO-8859-1 cannot represent. Previously, all files on z/OS were converted to ISO-8859-1 regardless of their tagged encoding, corrupting non-Latin-1 content. [(#592)](https://github.com/zowe/zowe-common-c/issues/592)
+- Enhancement: Added `isMultiByteCCSID(int ccsid)` to `charsets.h`/`charsets.c`. Returns `TRUE` for UTF-8 (1208), UTF-16 (1200/1201/1202), and EBCDIC MIX code pages (930, 933, 935, 937, 939, 1364, 1388, 1390, 1399); `FALSE` for single-byte encodings and unknown values. Available on z/OS, Linux, and AIX. [(#592)](https://github.com/zowe/zowe-common-c/issues/592)
 
 ## `3.5.0`
 - Enhancement: YAML comment preservation tooling for the YAML-to-JSON-to-YAML round-trip pipeline. Comments are scanned separately from libyaml, attached to the JSON tree, and re-emitted with configurable alignment (none, fixed, original). Opt-in; not yet enabled in configmgr. [(#583)](https://github.com/zowe/zowe-common-c/issues/583)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Zowe Common C Changelog
 
+## `3.6.0`
+- Bugfix: USS file content served via `respondWithUnixFile2()` now selects the HTTP target encoding based on the source file's CCSID rather than a compile-time OS constant. Single-byte source CCSIDs (e.g. IBM-1047) continue to produce ISO-8859-1 output; multi-byte source CCSIDs (UTF-8 / UTF-16 / EBCDIC MIX) now produce UTF-8 output, preserving characters that ISO-8859-1 cannot represent. Previously, all files on z/OS were converted to ISO-8859-1 regardless of their tagged encoding, corrupting non-Latin-1 content. 
+- Enhancement: Added `isMultiByteCCSID(int ccsid)` to `charsets.h`/`charsets.c`. Returns `TRUE` for UTF-8 (1208), UTF-16 (1200/1201/1202), and EBCDIC MIX code pages (930, 933, 935, 937, 939, 1364, 1388, 1390, 1399); `FALSE` for single-byte encodings and unknown values. Available on z/OS, Linux, and AIX. 
+
 ## `3.5.0`
 - Enhancement: YAML comment preservation tooling for the YAML-to-JSON-to-YAML round-trip pipeline. Comments are scanned separately from libyaml, attached to the JSON tree, and re-emitted with configurable alignment (none, fixed, original). Opt-in; not yet enabled in configmgr. [(#583)](https://github.com/zowe/zowe-common-c/issues/583)
 - Enhancement: `TlsSettings` now supports a `clientLabel` field. When set, `tlsSocketInit` uses this label for outbound (client) TLS connections instead of `label`, allowing a separate certificate with a client-only EKU to be used. When `clientLabel` is NULL, `label` continues to be used for both server and client connections as before. [(#590)](https://github.com/zowe/zowe-common-c/pull/590)

--- a/c/charsets.c
+++ b/c/charsets.c
@@ -74,6 +74,32 @@ int getCharsetCode(const char *charsetName) {
   }
 }
 
+#if defined(__ZOWE_OS_ZOS) || defined(__ZOWE_OS_LINUX) || defined(__ZOWE_OS_AIX)
+
+bool isMultiByteCCSID(int ccsid) {
+  switch (ccsid) {
+    /* Unicode multi-byte encodings */
+    case CCSID_UTF_8:      /* 1208 */
+    case CCSID_UTF_16:     /* 1200 */
+    case CCSID_UTF_16_BE:  /* 1201 */
+    case CCSID_UTF_16_LE:  /* 1202 */
+    /* EBCDIC MIX (SBCS+DBCS) code pages */
+    case 930:   /* IBM930  - EBCDIC MIX Japanese */
+    case 933:   /* IBM933  - EBCDIC MIX Korean */
+    case 935:   /* IBM935  - EBCDIC MIX Simplified Chinese */
+    case 937:   /* IBM937  - EBCDIC MIX Traditional Chinese */
+    case 939:   /* IBM939  - EBCDIC MIX Japanese (Latin extension) */
+    case 1364:  /* IBM1364 - EBCDIC MIX Korean */
+    case 1388:  /* IBM1388 - EBCDIC MIX Simplified Chinese */
+    case 1390:  /* IBM1390 - EBCDIC MIX Japanese */
+    case 1399:  /* IBM1399 - EBCDIC MIX Japanese */
+      return TRUE;
+    default:
+      return FALSE;
+  }
+}
+
+#endif /* z/OS, Linux, AIX */
 
 #ifdef __ZOWE_OS_WINDOWS
 

--- a/c/httpserver.c
+++ b/c/httpserver.c
@@ -4449,29 +4449,20 @@ void respondWithUnixFile2(HttpService* service, HttpResponse* response, char* ab
       writeHeader(response);
       zowelog(NULL, LOG_COMP_HTTPSERVER, ZOWE_LOG_DEBUG, "Streaming %d for %s\n", ccsid, absolutePath);
 
-      /* TBD: This isn't really an OS dependency, but this is what I had
-         to do to get this working on Linux. The problem is that there really
-         are some of the JavaScript files encoded as UTF-8, that contain characters 
-         outside the set representable ny ISO-8859-1. I'm not sure how this is 
-         working on z/OS; I suspect that the encoding function is more permissive.
-         I think we're going to need:
-
-           * A separate lookaside file on non-z/OS platforms to provide the file
-             encoding information available on z/OS through tagging.
-           * Tagging the files encoded as UTF-8 (using whatever platform-dependent
-             mechanism).
-           * Setting the Content-type header with the appropriate encoding.
-       */
-
-      int webCodePage = 
+      /* Choose the target web encoding based on the source file's CCSID.
+         Single-byte source CCSIDs (e.g. IBM-1047, ISO-8859-1) map to
+         ISO-8859-1 (819) since every byte value round-trips cleanly.
+         Multi-byte source CCSIDs (UTF-8, UTF-16, EBCDIC MIX) map to
+         UTF-8 (1208) to preserve characters that cannot be represented
+         in a single-byte encoding. */
 #ifdef __ZOWE_OS_ZOS
-        CCSID_ISO_8859_1
+      int effectiveCCSID = (ccsid == 0) ? NATIVE_CODEPAGE : ccsid;
+      int webCodePage = isMultiByteCCSID(effectiveCCSID) ? CCSID_UTF_8 : CCSID_ISO_8859_1;
 #elif defined(__ZOWE_OS_LINUX) || defined(__ZOWE_OS_AIX) || defined(__ZOWE_OS_WINDOWS)
-        CCSID_UTF_8
+      int webCodePage = CCSID_UTF_8;
 #else
 #error Unknown OS
 #endif
-        ;
     char *forceEnabled = getQueryParam(response->request, "force");
     if (ccsid == 0 && !strcmp(forceEnabled, "enable")) {
         char *sourceEncoding = getQueryParam(response->request, "source");

--- a/h/charsets.h
+++ b/h/charsets.h
@@ -50,6 +50,13 @@
 #define CCSID_UNTAGGED        (short)0x0000
 #define CCSID_BINARY          (short)0xFFFF
 
+/**
+ * Returns TRUE if the given CCSID uses a multi-byte encoding (e.g. UTF-8,
+ * UTF-16, or EBCDIC MIX), and FALSE if it is single-byte.
+ * Returns FALSE for unrecognised or special values (0, -1, 0xFFFF).
+ */
+bool isMultiByteCCSID(int ccsid);
+
 #elif defined(__ZOWE_OS_WINDOWS)
 #include <Windows.h>
 /* WINDOWS CCSID's that are not common 


### PR DESCRIPTION
<!-- Thank you for submitting a PR to Zowe! To help us understand, test, and give feedback on your code, please fill in the details below. -->

## Proposed changes

Fix the default target encoding used when serving USS file content via `respondWithUnixFile2()` in `httpserver.c`. Previously, on z/OS the target was hardcoded to ISO-8859-1 (819) for all text-type files regardless of their tagged CCSID. This corrupted content from files tagged as UTF-8 (1208), UTF-16 (1200/1201/1202), or any EBCDIC MIX code page (930, 933, 935, 937, 939, 1364, 1388, 1390, 1399).

The fix introduces `isMultiByteCCSID(int ccsid)` in `charsets.c`/`charsets.h` and uses it at runtime to select the target:
- Single-byte source (e.g. IBM-1047, ISO-8859-1) → target remains ISO-8859-1 (819), no behaviour change.
- Multi-byte source (UTF-8, UTF-16, EBCDIC MIX) → target is now UTF-8 (1208).

The OS-based `#ifdef` TBD comment is replaced with this runtime selection on z/OS. Non-z/OS platforms (Linux, AIX, Windows) continue to use UTF-8 as before.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## PR Checklist

- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zss/blob/v2.x/master/CONTRIBUTING.md))
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works, or describe a test method below

## Testing

**Manual test — UTF-8 tagged file:**
1. On z/OS, create a USS file containing UTF-8 encoded text (e.g. a file with Japanese or Chinese characters).
2. Tag it: `chtag -tc 1208 <file>`
3. GET `/unixFileContents/<path>` with no query parameters.
4. Verify the response bytes are valid UTF-8 and the non-Latin-1 characters are present and correct.
5. Before this fix, non-Latin-1 bytes would be corrupted or replaced.

**Regression — IBM-1047 tagged file:**
1. Create or use an existing USS file tagged CCSID 1047.
2. GET `/unixFileContents/<path>`.
3. Verify the response is the same ISO-8859-1 content as before this change.

**Regression — untagged file:**
1. Create or use an untagged USS file (`chtag -b <file>` to remove tag, or leave untagged).
2. GET `/unixFileContents/<path>`.
3. Verify the response is NATIVE_CODEPAGE (1047) → ISO-8859-1 converted output, same as before.

**Unit test — `isMultiByteCCSID()`:**

| Input | Expected |
|---|---|
| 1208 (UTF-8) | TRUE |
| 1200 (UTF-16) | TRUE |
| 1201 (UTF-16BE) | TRUE |
| 1202 (UTF-16LE) | TRUE |
| 930 (EBCDIC MIX Japanese) | TRUE |
| 933, 935, 937, 939 | TRUE |
| 1364, 1388, 1390, 1399 | TRUE |
| 1047 (IBM-1047) | FALSE |
| 819 (ISO-8859-1) | FALSE |
| 37 (IBM-037) | FALSE |
| 0 (untagged) | FALSE |
| -1 / 65535 (binary) | FALSE |

## Further comments

The original code contained an explicit TBD comment acknowledging that the OS-based selection "isn't really an OS dependency". This PR resolves that TBD by selecting the target encoding at runtime based on `isMultiByteCCSID()`.

The `isMultiByteCCSID()` function is intentionally conservative: it covers the Unicode encodings and the EBCDIC MIX (SBCS+DBCS) code pages that are realistic as USS file tags. Pure DBCS-only pages (300, 834, 835, 837) are excluded because they require SO/SI byte handling and are unlikely to appear as file-level CCSID tags in practice. The set can be extended in a follow-up if needed.
