### PR TITLE
Strengthen ICSF encryption

### DIFF
--- a/c/httpserver.c
+++ b/c/httpserver.c
@@ -1410,9 +1410,24 @@ static int encodeSessionToken(ShortLivedHeap *slh,
                               const HttpServerConfig *config,
                               const char *tokenText,
                               unsigned int tokenTextLength,
-                              char **result) {
+                              char **result,
+                              unsigned int *resultLength) {
 
-  unsigned int encodedTokenTextLength = tokenTextLength;
+  unsigned int encodedTokenTextLength;
+#ifdef __ZOWE_OS_ZOS
+
+  if (icsfEncipherOutputLength(tokenTextLength, &encodedTokenTextLength) != 0) {
+    zowelog(NULL, LOG_COMP_HTTPSERVER, ZOWE_LOG_DEBUG,
+      "Error: incorrect decoded session token length (size=%u)\n", tokenTextLength);
+    return -1;
+  }
+
+#elif defined(__ZOWE_OS_WINDOWS)
+
+    encodedTokenTextLength = tokenTextLength;
+
+#endif
+
   char *encodedTokenText = SLHAlloc(slh, encodedTokenTextLength);
   if (encodedTokenText == NULL) {
     zowelog(NULL, LOG_COMP_HTTPSERVER, ZOWE_LOG_DEBUG,
@@ -1421,9 +1436,7 @@ static int encodeSessionToken(ShortLivedHeap *slh,
     return -1;
   }
 
-
 #ifdef __ZOWE_OS_ZOS
-
 
   int icsfRSN = 0;
   int icsfRC = icsfEncipher(config->sessionTokenKey,
@@ -1440,21 +1453,20 @@ static int encodeSessionToken(ShortLivedHeap *slh,
     return -1;
   }
 
-  *result = encodedTokenText;
-  return 0;
-
 #elif defined(__ZOWE_OS_WINDOWS)
 
   printf("*WARNING* - Trivial Cipher in use\n");
   trivialEncipher(encodedTokenText,tokenText,tokenTextLength);
-  *result = encodedTokenText;
-  return 0;
   
 #else
 
 #error Session token encoding has been implemented for z/OS only
 
 #endif /* __ZOWE_OS_ZOS */
+
+  *result = encodedTokenText;
+  *resultLength = encodedTokenTextLength;
+  return 0;
 
 }
 
@@ -1463,13 +1475,28 @@ static int decodeSessionToken(ShortLivedHeap *slh,
                               const char *encodedTokenText,
                               unsigned int encodedTokenTextLength,
                               char **result) {
-  unsigned int tokenTextLength = encodedTokenTextLength;
+  unsigned int tokenTextLength;
+
+#ifdef __ZOWE_OS_ZOS
+
+  if (icsfDecipherOutputLength(encodedTokenTextLength, &tokenTextLength) != 0) {
+    zowelog(NULL, LOG_COMP_HTTPSERVER, ZOWE_LOG_DEBUG,
+      "Error: incorrect decoded session token length (size=%u)\n", encodedTokenTextLength);
+    return -1;
+  }
+
+#elif defined(__ZOWE_OS_WINDOWS)
+
+  tokenTextLength = encodedTokenTextLength;
+
+#endif
+
   unsigned int paddingLength = 4;
   char *tokenText = SLHAlloc(slh, tokenTextLength+paddingLength);
   if (tokenText == NULL) {
     zowelog(NULL, LOG_COMP_HTTPSERVER, ZOWE_LOG_DEBUG,
     		    "Error: decoded session token buffer not allocated "
-            "(size=%u, SLH=%p)\n", encodedTokenTextLength, slh);
+            "(size=%u, SLH=%p)\n", tokenTextLength, slh);
     return -1;
   }
 
@@ -1492,16 +1519,11 @@ static int decodeSessionToken(ShortLivedHeap *slh,
 
   // always null terminate because consumer might be expecting null terminate on other side
   tokenText[tokenTextLength]=0;
-  *result = tokenText;
-  return 0;
 
 #elif defined(__ZOWE_OS_WINDOWS)
 
   printf("*WARNING* - Trivial Cipher in use\n");
   trivialDecipher(tokenText,encodedTokenText,tokenTextLength);
-  *result = tokenText;
-  return 0;
-
 
 #else
 
@@ -1509,6 +1531,8 @@ static int decodeSessionToken(ShortLivedHeap *slh,
 
 #endif /* __ZOWE_OS_ZOS */
 
+  *result = tokenText;
+  return 0;
 }
 
 static
@@ -3120,16 +3144,18 @@ static char *generateSessionTokenKeyValue(HttpService *service, HttpRequest *req
   int tokenPlaintextLength = sprintf(tokenPlaintextBuffer,"%s:%llx:%llx",username,getFineGrainedTime(),service->serverInstanceUID);
 
   char *tokenCiphertext = NULL;
+  unsigned int tokenCiphertextLength = 0;
   int encodeRC = encodeSessionToken(slh, server->config,
                                     tokenPlaintextBuffer,
                                     tokenPlaintextLength,
-                                    &tokenCiphertext);
+                                    &tokenCiphertext,
+                                    &tokenCiphertextLength);
   if (encodeRC != 0) {
     return NULL;
   }
 
   int encodedLength = 0;
-  char *base64Output = encodeBase64(slh,tokenCiphertext,tokenPlaintextLength,&encodedLength,TRUE);
+  char *base64Output = encodeBase64(slh,tokenCiphertext,tokenCiphertextLength,&encodedLength,TRUE);
 
   char *cookieName = getSessionTokenCookieName(service);
 

--- a/c/icsf.c
+++ b/c/icsf.c
@@ -24,6 +24,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdarg.h>  
+#include <limits.h>
 #endif
 
 #include "copyright.h"
@@ -384,6 +385,26 @@ int icsfDigestFully(char *digestType, char *s, int len){
   
 }
 
+#define ICV_LENGTH 12
+#define GCM_LENGTH 16
+typedef struct ICSFEncodingBlockHeader_tag {
+  char icv[ICV_LENGTH];
+  char gcm[GCM_LENGTH];
+} ICSFEncodingBlockHeader;
+
+typedef struct ICSFEncodingBlock_tag {
+  ICSFEncodingBlockHeader header;
+  char payload[1];
+} ICSFEncodingBlock;
+
+int icsfEncipherOutputLength(unsigned int inputLength, unsigned int *outputLength) {
+    if (UINT_MAX - inputLength < sizeof(ICSFEncodingBlockHeader)) {
+        return 1;
+    }
+    *outputLength = inputLength + sizeof(ICSFEncodingBlockHeader);
+    return 0;
+}
+
 int icsfEncipher(const void *key, unsigned int keyLength,
                  const char *text, unsigned int textLength,
                  char *resultBuffer, unsigned int resultBufferLength,
@@ -397,28 +418,26 @@ int icsfEncipher(const void *key, unsigned int keyLength,
 #define ICSF_SYN_ENC_RULE_COUNT 4
   char ruleArray[ICSF_SYN_ENC_RULE_COUNT][8] = {
       {"AES     "},
-      {"CFB     "},
+      {"GCM     "},
       {"KEY-CLR "},
-      {"INITIAL "},
+      {"ONLY    "},
   };
   unsigned int ruleArrayCount = ICSF_SYN_ENC_RULE_COUNT;
 
   unsigned int keyIdentifierLength = keyLength;
   const void *keyIdentifier = key;
 
-  unsigned int keyParmsLength = 0;
-  void *keyParms = NULL;
+  unsigned int keyParmsLength = GCM_LENGTH;
+  char keyParms[GCM_LENGTH] = {0};
 
   unsigned int blockLength = 16; /* AES */
 
-  /* ICV doesn't need to be secret */
-  char icv[16] = {
-      0xEB, 0xE3, 0xD0, 0x08,
-      0x00, 0x24, 0xB9, 0x04,
-      0x00, 0xFD, 0xE3, 0xD0,
-      0xD0, 0x88, 0x00, 0x04
-  };
-  unsigned int icvLength = sizeof(icv);
+  unsigned int icvLength = ICV_LENGTH;
+  char icv[ICV_LENGTH] = {0};
+  if (0 != (rc = icsfGenerateRandomNumber(icv, icvLength, &rsn))) {
+    *reasonCode = rsn;
+    return rc;
+  }
 
   char chainData[32] = {0};
   unsigned int chainDataLength = sizeof(chainData);
@@ -426,8 +445,8 @@ int icsfEncipher(const void *key, unsigned int keyLength,
   unsigned int clearTextLength = textLength;
   const char *clearText = text;
 
-  unsigned int cipherTextLength = resultBufferLength;
-  char *cipherText = resultBuffer;
+  unsigned int cipherTextLength = resultBufferLength - sizeof(ICSFEncodingBlockHeader);
+  char *cipherText = ((ICSFEncodingBlock*)resultBuffer)->payload;
 
   unsigned int optionalDataLength = 0;
   void *optionalData = NULL;
@@ -471,10 +490,22 @@ int icsfEncipher(const void *key, unsigned int keyLength,
       optionalData
   );
 
+  if (rc == 0 || rc == 4) {
+    memcpy(((ICSFEncodingBlock*)resultBuffer)->header.gcm, keyParms, GCM_LENGTH);
+    memcpy(((ICSFEncodingBlock*)resultBuffer)->header.icv, icv, ICV_LENGTH);
+  }
+
   *reasonCode = rsn;
   return rc;
 }
 
+int icsfDecipherOutputLength(unsigned int inputLength, unsigned int *outputLength) {
+    if (inputLength <= sizeof(ICSFEncodingBlockHeader)) {
+        return 1;
+    }
+    *outputLength = inputLength - sizeof(ICSFEncodingBlockHeader);
+    return 0;
+}
 
 int icsfDecipher(const void *key, unsigned int keyLength,
                  const char *text, unsigned int textLength,
@@ -489,37 +520,35 @@ int icsfDecipher(const void *key, unsigned int keyLength,
 #define ICSF_SYN_DEC_RULE_COUNT 4
   char ruleArray[ICSF_SYN_DEC_RULE_COUNT][8] = {
       {"AES     "},
-      {"CFB     "},
+      {"GCM     "},
       {"KEY-CLR "},
-      {"INITIAL "},
+      {"ONLY    "},
   };
   unsigned int ruleArrayCount = ICSF_SYN_DEC_RULE_COUNT;
 
   unsigned int keyIdentifierLength = keyLength;
   const void *keyIdentifier = key;
 
-  unsigned int keyParmsLength = 0;
-  void *keyParms = NULL;
+  unsigned int keyParmsLength = GCM_LENGTH;
+  char gcmParms[GCM_LENGTH];
+  memcpy(gcmParms, ((ICSFEncodingBlock*)text)->header.gcm, GCM_LENGTH);
+  void *keyParms = gcmParms;
 
   unsigned int blockLength = 16; /* AES */
 
   /* ICV doesn't need to be secret */
-  char icv[16] = {
-      0xEB, 0xE3, 0xD0, 0x08,
-      0x00, 0x24, 0xB9, 0x04,
-      0x00, 0xFD, 0xE3, 0xD0,
-      0xD0, 0x88, 0x00, 0x04
-  };
-  unsigned int icvLength = sizeof(icv);
+  unsigned int icvLength = ICV_LENGTH;
+  char icv[ICV_LENGTH];
+  memcpy(icv, ((ICSFEncodingBlock*)text)->header.icv, ICV_LENGTH);
 
   char chainData[32] = {0};
   unsigned int chainDataLength = sizeof(chainData);
 
-  unsigned int cipherTextLength = textLength;
-  const char *cipherText = text;
+  unsigned int cipherTextLength = textLength - sizeof(ICSFEncodingBlockHeader);
+  const char *cipherText = ((ICSFEncodingBlock*)text)->payload;
 
   unsigned int clearTextLength = resultBufferLength;
-  const char *clearText = resultBuffer;
+  char *clearText = resultBuffer;
 
   unsigned int optionalDataLength = 0;
   void *optionalData = NULL;

--- a/h/icsf.h
+++ b/h/icsf.h
@@ -47,10 +47,12 @@ int icsfDigestInit(ICSFDigest *digest, int type);
 int icsfDigestUpdate(ICSFDigest *digest, char *data, int len);
 int icsfDigestFinish(ICSFDigest *digest, char *hash);
 
+int icsfEncipherOutputLength(unsigned int inputLength, unsigned int *outputLength);
 int icsfEncipher(const void *key, unsigned int keyLength,
                  const char *text, unsigned int textLength,
                  char *resultBuffer, unsigned int resultBufferLength,
                  int *reasonCode);
+int icsfDecipherOutputLength(unsigned int inputLength, unsigned int *outputLength);
 int icsfDecipher(const void *key, unsigned int keyLength,
                  const char *text, unsigned int textLength,
                  char *resultBuffer, unsigned int resultBufferLength,


### PR DESCRIPTION
## What's the problem?

Our session token encryption logic might have a cryptographic flaw.

Currently, the code uses AES-CFB mode via z/OS ICSF (CSNBSYE / CSNBSYD), but it relies on a static Initialization Vector (ICV) and lacks integrity verification. Because the encryption stream is predictable and unauthenticated, it makes our session tokens malleable. An attacker could potentially perform bit-flipping attacks to forge tokens or impersonate other users without knowing the key.

## How is it fixed?

I have refactored the encryption and decryption logic:

Switched to AES-GCM: Changed the ICSF processing rule from CFB to GCM. I also updated the rule keyword from INITIAL to ONLY to comply with IBM ICSF requirements for GCM mode.

Dynamic ICV: I use `icsfGenerateRandomNumber` to generate a unique 12-byte IV for every single encryption call.

Integrity Protection: We now leverage the 16-byte GCM authentication tag (keyParms in ICSF) to ensure data integrity. The decryption service will automatically validate this tag and fail if the ciphertext has been modified.

Token Structure Adjustment: Introduced a structured wire format (ICSFEncodingBlock) that packs the 12-byte random IV, the 16-byte GCM tag, and the actual ciphertext payload together.

## Test

Not done yet. This is a draft PR for now. The purpose is to better illustrate the idea by the code-diff view.

## References

https://www.ibm.com/docs/en/zos/2.5.0?topic=data-symmetric-key-encipher-csnbsye-csnbsye1-csnesye-csnesye1