### PR TITLE
httpfileservice: check if double length is fine

### DIFF
--- a/c/httpfileservice.c
+++ b/c/httpfileservice.c
@@ -825,7 +825,7 @@ int writeBinaryDataFromBase64(UnixFile *file, char *fileContents, int contentLen
   int reasonCode = 0;
   int convertBufferSize;
 
-  if (contentLength > 0 && (long long)contentLength * 2 + 7 <= INT_MAX) {
+  if (contentLength > 0 && (int64)contentLength * 2 + 7 <= INT_MAX) {
     convertBufferSize = 2 * contentLength;
   } else {
     zowelog(NULL, LOG_COMP_RESTFILE, ZOWE_LOG_DEBUG, "Content length is too large to process: %i\n", contentLength);
@@ -901,7 +901,7 @@ int writeAsciiDataFromBase64(UnixFile *file, char *fileContents, int contentLeng
   int reasonCode = 0;
   int dataToWriteSize;
 
-  if (contentLength > 0 && (long long)contentLength * 2 + 7 <= INT_MAX) {
+  if (contentLength > 0 && (int64)contentLength * 2 + 7 <= INT_MAX) {
     dataToWriteSize = 2 * contentLength;
   } else {
     zowelog(NULL, LOG_COMP_RESTFILE, ZOWE_LOG_DEBUG, "Content length is too large to process: %i\n", contentLength);

--- a/c/httpfileservice.c
+++ b/c/httpfileservice.c
@@ -49,6 +49,8 @@
 # endif
 #endif
 
+#define MAX_BASE64_CONTENT_LENGTH (256 * 1024 * 1024)
+
 #ifdef __ZOWE_OS_ZOS
 #define NATIVE_CODEPAGE CCSID_EBCDIC_1047
 #define DEFAULT_UMASK 0022
@@ -825,10 +827,10 @@ int writeBinaryDataFromBase64(UnixFile *file, char *fileContents, int contentLen
   int reasonCode = 0;
   int convertBufferSize;
 
-  if (contentLength > 0 && (int64)contentLength * 2 + 7 <= INT_MAX) {
+  if (contentLength > 0 && contentLength <= MAX_BASE64_CONTENT_LENGTH) {
     convertBufferSize = 2 * contentLength;
   } else {
-    zowelog(NULL, LOG_COMP_RESTFILE, ZOWE_LOG_DEBUG, "Content length is too large to process: %i\n", contentLength);
+    zowelog(NULL, LOG_COMP_RESTFILE, ZOWE_LOG_WARNING, "Content length is invalid or too large to process: %i\n", contentLength);
     return -1;
   }
 
@@ -901,10 +903,10 @@ int writeAsciiDataFromBase64(UnixFile *file, char *fileContents, int contentLeng
   int reasonCode = 0;
   int dataToWriteSize;
 
-  if (contentLength > 0 && (int64)contentLength * 2 + 7 <= INT_MAX) {
+  if (contentLength > 0 && contentLength <= MAX_BASE64_CONTENT_LENGTH) {
     dataToWriteSize = 2 * contentLength;
   } else {
-    zowelog(NULL, LOG_COMP_RESTFILE, ZOWE_LOG_DEBUG, "Content length is too large to process: %i\n", contentLength);
+    zowelog(NULL, LOG_COMP_RESTFILE, ZOWE_LOG_WARNING, "Content length is invalid or too large to process: %i\n", contentLength);
     return -1;
   }
 

--- a/c/httpfileservice.c
+++ b/c/httpfileservice.c
@@ -823,7 +823,14 @@ int writeBinaryDataFromBase64(UnixFile *file, char *fileContents, int contentLen
   int status = 0;
   int returnCode = 0;
   int reasonCode = 0;
-  int convertBufferSize = contentLength * 2;
+  int convertBufferSize;
+
+  if (contentLength > 0 && (long long)contentLength * 2 + 7 <= INT_MAX) {
+    convertBufferSize = 2 * contentLength;
+  } else {
+    zowelog(NULL, LOG_COMP_RESTFILE, ZOWE_LOG_DEBUG, "Content length is too large to process: %i\n", contentLength);
+    return -1;
+  }
 
   char *convertBuffer = safeMalloc(convertBufferSize, "CONVERT BUFFER");
   int conversionLength = 0;
@@ -892,7 +899,14 @@ int writeAsciiDataFromBase64(UnixFile *file, char *fileContents, int contentLeng
   int status = 0;
   int returnCode = 0;
   int reasonCode = 0;
-  int dataToWriteSize = contentLength * 2;
+  int dataToWriteSize;
+
+  if (contentLength > 0 && (long long)contentLength * 2 + 7 <= INT_MAX) {
+    dataToWriteSize = 2 * contentLength;
+  } else {
+    zowelog(NULL, LOG_COMP_RESTFILE, ZOWE_LOG_DEBUG, "Content length is too large to process: %i\n", contentLength);
+    return -1;
+  }
 
   char *dataToWrite = safeMalloc(dataToWriteSize, "CONVERT BUFFER");
   int dataSize = 0;


### PR DESCRIPTION
* New constant for base64 oprations 256MB 
* Check if `contentLength` > 0 and < 256MB
* We can safely double the `contentLength`
* `DEBUG3` to `WARNING`
