### PR TITLE
JWT: use timing safe memory compare

### DIFF
--- a/c/utils.c
+++ b/c/utils.c
@@ -2254,13 +2254,6 @@ int timesafe_memcmp(const void *a, const void *b, size_t n) {
 
   for (size_t i = 0; i < n; i++) {
     result |= pointer_a[i] ^ pointer_b[i];
-
-    __asm volatile(
-        ASM_PREFIX
-        ""
-        : "+r"(result)
-    );
-
   }
 
   return result;

--- a/c/utils.c
+++ b/c/utils.c
@@ -2247,20 +2247,20 @@ bool isPassPhrase(const char *password) {
 
 /* timingsafe_memcmp compares two memory regions for equality in a way that is safe against timing attacks. */
 /* returns 0 if the regions are equal, non-zero otherwise */
-int timingsafe_memcmp(const void *a, const void *b, size_t n) {
+int timesafe_memcmp(const void *a, const void *b, size_t n) {
   const unsigned char *pointer_a = (const unsigned char *)a;
   const unsigned char *pointer_b = (const unsigned char *)b;
   volatile unsigned char result = 0;
 
   for (size_t i = 0; i < n; i++) {
     result |= pointer_a[i] ^ pointer_b[i];
-	/*
+
     __asm volatile(
         ASM_PREFIX
         ""
         : "+r"(result)
     );
-	*/
+
   }
 
   return result;

--- a/c/utils.c
+++ b/c/utils.c
@@ -2254,11 +2254,13 @@ int timingsafe_memcmp(const void *a, const void *b, size_t n) {
 
   for (size_t i = 0; i < n; i++) {
     result |= pointer_a[i] ^ pointer_b[i];
+	/*
     __asm volatile(
         ASM_PREFIX
         ""
         : "+r"(result)
     );
+	*/
   }
 
   return result;

--- a/c/utils.c
+++ b/c/utils.c
@@ -2253,7 +2253,9 @@ int timesafe_memcmp(const void *a, const void *b, size_t n) {
   volatile unsigned char result = 0;
 
   for (size_t i = 0; i < n; i++) {
-    result |= pointer_a[i] ^ pointer_b[i];
+    unsigned char diff = pointer_a[i] ^ pointer_b[i];
+    __asm volatile("" : "+r"(diff));
+    result |= diff;
   }
 
   return result;

--- a/c/utils.c
+++ b/c/utils.c
@@ -2245,6 +2245,24 @@ bool isPassPhrase(const char *password) {
   return strlen(password) > 8;
 }
 
+/* timingsafe_memcmp compares two memory regions for equality in a way that is safe against timing attacks. */
+/* returns 0 if the regions are equal, non-zero otherwise */
+int timingsafe_memcmp(const void *a, const void *b, size_t n) {
+  const unsigned char *pointer_a = (const unsigned char *)a;
+  const unsigned char *pointer_b = (const unsigned char *)b;
+  volatile unsigned char result = 0;
+
+  for (size_t i = 0; i < n; i++) {
+    result |= pointer_a[i] ^ pointer_b[i];
+    __asm volatile(
+        ASM_PREFIX
+        ""
+        : "+r"(result)
+    );
+  }
+
+  return result;
+}
 
 
 /*

--- a/c/utils.c
+++ b/c/utils.c
@@ -2245,7 +2245,7 @@ bool isPassPhrase(const char *password) {
   return strlen(password) > 8;
 }
 
-/* timingsafe_memcmp compares two memory regions for equality in a way that is safe against timing attacks. */
+/* timesafe_memcmp compares two memory regions for equality in a way that is safe against timing attacks. */
 /* returns 0 if the regions are equal, non-zero otherwise */
 int timesafe_memcmp(const void *a, const void *b, size_t n) {
   const unsigned char *pointer_a = (const unsigned char *)a;

--- a/c/utils.c
+++ b/c/utils.c
@@ -2245,9 +2245,9 @@ bool isPassPhrase(const char *password) {
   return strlen(password) > 8;
 }
 
-/* timesafe_memcmp compares two memory regions for equality in a way that is safe against timing attacks. */
+/* timingsafe_memcompare compares two memory regions for equality in a way that is safe against timing attacks. */
 /* returns 0 if the regions are equal, non-zero otherwise */
-int timesafe_memcmp(const void *a, const void *b, size_t n) {
+int timingsafe_memcompare(const void *a, const void *b, size_t n) {
   const unsigned char *pointer_a = (const unsigned char *)a;
   const unsigned char *pointer_b = (const unsigned char *)b;
   volatile unsigned char result = 0;

--- a/jwt/jwt/jwt.c
+++ b/jwt/jwt/jwt.c
@@ -341,7 +341,7 @@ static int checkSignature(JwsAlgorithm algorithm,
       if (jwtTrace) {
         dumpbuffer(hmacbuf, sizeof(hmacbuf));
       }
-      if (0 != timingsafe_memcmp(signature, hmacbuf, ICSFP11_SHA256_HASHLEN)) {
+      if (0 != timesafe_memcmp(signature, hmacbuf, ICSFP11_SHA256_HASHLEN)) {
         zowelog(NULL, LOG_COMP_JWT, ZOWE_LOG_DEBUG, "signature verification failed\n");
         sts = RC_JWT_SIG_MISMATCH;
         break;
@@ -376,7 +376,7 @@ static int checkSignature(JwsAlgorithm algorithm,
       if (jwtTrace) {  
         dumpbuffer(hmacbuf, sizeof(hmacbuf));
       }
-      if (0 != timingsafe_memcmp(signature, hmacbuf, ICSFP11_SHA384_HASHLEN)) {
+      if (0 != timesafe_memcmp(signature, hmacbuf, ICSFP11_SHA384_HASHLEN)) {
         zowelog(NULL, LOG_COMP_JWT, ZOWE_LOG_DEBUG, "signature verification failed\n");
         sts = RC_JWT_SIG_MISMATCH;
         break;
@@ -409,7 +409,7 @@ static int checkSignature(JwsAlgorithm algorithm,
       if (jwtTrace) {
         dumpbuffer(hmacbuf, sizeof(hmacbuf));
       }
-      if (0 != timingsafe_memcmp(signature, hmacbuf, ICSFP11_SHA512_HASHLEN)) {
+      if (0 != timesafe_memcmp(signature, hmacbuf, ICSFP11_SHA512_HASHLEN)) {
         zowelog(NULL, LOG_COMP_JWT, ZOWE_LOG_DEBUG, "signature verification failed\n");
         sts = RC_JWT_SIG_MISMATCH;
         break;

--- a/jwt/jwt/jwt.c
+++ b/jwt/jwt/jwt.c
@@ -341,7 +341,7 @@ static int checkSignature(JwsAlgorithm algorithm,
       if (jwtTrace) {
         dumpbuffer(hmacbuf, sizeof(hmacbuf));
       }
-      if (0 != memcmp(signature, hmacbuf, ICSFP11_SHA256_HASHLEN)) {
+      if (0 != timingsafe_memcmp(signature, hmacbuf, ICSFP11_SHA256_HASHLEN)) {
         zowelog(NULL, LOG_COMP_JWT, ZOWE_LOG_DEBUG, "signature verification failed\n");
         sts = RC_JWT_SIG_MISMATCH;
         break;
@@ -352,7 +352,7 @@ static int checkSignature(JwsAlgorithm algorithm,
 
     case JWS_ALGORITHM_HS384: {
       if (sigLen != ICSFP11_SHA384_HASHLEN) {
-        zowelog(NULL, LOG_COMP_JWT, ZOWE_LOG_DEBUG, "saw HS256 sig alg with unexpected signature length\n");
+        zowelog(NULL, LOG_COMP_JWT, ZOWE_LOG_DEBUG, "saw HS384 sig alg with unexpected signature length\n");
         sts = RC_JWT_INVALID_SIGLEN;
         break;
       }
@@ -376,7 +376,7 @@ static int checkSignature(JwsAlgorithm algorithm,
       if (jwtTrace) {  
         dumpbuffer(hmacbuf, sizeof(hmacbuf));
       }
-      if (0 != memcmp(signature, hmacbuf, ICSFP11_SHA384_HASHLEN)) {
+      if (0 != timingsafe_memcmp(signature, hmacbuf, ICSFP11_SHA384_HASHLEN)) {
         zowelog(NULL, LOG_COMP_JWT, ZOWE_LOG_DEBUG, "signature verification failed\n");
         sts = RC_JWT_SIG_MISMATCH;
         break;
@@ -387,7 +387,7 @@ static int checkSignature(JwsAlgorithm algorithm,
 
     case JWS_ALGORITHM_HS512: {
       if (sigLen != ICSFP11_SHA512_HASHLEN) {
-        zowelog(NULL, LOG_COMP_JWT, ZOWE_LOG_DEBUG, "saw HS256 sig alg with unexpected signature length\n");
+        zowelog(NULL, LOG_COMP_JWT, ZOWE_LOG_DEBUG, "saw HS512 sig alg with unexpected signature length\n");
         sts = RC_JWT_INVALID_SIGLEN;
         break;
       }
@@ -409,7 +409,7 @@ static int checkSignature(JwsAlgorithm algorithm,
       if (jwtTrace) {
         dumpbuffer(hmacbuf, sizeof(hmacbuf));
       }
-      if (0 != memcmp(signature, hmacbuf, ICSFP11_SHA512_HASHLEN)) {
+      if (0 != timingsafe_memcmp(signature, hmacbuf, ICSFP11_SHA512_HASHLEN)) {
         zowelog(NULL, LOG_COMP_JWT, ZOWE_LOG_DEBUG, "signature verification failed\n");
         sts = RC_JWT_SIG_MISMATCH;
         break;

--- a/jwt/jwt/jwt.c
+++ b/jwt/jwt/jwt.c
@@ -341,7 +341,7 @@ static int checkSignature(JwsAlgorithm algorithm,
       if (jwtTrace) {
         dumpbuffer(hmacbuf, sizeof(hmacbuf));
       }
-      if (0 != timesafe_memcmp(signature, hmacbuf, ICSFP11_SHA256_HASHLEN)) {
+      if (0 != timingsafe_memcompare(signature, hmacbuf, ICSFP11_SHA256_HASHLEN)) {
         zowelog(NULL, LOG_COMP_JWT, ZOWE_LOG_DEBUG, "signature verification failed\n");
         sts = RC_JWT_SIG_MISMATCH;
         break;
@@ -376,7 +376,7 @@ static int checkSignature(JwsAlgorithm algorithm,
       if (jwtTrace) {  
         dumpbuffer(hmacbuf, sizeof(hmacbuf));
       }
-      if (0 != timesafe_memcmp(signature, hmacbuf, ICSFP11_SHA384_HASHLEN)) {
+      if (0 != timingsafe_memcompare(signature, hmacbuf, ICSFP11_SHA384_HASHLEN)) {
         zowelog(NULL, LOG_COMP_JWT, ZOWE_LOG_DEBUG, "signature verification failed\n");
         sts = RC_JWT_SIG_MISMATCH;
         break;
@@ -409,7 +409,7 @@ static int checkSignature(JwsAlgorithm algorithm,
       if (jwtTrace) {
         dumpbuffer(hmacbuf, sizeof(hmacbuf));
       }
-      if (0 != timesafe_memcmp(signature, hmacbuf, ICSFP11_SHA512_HASHLEN)) {
+      if (0 != timingsafe_memcompare(signature, hmacbuf, ICSFP11_SHA512_HASHLEN)) {
         zowelog(NULL, LOG_COMP_JWT, ZOWE_LOG_DEBUG, "signature verification failed\n");
         sts = RC_JWT_SIG_MISMATCH;
         break;


### PR DESCRIPTION
* Replace `memcmp` with new function `timingsafe_memcompare`.
* Minor debug messages updates

`__asm` force the code to reload the `diff`:
```
00008A  E320  47E0  0090  002257 |                   LLGC     r2,diff(,r4,2016)
000090  B904  0002        002257 |                   LGR      r0,r2
000094  E300  8000  0080  002257 |                   NG       r0,=FD'255'
00009A  4200  47E0        002257 |                   STC      r0,diff(,r4,2016)
```

Manual unit test
```c
#include <stdio.h>
#include <string.h>
#include <stdint.h>

int timingsafe_memcompare(const void *a, const void *b, size_t n) {
  const unsigned char *pointer_a = (const unsigned char *)a;
  const unsigned char *pointer_b = (const unsigned char *)b;
  volatile unsigned char result = 0; 
  for (size_t i = 0; i < n; i++) {
    unsigned char diff = pointer_a[i] ^ pointer_b[i];
    __asm volatile("" : "+r"(diff));
    result |= diff;
  }

  return result;
}

static int passed = 0;
static int failed = 0;

static void check(const char *desc, int got, int expected_zero) {
    int ok = expected_zero ? (got == 0) : (got != 0);
    if (ok) {
        printf("  PASS  %s\n", desc);
        passed++;
    } else {
        printf("  FAIL  %s  (got %d, expected %s)\n",
               desc, got, expected_zero ? "0" : "non-zero");
        failed++;
    }
}

int main(void) {
    printf("=== Equal inputs ===\n");
    check("identical 1-byte",          timingsafe_memcompare("A", "A", 1),             1);
    check("identical 3-byte",          timingsafe_memcompare("AAA", "AAA", 3),         1);
    check("all-zero bytes equal",      timingsafe_memcompare("\0\0\0", "\0\0\0", 3),   1);
    check("all-0xFF bytes equal",      timingsafe_memcompare("\xFF\xFF", "\xFF\xFF", 2),1);
    check("n=0 (empty compare)",       timingsafe_memcompare("X", "Y", 0),             1);

    printf("\n=== Unequal inputs ===\n");
    check("case differs (a vs A)",     timingsafe_memcompare("aaa", "AAA", 3),         0);
    check("mixed case mismatch",       timingsafe_memcompare("aaa", "AaA", 3),         0);
    check("NUL vs 0xFF",               timingsafe_memcompare("\0", "\xFF", 1),         0);
    check("two-byte all differ",       timingsafe_memcompare("\0\0", "\xFF\x01", 2),   0);
    check("differ only at last byte",  timingsafe_memcompare("AAB", "AAA", 3),         0);
    check("differ only at first byte", timingsafe_memcompare("BAA", "AAA", 3),         0);
    check("differ only at middle",     timingsafe_memcompare("ABA", "AAA", 3),         0);
    check("single bit flip",           timingsafe_memcompare("\x01", "\x00", 1),       0);

    printf("\n=== Boundary values ===\n");
    check("0x00 vs 0x01",              timingsafe_memcompare("\x00", "\x01", 1),       0);
    check("0x7F vs 0x80 (sign edge)",  timingsafe_memcompare("\x7F", "\x80", 1),       0);
    check("0xFE vs 0xFF",              timingsafe_memcompare("\xFE", "\xFF", 1),       0);
    check("0xFF vs 0x00",              timingsafe_memcompare("\xFF", "\x00", 1),       0);

    printf("\n=== Accumulation (OR correctness) ===\n");
    /* The result must be non-zero even if only one byte differs in a long run */
    check("match then differ",         timingsafe_memcompare("AAAB", "AAAA", 4),      0);
    check("differ then match",         timingsafe_memcompare("BAAA", "AAAA", 4),      0);
    check("differ in middle of long",  timingsafe_memcompare("AABAA", "AAAAA", 5),    0);
    /* Confirm OR accumulation doesn't spuriously fire on equal data */
    check("long equal run",            timingsafe_memcompare("AAAAAAA", "AAAAAAA", 7),1);

    printf("\n=== Embedded NUL handling ===\n");
    /* Unlike strcmp, we compare exactly n bytes regardless of NUL position */
    check("NUL mid-string equal",      timingsafe_memcompare("A\0B", "A\0B", 3),      1);
    check("NUL mid-string unequal",    timingsafe_memcompare("A\0B", "A\0C", 3),      0);
    check("NUL vs non-NUL mid",        timingsafe_memcompare("A\0B", "AXB", 3),       0);

    printf("\n--- %d passed, %d failed ---\n", passed, failed);
    return failed ? 1 : 0;
}
```