### PR TITLE
Use "%.*s" version of snprintf to stop overreading in 'zosResolveSymbol()'.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Zowe Common C Changelog
 
+## `2.18.5`
+- Bugfix: Use "%.*s" version of snprintf to stop overreading in 'zosResolveSymbol()' which causes abend.([#595](https://github.com/zowe/zowe-common-c/pull/595))
+
 ## `2.18.3`
 - Bugfix: Fix a leak in the safeFree64Internal by adding free() and protect against rexx variable changes in addConfig ([#556](https://github.com/zowe/zowe-common-c/pull/556))
 

--- a/c/qjszos.c
+++ b/c/qjszos.c
@@ -84,6 +84,14 @@ static JSValue zosResolveSymbol(JSContext *ctx, JSValueConst this_val,
   JS_FreeCString(ctx,symbol);
 
 #ifdef __ZOWE_OS_ZOS
+  if (result == NULL) {
+    if (rc != 0) {
+      return JS_ThrowReferenceError(ctx,
+                                    "resolveSymbol failed for '%s' (rc=%d, rsn=%d)",
+                                    symbolNative, rc, rsn);
+    }
+    return JS_NULL;
+  }
   return newJSStringFromNative(ctx, result, strlen(result));
 #else
   return JS_NewString(ctx, NULL);

--- a/c/zos.c
+++ b/c/zos.c
@@ -405,11 +405,11 @@ char *resolveSymbolBySyscall(const char *inputSymbol, int *rc, int *rsn) {
       result = safeMalloc(outputLen+1, "output");
       if (result == NULL) {
         *rc = RESOLVESYMBOL_RETURN_ALLOC_FAILED;
-    } else {
-      snprintf(result, outputLen+1, "%.*s", outputLen, below2G->output);
-    }
-    FREE_STRUCT31(STRUCT31_NAME(below2G));
-    return result;
+      } else {
+        snprintf(result, outputLen+1, "%.*s", outputLen, below2G->output);
+      }
+      FREE_STRUCT31(STRUCT31_NAME(below2G));
+      return result;
     }
 
 }

--- a/c/zos.c
+++ b/c/zos.c
@@ -396,23 +396,21 @@ char *resolveSymbolBySyscall(const char *inputSymbol, int *rc, int *rsn) {
     }
 
 //    printf("input '%s', output '%s'\n", below2G->input, below2G->output);
+    // We are not checking for return code here and therefore cannot differentiate between a blank and not found.
+    // For more info: https://www.ibm.com/docs/en/zos/2.2.0?topic=hsp-asasymbm-asasymbf-substitute-text-symbols
+    // printf("ASASYMBF return code %x\n", below2G->returnCode);
     int outputLen = strlen(below2G->output);
-    if (outputLen != 0){
-      char *result = safeMalloc(outputLen+1, "output");
+    char *result = NULL;
+    if (outputLen > 0) {
+      result = safeMalloc(outputLen+1, "output");
       if (result == NULL) {
         *rc = RESOLVESYMBOL_RETURN_ALLOC_FAILED;
-        FREE_STRUCT31(STRUCT31_NAME(below2G));
-        return NULL;
-      }
-      memcpy(result, below2G->output, outputLen);
-      result[outputLen] = '\0';
-      FREE_STRUCT31(STRUCT31_NAME(below2G));
-      return result;
-    } else{
-      FREE_STRUCT31(STRUCT31_NAME(below2G));
-      return NULL;
+    } else {
+      snprintf(result, outputLen+1, "%.*s", outputLen, below2G->output);
     }
-
+    FREE_STRUCT31(STRUCT31_NAME(below2G));
+    return result;
+    }
 
 }
 
@@ -459,75 +457,35 @@ char *resolveSymbol(const char *inputSymbol, int *rc, int *rsn) {
 
 
   SymbTableEntry *entry = firstEntry;
+  for (int i = 0; i < entryCount; i++, entry++) {
+    char *currentSymbol;
+    const char *subtextSrc;
+    int subtextLen;
 
-  for (int i = 0; i < entryCount; i++) {
     if (useEntryOffsets) {
-      //printf("firstEntry = 0x%p, symbol offset = 0x%x, length=%d, subtext offset = 0x%x, length=%d\n", firstEntry, entry->symbolOffset, entry->symbolLength, entry->subtextOffset, entry->subtextLength);
-      
-      char *currentSymbol = (char*)firstEntry + entry->symbolOffset;
-//      printf("Symbol=%.*s\n", entry->symbolLength, currentSymbol);
-
-      // extra '.' at end to account for
-      if ((inputLen+1 == entry->symbolLength) && (memcmp(currentSymbol, inputSymbol, inputLen) == 0) && currentSymbol[inputLen]=='.') {
-        if (entry->subtextLength == 0) {
-          // symbol is defined but has no value - return empty string
-          char *result = (char*) safeMalloc(1, "subtext");
-          if (result == NULL) {
-            *rc = RESOLVESYMBOL_RETURN_ALLOC_FAILED;
-            return NULL;
-          }
-          result[0] = '\0';
-          return result;
-        }
-        char *subtextSrc = (char*)firstEntry + entry->subtextOffset;
-        char *result = (char*) safeMalloc(entry->subtextLength+1, "subtext");
-        if (result == NULL) {
-          *rc = RESOLVESYMBOL_RETURN_ALLOC_FAILED;
-          return NULL;
-        }
-        memcpy(result, subtextSrc, entry->subtextLength);
-        result[entry->subtextLength] = '\0';
-        return result;
-      }
-
-      entry = entry+1;
-    } else{
-      char *currentSymbol = entry->symbolPtr;
-
-      if (currentSymbol == NULL) {
-        entry = entry+1;
-        continue;
-      }
-
-      printf("Symbol=%.*s\n", entry->symbolLength, currentSymbol);
-
-
-      // extra '.' at end to account for
-      if ((inputLen+1 == entry->symbolLength) && (memcmp(currentSymbol, inputSymbol, inputLen) == 0) && currentSymbol[inputLen]=='.') {
-       if (entry->subtextPtr == NULL || entry->subtextLength == 0) {
-         // symbol is defined but has no value - return empty string
-         char *result = (char*) safeMalloc(1, "subtext");
-         if (result == NULL) {
-           *rc = RESOLVESYMBOL_RETURN_ALLOC_FAILED;
-           return NULL;
-         }
-         result[0] = '\0';
-         return result;
-       }
-        char *result = (char*) safeMalloc(entry->subtextLength+1, "subtext");
-        if (result == NULL) {
-          *rc = RESOLVESYMBOL_RETURN_ALLOC_FAILED;
-          return NULL;
-        }
-        memcpy(result, entry->subtextPtr, entry->subtextLength);
-        result[entry->subtextLength] = '\0';
-        return result;
-      }
-      entry = entry+1;
+      currentSymbol = (char*)firstEntry + entry->symbolOffset;
+      subtextSrc    = (char*)firstEntry + entry->subtextOffset;
+      subtextLen    = entry->subtextLength;
+    } else {
+      if (entry->symbolPtr == NULL) continue;
+      currentSymbol = entry->symbolPtr;
+      subtextSrc    = entry->subtextPtr ? entry->subtextPtr : "";
+      subtextLen    = entry->subtextPtr ? entry->subtextLength : 0;
     }
- 
-     //printf("next entry at 0x%p\n", entry);
 
+    // extra '.' at end to account for
+    if ((inputLen+1 == entry->symbolLength) &&
+        (memcmp(currentSymbol, inputSymbol, inputLen) == 0) &&
+        currentSymbol[inputLen] == '.') {
+      char *result = (char*) safeMalloc(subtextLen+1, "subtext");
+      if (result == NULL) {
+        *rc = RESOLVESYMBOL_RETURN_ALLOC_FAILED;
+        return NULL;
+      }
+      // NOTE: For a blank subtext (offset mode: subtextLength == 0, pointer mode: subtextPtr == NULL), an empty string "" is returned.
+      snprintf(result, subtextLen+1, "%.*s", subtextLen, subtextSrc);
+      return result;
+    }
   }
 
   return resolveSymbolBySyscall(inputSymbol, rc, rsn);

--- a/c/zos.c
+++ b/c/zos.c
@@ -412,6 +412,9 @@ char *resolveSymbolBySyscall(const char *inputSymbol, int *rc, int *rsn) {
       return result;
     }
 
+    FREE_STRUCT31(STRUCT31_NAME(below2G));
+    return NULL;
+
 }
 
 

--- a/c/zos.c
+++ b/c/zos.c
@@ -398,8 +398,14 @@ char *resolveSymbolBySyscall(const char *inputSymbol, int *rc, int *rsn) {
 //    printf("input '%s', output '%s'\n", below2G->input, below2G->output);
     int outputLen = strlen(below2G->output);
     if (outputLen != 0){
-      char *result = safeMalloc(sizeof(below2G->output), "output");
-      snprintf(result, outputLen+1, "%s", below2G->output);
+      char *result = safeMalloc(outputLen+1, "output");
+      if (result == NULL) {
+        *rc = RESOLVESYMBOL_RETURN_ALLOC_FAILED;
+        FREE_STRUCT31(STRUCT31_NAME(below2G));
+        return NULL;
+      }
+      memcpy(result, below2G->output, outputLen);
+      result[outputLen] = '\0';
       FREE_STRUCT31(STRUCT31_NAME(below2G));
       return result;
     } else{
@@ -462,9 +468,25 @@ char *resolveSymbol(const char *inputSymbol, int *rc, int *rsn) {
 //      printf("Symbol=%.*s\n", entry->symbolLength, currentSymbol);
 
       // extra '.' at end to account for
-      if ((inputLen+1 == entry->symbolLength) && (memcmp(currentSymbol, inputSymbol, inputLen) == 0) && currentSymbol[inputLen]=='.'){
+      if ((inputLen+1 == entry->symbolLength) && (memcmp(currentSymbol, inputSymbol, inputLen) == 0) && currentSymbol[inputLen]=='.') {
+        if (entry->subtextLength == 0) {
+          // symbol is defined but has no value - return empty string
+          char *result = (char*) safeMalloc(1, "subtext");
+          if (result == NULL) {
+            *rc = RESOLVESYMBOL_RETURN_ALLOC_FAILED;
+            return NULL;
+          }
+          result[0] = '\0';
+          return result;
+        }
+        char *subtextSrc = (char*)firstEntry + entry->subtextOffset;
         char *result = (char*) safeMalloc(entry->subtextLength+1, "subtext");
-        snprintf(result, entry->subtextLength+1, "%s", (char*)firstEntry + entry->subtextOffset);
+        if (result == NULL) {
+          *rc = RESOLVESYMBOL_RETURN_ALLOC_FAILED;
+          return NULL;
+        }
+        memcpy(result, subtextSrc, entry->subtextLength);
+        result[entry->subtextLength] = '\0';
         return result;
       }
 
@@ -472,15 +494,36 @@ char *resolveSymbol(const char *inputSymbol, int *rc, int *rsn) {
     } else{
       char *currentSymbol = entry->symbolPtr;
 
+      if (currentSymbol == NULL) {
+        entry = entry+1;
+        continue;
+      }
+
       printf("Symbol=%.*s\n", entry->symbolLength, currentSymbol);
 
 
       // extra '.' at end to account for
-      if ((inputLen+1 == entry->symbolLength) && (memcmp(currentSymbol, inputSymbol, inputLen) == 0) && currentSymbol[inputLen]=='.'){
+      if ((inputLen+1 == entry->symbolLength) && (memcmp(currentSymbol, inputSymbol, inputLen) == 0) && currentSymbol[inputLen]=='.') {
+       if (entry->subtextPtr == NULL || entry->subtextLength == 0) {
+         // symbol is defined but has no value - return empty string
+         char *result = (char*) safeMalloc(1, "subtext");
+         if (result == NULL) {
+           *rc = RESOLVESYMBOL_RETURN_ALLOC_FAILED;
+           return NULL;
+         }
+         result[0] = '\0';
+         return result;
+       }
         char *result = (char*) safeMalloc(entry->subtextLength+1, "subtext");
-        snprintf(result, entry->subtextLength+1, "%s", entry->subtextPtr);
+        if (result == NULL) {
+          *rc = RESOLVESYMBOL_RETURN_ALLOC_FAILED;
+          return NULL;
+        }
+        memcpy(result, entry->subtextPtr, entry->subtextLength);
+        result[entry->subtextLength] = '\0';
         return result;
       }
+      entry = entry+1;
     }
  
      //printf("next entry at 0x%p\n", entry);

--- a/h/zos.h
+++ b/h/zos.h
@@ -471,6 +471,7 @@ typedef struct SymbTable1_tag{
 #define SYMBT_MAXSTATIC_TABLE_SIZE 32512
 
 #define RESOLVESYMBOL_RETURN_BAD_INPUT 1
+#define RESOLVESYMBOL_RETURN_ALLOC_FAILED 2
 
 typedef struct ecvt_tag{
   char  eyecatcher[4];


### PR DESCRIPTION
## Description
Resolving system symbols causes abend sometimes.

Root cause
----------
The original resolveSymbol() code copied resolved subtext with snprintf(..., "%s", ...).
In offset mode, symbol values are length-delimited in a packed symbol area and are not guaranteed to be null-terminated.
Using "%s" could therefore read past the intended value into adjacent packed entries and eventually into invalid storage, causing an 0C4 abend.

A second issue existed in the QuickJS wrapper: if resolveSymbol() returned NULL, qjszos.c would still call strlen(result), which could also crash.


## Proposed changes
1. resolveSymbol() now copies using "%.*s" which limits the number of bytes read to subtextLength.
2. If a symbol is defined but has no value:
   - offset mode: subtextLength == 0 -> return an allocated empty string
   - pointer mode: subtextPtr == NULL or subtextLength == 0 -> return an allocated empty string
3. Allocation failures now set RESOLVESYMBOL_RETURN_ALLOC_FAILED.
4. zosResolveSymbol() in c/qjszos.c now checks for NULL returns:
   - if rc != 0, it throws a JS exception using JS_ThrowReferenceError
   - otherwise it returns JS_NULL
   - this avoids assuming JS_ThrowInternalError is available in the embedded QuickJS version
5. resolveSymbolBySyscall() was updated for consistency **BUT still needs changes as the current code cannot differentiate between a blank and symbol not found and returns NULL in these cases.**

### Description of %.*s in snprintf() 
Syntax
`snprintf(dest, destSize, "%.*s", precision, src);`
How it works
%.*s is a width-bounded string format specifier. The `.*` means the precision is supplied as a runtime argument (the int before src).
Argument: Role
dest: Destination buffer to write into
destSize: Maximum bytes to write including null terminator
precision: Maximum bytes to read from src
src: Source pointer

This PR addresses Issue: [*Link to Github issue within https://github.com/zowe/zowe-common-c/issues* if any]

This PR depends upon the following PRs:

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Change in a documentation
- [x] Refactor the code 
- [ ] Chore, repository cleanup, updates the dependencies.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zss/blob/v2.x/master/CONTRIBUTING.md))
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [ ] video or image is included if visual changes are made
- [x] Relevant update to CHANGELOG.md
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works, or describe a test method below

## Testing
Using a lot of system symbol in your yaml and recycle your Zowe.
Before:
You will get a OC4 ABEND

After:
You will not see the abend.

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, or if there are follow-up tasks and TODOs etc... -->
