### PR TITLE
Remove redundant memcpy

### DIFF
--- a/c/utils.c
+++ b/c/utils.c
@@ -1714,7 +1714,6 @@ char *stringListPrint(StringList *list, int start, int max, char *separator, cha
   }
   /* printf("string list formats to %d chars \n",pos); */
   out[pos] = 0;
-  printf("stringListPrint out '%s'\n", out);  // Delete me
   return out;
 }
 

--- a/c/utils.c
+++ b/c/utils.c
@@ -1691,7 +1691,6 @@ char *stringListPrint(StringList *list, int start, int max, char *separator, cha
   /* printf("stringListPrint totalSize = %d listCount=%d buffer size %d, max=%d, slh=0x%x\n",
      list->totalSize,list->count,allocSize,max,list->slh); */
   out = SLHAlloc(list->slh, allocSize);
-  memcpy(out,"                        ",20);
   for (i=0; (i<start && elt); i++){
     elt = elt->next;
   }
@@ -1715,6 +1714,7 @@ char *stringListPrint(StringList *list, int start, int max, char *separator, cha
   }
   /* printf("string list formats to %d chars \n",pos); */
   out[pos] = 0;
+  printf("stringListPrint out '%s'\n", out);  // Delete me
   return out;
 }
 


### PR DESCRIPTION
Running with debug message and using Editor:

```
stringListPrint out 'u/martin'
stringListPrint out 'u/martin/zowe'
stringListPrint out 'u/martin/zowe/runtime'
stringListPrint out 'u/martin/zowe/runtime/350'
stringListPrint out 'u/martin/zowe/runtime/350/components'
stringListPrint out 'u/martin/zowe/runtime/350/components'
stringListPrint out 'u/martin/zowe/runtime/350/fingerprint'
stringListPrint out 'u/martin/zowe/runtime/350/fingerprint/RefRuntimeHash-3.5.0.txt'
stringListPrint out 'name'
stringListPrint out 'MARTIN.ZOWE'
stringListPrint out 'MARTIN.ZOWE.JCL(IEFBR14)'
```