### PR TITLE
Fix swapped Min/Max TLS log labels

### DIFF
--- a/c/tls.c
+++ b/c/tls.c
@@ -88,12 +88,12 @@ static int getTlsMax(TlsSettings *settings) {
   if (settings->maxTls != NULL) {
     for (int i = 0; i < sizeof(TLS_NAMES)/sizeof(TLS_NAMES[0]); i++) {
       if (!strcmp(settings->maxTls, TLS_NAMES[i])) {
-        zowelog(NULL, LOG_COMP_HTTPSERVER, ZOWE_LOG_DEBUG, "Min TLS requested=%s\n", TLS_NAMES[i]);
+        zowelog(NULL, LOG_COMP_HTTPSERVER, ZOWE_LOG_DEBUG, "Max TLS requested=%s\n", TLS_NAMES[i]);
         return i;
       }
     }
   }
-  zowelog(NULL, LOG_COMP_HTTPSERVER, ZOWE_LOG_DEBUG, "Min TLS defaulting\n");
+  zowelog(NULL, LOG_COMP_HTTPSERVER, ZOWE_LOG_DEBUG, "Max TLS defaulting\n");
   return TLS_MAX_DEFAULT;
 }
 
@@ -101,12 +101,12 @@ static int getTlsMin(TlsSettings *settings) {
   if (settings->minTls != NULL) {
     for (int i = 0; i < sizeof(TLS_NAMES)/sizeof(TLS_NAMES[0]); i++) {
       if (!strcmp(settings->minTls, TLS_NAMES[i])) {
-        zowelog(NULL, LOG_COMP_HTTPSERVER, ZOWE_LOG_DEBUG, "Max TLS requested=%s\n", TLS_NAMES[i]);
+        zowelog(NULL, LOG_COMP_HTTPSERVER, ZOWE_LOG_DEBUG, "Min TLS requested=%s\n", TLS_NAMES[i]);
         return i;
       }
     }
   }
-  zowelog(NULL, LOG_COMP_HTTPSERVER, ZOWE_LOG_DEBUG, "Max TLS defaulting\n");
+  zowelog(NULL, LOG_COMP_HTTPSERVER, ZOWE_LOG_DEBUG, "Min TLS defaulting\n");
   return TLS_MIN_DEFAULT;
 }
 


### PR DESCRIPTION
The getTlsMax() and getTlsMin() functions in c/tls.c had their log messages swapped, getTlsMax() was printing "Min TLS requested" and getTlsMin() was printing "Max TLS requested". This makes debugging TLS configuration issues unnecessarily confusing.