### PR TITLE
Json conversion length

### DIFF
--- a/c/json.c
+++ b/c/json.c
@@ -2680,6 +2680,9 @@ Json *jsonParseUnterminatedUtf8String(ShortLivedHeap *slh, int outputCCSID,
   if (len > 0 && len <= (((INT_MAX) / 2) - 7)) {
     conversionOutputLength = 2 * len;
     buffer = SLHAlloc(slh, conversionOutputLength);
+  } else {
+    snprintf(errorBufferOrNull, errorBufferSize, "incorrect UTF8 string length %i", len);
+    return NULL;
   }
   if (buffer == NULL) {
     snprintf(errorBufferOrNull, errorBufferSize, "not enough memory");

--- a/c/json.c
+++ b/c/json.c
@@ -281,7 +281,7 @@ static char UTF8_ESCAPED_BACKSLASH[2]={ 0x5C, 0x5C};
 
 static ssize_t
 convertToUtf8(jsonPrinter *p, size_t len, char text[len], int inputCCSID) {
-  int convesionOutputLength = 0;
+  int conversionOutputLength = 0;
   int reasonCode = 0;
   int reallocLimit = 10;
   int convRc = 0;
@@ -304,9 +304,9 @@ convertToUtf8(jsonPrinter *p, size_t len, char text[len], int inputCCSID) {
     }
     convRc = convertCharset(text, len, inputCCSID, CHARSET_OUTPUT_USE_BUFFER,
         &p->_conversionBuffer, p->_conversionBufferSize, CCSID_UTF_8,
-        NULL, &convesionOutputLength, &reasonCode);
+        NULL, &conversionOutputLength, &reasonCode);
     if (convRc == CHARSET_CONVERSION_SUCCESS) {
-      return  convesionOutputLength;
+      return  conversionOutputLength;
     } else if (convRc != CHARSET_SHORT_BUFFER) {
       JSONERROR("JSON: conversion error, rc %d, reason %d\n", convRc,
               reasonCode);
@@ -371,13 +371,13 @@ writeBufferWithEscaping(jsonPrinter *p, size_t len, char text[len]) {
         if (SOURCE_CODE_CHARSET != CCSID_UTF_8) {
           char escapeUtf[ESCAPE_NATIVE_BUF_SIZE * 3];
           char *ptrToUtf8Buf = escapeUtf;
-          int convesionOutputLength = 0;
+          int conversionOutputLength = 0;
           int convRc = 0;
           int reasonCode = 0;
 
           convRc = convertCharset(escape, ESCAPE_LEN, SOURCE_CODE_CHARSET,
               CHARSET_OUTPUT_USE_BUFFER, &ptrToUtf8Buf, sizeof (escapeUtf),
-              CCSID_UTF_8, NULL, &convesionOutputLength, &reasonCode);
+              CCSID_UTF_8, NULL, &conversionOutputLength, &reasonCode);
           if (convRc != CHARSET_CONVERSION_SUCCESS) {
             JSONERROR("JSON: conversion error, rc %d, reason %d\n",
                     convRc, reasonCode);
@@ -2673,17 +2673,10 @@ Json *jsonParseUnterminatedUtf8String(ShortLivedHeap *slh, int outputCCSID,
                                       char *jsonUtf8String, int len,
                                       char* errorBufferOrNull, int errorBufferSize) {
   int convRc, convRsn;
-  int conversionOutputLength = 0;
+  int conversionOutputLength = 2 * len;
   char *buffer = NULL;
 
-  // SLHAlloc rounds up to a multiple of 8
-  if (len > 0 && (long long)len * 2 + 7 <= INT_MAX) {
-    conversionOutputLength = 2 * len;
-    buffer = SLHAlloc(slh, conversionOutputLength);
-  } else {
-    snprintf(errorBufferOrNull, errorBufferSize, "incorrect UTF8 string length %i", len);
-    return NULL;
-  }
+  buffer = SLHAlloc(slh, conversionOutputLength);
   if (buffer == NULL) {
     snprintf(errorBufferOrNull, errorBufferSize, "not enough memory");
     return NULL;

--- a/c/json.c
+++ b/c/json.c
@@ -2677,7 +2677,7 @@ Json *jsonParseUnterminatedUtf8String(ShortLivedHeap *slh, int outputCCSID,
   char *buffer = NULL;
 
   // SLHAlloc rounds up to a multiple of 8
-  if (len > 0 &&len <= (((INT_MAX) / 2) - 7)) {
+  if (len > 0 && len <= (((INT_MAX) / 2) - 7)) {
     conversionOutputLength = 2 * len;
     buffer = SLHAlloc(slh, conversionOutputLength);
   }

--- a/c/json.c
+++ b/c/json.c
@@ -2677,7 +2677,7 @@ Json *jsonParseUnterminatedUtf8String(ShortLivedHeap *slh, int outputCCSID,
   char *buffer = NULL;
 
   // SLHAlloc rounds up to a multiple of 8
-  if (len > 0 && len <= (((INT_MAX) / 2) - 7)) {
+  if (len > 0 && (long long)len * 2 + 7 <= INT_MAX) {
     conversionOutputLength = 2 * len;
     buffer = SLHAlloc(slh, conversionOutputLength);
   } else {

--- a/c/json.c
+++ b/c/json.c
@@ -2673,23 +2673,27 @@ Json *jsonParseUnterminatedUtf8String(ShortLivedHeap *slh, int outputCCSID,
                                       char *jsonUtf8String, int len,
                                       char* errorBufferOrNull, int errorBufferSize) {
   int convRc, convRsn;
-  int convesionOutputLength = 2 * len;
-  char *buffer;
+  int conversionOutputLength = 0;
+  char *buffer = NULL;
 
-  buffer = SLHAlloc(slh, convesionOutputLength);
+  // SLHAlloc rounds up to a multiple of 8
+  if (len > 0 &&len <= (((INT_MAX) / 2) - 7)) {
+    conversionOutputLength = 2 * len;
+    buffer = SLHAlloc(slh, conversionOutputLength);
+  }
   if (buffer == NULL) {
     snprintf(errorBufferOrNull, errorBufferSize, "not enough memory");
     return NULL;
   }
   convRc = convertCharset(jsonUtf8String, len, CCSID_UTF_8,
-      CHARSET_OUTPUT_USE_BUFFER, &buffer, convesionOutputLength, outputCCSID,
-      NULL, &convesionOutputLength, &convRsn);
+      CHARSET_OUTPUT_USE_BUFFER, &buffer, conversionOutputLength, outputCCSID,
+      NULL, &conversionOutputLength, &convRsn);
   if (convRc != 0) {
     snprintf(errorBufferOrNull, errorBufferSize, "could not convert from UTF8:"
         " conversion rc %d, reason %d", convRc, convRsn);
     return NULL;
   }
-  return jsonParseUnterminatedString(slh, buffer, convesionOutputLength,
+  return jsonParseUnterminatedString(slh, buffer, conversionOutputLength,
       errorBufferOrNull, errorBufferSize);
 }
 


### PR DESCRIPTION
## Check the `len`
```c
  if (len > 0 && (long long)len * 2 + 7 <= INT_MAX) {
    conversionOutputLength = 2 * len;
    buffer = SLHAlloc(slh, conversionOutputLength);
  }
```

`SLHAlloc` rounds up the memory length to 8-byte boundary. This check ensures we will stay in `int` range.

## Local variable renamed
`convesionOutputLength` -> `conversionOutputLength`

## Update

The size logic was moved to `SLHAlloc` in #620 
Once reviewed and merged, this PR can be updated.

## Final change

The #620 was merged, so the changes:
* buffer initially NULL (just for sure)
* variable renamed