### PR TITLE
Use cookieNameLength in memcmp

### DIFF
--- a/c/httpserver.c
+++ b/c/httpserver.c
@@ -2525,9 +2525,10 @@ static char *getCookieValue(HttpRequest *request, char *cookieName){
       keyValuePairLength = semiPos-pos;
       nextPos = semiPos+1;
     }
-    int equalsPos = indexOf(cookieText, cookieTextLength, '=', pos);
+    int equalsPos = indexOf(cookieText, (semiPos == -1 ? cookieTextLength : semiPos), '=', pos);
     if ((equalsPos != -1) &&
-        !memcmp(cookieText+pos,cookieName,equalsPos-pos)){
+        (equalsPos-pos == cookieNameLength) &&
+        !memcmp(cookieText+pos,cookieName,cookieNameLength)){
       char *cookieValue = copyString(slh, &cookieText[equalsPos + 1],
           pos + keyValuePairLength - (equalsPos + 1));
       return cookieValue;


### PR DESCRIPTION
* Bounds the `=` search to the current key/value segment (`semiPos`), fixing the boundary issue.
* Requires the candidate key's length to exactly equal `cookieNameLength` before comparing, then always compares exactly `cookieNameLength` bytes — eliminating both the **prefix-collision** false match and the **out-of-bounds** read.