### PR TITLE
Add null check for password before length check

### DIFF
--- a/c/zos.c
+++ b/c/zos.c
@@ -1178,7 +1178,7 @@ static int safVerifyInternal(int options,
   ACEE * __ptr32  * __ptr32 ACEEPtr =  (ACEE * __ptr32 * __ptr32) safeMalloc31(4, "ACEE ptr");
   safVerifyRequest *verifyRequest = (safVerifyRequest*)(((char*)safWrapper)+ sizeof(safp));
   char *countedUserid = makeCountedString("userid", userid, 8, FALSE, &countedUserSize);
-  if (strlen (password) <= 8) {
+  if (!password || strlen (password) <= 8) {
     countedPassword = makeCountedString("password", password, 8, FALSE, &countedPasswordSize);
   }
   else {


### PR DESCRIPTION
Impersonation calls directly with `NULL` as password couple times, for example:

https://github.com/zowe/zowe-common-c/blob/773d70bc3bac9c200ccbf89558cb0645d7a18a63/c/impersonation.c#L61-L66


