### PR TITLE
(v3) Use "%.*s" version of snprintf to stop overreading in 'zosResolveSymbol()'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Bugfix: Various XML updates. [(#598)](https://github.com/zowe/zowe-common-c/pull/598)
 - Enhancement: made zowe-common-c compatible with clang/llvm on z/OS and Linux. [(#596)](https://github.com/zowe/zowe-common-c/pull/596)
 - Enhancement: take into account active PC callers during termination [(#569)](https://github.com/zowe/zowe-common-c/pull/569)
+- Bugfix: Use "%.*s" version of snprintf to stop overreading in 'zosResolveSymbol()' which causes abend. [()]()
 
 ## `3.5.0`
 - Enhancement: YAML comment preservation tooling for the YAML-to-JSON-to-YAML round-trip pipeline. Comments are scanned separately from libyaml, attached to the JSON tree, and re-emitted with configurable alignment (none, fixed, original). Opt-in; not yet enabled in configmgr. [(#583)](https://github.com/zowe/zowe-common-c/issues/583)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Bugfix: Various XML updates. [(#598)](https://github.com/zowe/zowe-common-c/pull/598)
 - Enhancement: made zowe-common-c compatible with clang/llvm on z/OS and Linux. [(#596)](https://github.com/zowe/zowe-common-c/pull/596)
 - Enhancement: take into account active PC callers during termination [(#569)](https://github.com/zowe/zowe-common-c/pull/569)
-- Bugfix: Use "%.*s" version of snprintf to stop overreading in 'zosResolveSymbol()' which causes abend. [()]()
+ Bugfix: Use "%.*s" version of snprintf to stop overreading in 'zosResolveSymbol()' which causes abend. [(#626)](https://github.com/zowe/zowe-common-c/pull/626)
 
 ## `3.5.0`
 - Enhancement: YAML comment preservation tooling for the YAML-to-JSON-to-YAML round-trip pipeline. Comments are scanned separately from libyaml, attached to the JSON tree, and re-emitted with configurable alignment (none, fixed, original). Opt-in; not yet enabled in configmgr. [(#583)](https://github.com/zowe/zowe-common-c/issues/583)

--- a/c/qjszos.c
+++ b/c/qjszos.c
@@ -85,6 +85,14 @@ static JSValue zosResolveSymbol(JSContext *ctx, JSValueConst this_val,
   JS_FreeCString(ctx,symbol);
 
 #ifdef __ZOWE_OS_ZOS
+  if (result == NULL) {
+    if (rc != 0) {
+      return JS_ThrowReferenceError(ctx,
+                                    "resolveSymbol failed for '%s' (rc=%d, rsn=%d)",
+                                    symbolNative, rc, rsn);
+    }
+    return JS_NULL;
+  }
   return newJSStringFromNative(ctx, result, strlen(result));
 #else
   return JS_NewString(ctx, NULL);

--- a/c/zos.c
+++ b/c/zos.c
@@ -425,19 +425,28 @@ char *resolveSymbolBySyscall(const char *inputSymbol, int *rc, int *rsn) {
     }
 
 //    printf("input '%s', output '%s'\n", below2G->input, below2G->output);
+    // We are not checking for return code here and therefore cannot differentiate between a blank and not found.
+    // For more info: https://www.ibm.com/docs/en/zos/2.2.0?topic=hsp-asasymbm-asasymbf-substitute-text-symbols
+    // printf("ASASYMBF return code %x\n", below2G->returnCode);
     int outputLen = strlen(below2G->output);
-    if (outputLen != 0){
-      char *result = safeMalloc(sizeof(below2G->output), "output");
-      snprintf(result, outputLen+1, "%s", below2G->output);
+    char *result = NULL;
+    if (outputLen > 0) {
+      result = safeMalloc(outputLen+1, "output");
+      if (result == NULL) {
+        *rc = RESOLVESYMBOL_RETURN_ALLOC_FAILED;
+      } else {
+        snprintf(result, outputLen+1, "%.*s", outputLen, below2G->output);
+      }
       FREE_STRUCT31(STRUCT31_NAME(below2G));
       return result;
-    } else{
-      FREE_STRUCT31(STRUCT31_NAME(below2G));
-      return NULL;
     }
 
+    FREE_STRUCT31(STRUCT31_NAME(below2G));
+    return NULL;
 
 }
+
+
 
 
 /*
@@ -482,38 +491,35 @@ char *resolveSymbol(const char *inputSymbol, int *rc, int *rsn) {
 
 
   SymbTableEntry *entry = firstEntry;
+  for (int i = 0; i < entryCount; i++, entry++) {
+    char *currentSymbol;
+    const char *subtextSrc;
+    int subtextLen;
 
-  for (int i = 0; i < entryCount; i++) {
     if (useEntryOffsets) {
-      //printf("firstEntry = 0x%p, symbol offset = 0x%x, length=%d, subtext offset = 0x%x, length=%d\n", firstEntry, entry->symbolOffset, entry->symbolLength, entry->subtextOffset, entry->subtextLength);
-      
-      char *currentSymbol = (char*)firstEntry + entry->symbolOffset;
-//      printf("Symbol=%.*s\n", entry->symbolLength, currentSymbol);
-
-      // extra '.' at end to account for
-      if ((inputLen+1 == entry->symbolLength) && (memcmp(currentSymbol, inputSymbol, inputLen) == 0) && currentSymbol[inputLen]=='.'){
-        char *result = (char*) safeMalloc(entry->subtextLength+1, "subtext");
-        snprintf(result, entry->subtextLength+1, "%s", (char*)firstEntry + entry->subtextOffset);
-        return result;
-      }
-
-      entry = entry+1;
-    } else{
-      char *currentSymbol = entry->symbolPtr;
-
-      printf("Symbol=%.*s\n", entry->symbolLength, currentSymbol);
-
-
-      // extra '.' at end to account for
-      if ((inputLen+1 == entry->symbolLength) && (memcmp(currentSymbol, inputSymbol, inputLen) == 0) && currentSymbol[inputLen]=='.'){
-        char *result = (char*) safeMalloc(entry->subtextLength+1, "subtext");
-        snprintf(result, entry->subtextLength+1, "%s", entry->subtextPtr);
-        return result;
-      }
+      currentSymbol = (char*)firstEntry + entry->symbolOffset;
+      subtextSrc    = (char*)firstEntry + entry->subtextOffset;
+      subtextLen    = entry->subtextLength;
+    } else {
+      if (entry->symbolPtr == NULL) continue;
+      currentSymbol = entry->symbolPtr;
+      subtextSrc    = entry->subtextPtr ? entry->subtextPtr : "";
+      subtextLen    = entry->subtextPtr ? entry->subtextLength : 0;
     }
- 
-     //printf("next entry at 0x%p\n", entry);
 
+    // extra '.' at end to account for
+    if ((inputLen+1 == entry->symbolLength) &&
+        (memcmp(currentSymbol, inputSymbol, inputLen) == 0) &&
+        currentSymbol[inputLen] == '.') {
+      char *result = (char*) safeMalloc(subtextLen+1, "subtext");
+      if (result == NULL) {
+        *rc = RESOLVESYMBOL_RETURN_ALLOC_FAILED;
+        return NULL;
+      }
+      // NOTE: For a blank subtext (offset mode: subtextLength == 0, pointer mode: subtextPtr == NULL), an empty string "" is returned.
+      snprintf(result, subtextLen+1, "%.*s", subtextLen, subtextSrc);
+      return result;
+    }
   }
 
   return resolveSymbolBySyscall(inputSymbol, rc, rsn);

--- a/h/zos.h
+++ b/h/zos.h
@@ -473,6 +473,7 @@ typedef struct SymbTable1_tag{
 #define SYMBT_MAXSTATIC_TABLE_SIZE 32512
 
 #define RESOLVESYMBOL_RETURN_BAD_INPUT 1
+#define RESOLVESYMBOL_RETURN_ALLOC_FAILED 2
 
 typedef struct ecvt_tag{
   char  eyecatcher[4];


### PR DESCRIPTION
v3 PR for https://github.com/zowe/zowe-common-c/pull/595/