### PR TITLE
Add null check for forceEnabled in httpserver.c

### DIFF
--- a/c/httpserver.c
+++ b/c/httpserver.c
@@ -4490,7 +4490,7 @@ void respondWithUnixFile2(HttpService* service, HttpResponse* response, char* ab
 #endif
         ;
     char *forceEnabled = getQueryParam(response->request, "force");
-    if (ccsid == 0 && !strcmp(forceEnabled, "enable")) {
+    if (ccsid == 0 && forceEnabled && !strcmp(forceEnabled, "enable")) {
         char *sourceEncoding = getQueryParam(response->request, "source");
         char *targetEncoding = getQueryParam(response->request, "target");
         int sEncoding;


### PR DESCRIPTION
`getQueryParam` can possibly return `NULL`.
Check `NULL` value before the string compare.