### PR TITLE
Update `SLHAlloc` to check the limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Zowe Common C Changelog
 
 ## `3.6.0`
+- Bugfix: Internal Short Lived Heap allocation routine `SLHAlloc` checks the size [(#620)](https://github.com/zowe/zowe-common-c/issues/620)
 - Bugfix: Return code 414 (`HTTP_STATUS_URI_TOO_LONG`) for too long URI [(#597)](https://github.com/zowe/zowe-common-c/issues/597)
 - Bugfix: Various XML updates. [(#598)](https://github.com/zowe/zowe-common-c/pull/598)
 - Enhancement: made zowe-common-c compatible with clang/llvm on z/OS and Linux. [(#596)](https://github.com/zowe/zowe-common-c/pull/596)

--- a/c/utils.c
+++ b/c/utils.c
@@ -12,6 +12,7 @@
 
 #ifdef METTLE
 #include <metal/metal.h>
+#include <metal/limits.h>
 #include <metal/stddef.h>
 #include <metal/stdio.h>
 #include <metal/stdlib.h>
@@ -21,6 +22,7 @@
 #include "metalio.h"
 
 #else
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -1493,10 +1495,18 @@ ShortLivedHeap *makeShortLivedHeap64(int blockSize, int maxBlocks){
 }
 
 char *SLHAlloc(ShortLivedHeap *slh, int size){
+  if (size <= 0) {
+    return NULL; 
+  }
+
   /* expand for fullword alignment */
   int rem = size & 0x7;
   if (rem != 0){
-    size += (8-rem);
+    int padding = 8 - rem;
+    if (size > INT_MAX - padding) {
+      return NULL; // Handle overflow error (out of memory range)
+    }
+    size += padding;
   }
   char *data;
   /* 


### PR DESCRIPTION
For cases like #613 

## Change
* `SLHAlloc` rounds the memory up to 8 byte boundary
* When calling `SLHAlloc` with size close to `INT_MAX`, it can possibly overflow and negative int will be later treated as unsigned int (large number).
* Before the change, caller should check, if the rounded size is <= INT_MAX
* After the change, this check is part of the `SLHAlloc`