### PR TITLE
Use 31-bit storage for the recovery analysis function in httpserver 64-bit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Enhancement: made zowe-common-c compatible with clang/llvm on z/OS and Linux. [(#596)](https://github.com/zowe/zowe-common-c/pull/596)
 - Enhancement: take into account active PC callers during termination [(#569)](https://github.com/zowe/zowe-common-c/pull/569)
  Bugfix: Use "%.*s" version of snprintf to stop overreading in 'zosResolveSymbol()' which causes abend. [(#626)](https://github.com/zowe/zowe-common-c/pull/626)
+- Bugfix: fix recovery in 64-bit httpserver [(#622)](https://github.com/zowe/zowe-common-c/issues/622)
 
 ## `3.5.0`
 - Enhancement: YAML comment preservation tooling for the YAML-to-JSON-to-YAML round-trip pipeline. Comments are scanned separately from libyaml, attached to the JSON tree, and re-emitted with configurable alignment (none, fixed, original). Opt-in; not yet enabled in configmgr. [(#583)](https://github.com/zowe/zowe-common-c/issues/583)

--- a/c/httpserver.c
+++ b/c/httpserver.c
@@ -3634,10 +3634,16 @@ static int handleHttpService(HttpServer *server,
     return handleServiceFailed(conversation, service, response);
   }
 
-  HTTPServiceABENDInfo abendInfo = {"RSHTTPAI", 0, 0};
+  ALLOC_STRUCT31(
+    STRUCT31_NAME(below2G),
+    STRUCT31_FIELDS(
+      HTTPServiceABENDInfo abendInfo;
+    )
+  );
+  below2G->abendInfo = (HTTPServiceABENDInfo){"RSHTTPAI"};
   int recoveryRC = recoveryPush(service->name,
                                 RCVR_FLAG_RETRY | RCVR_FLAG_SDWA_TO_LOGREC | RCVR_FLAG_DELETE_ON_RETRY,
-                                NULL, extractABENDInfo, &abendInfo, NULL, NULL);
+                                NULL, extractABENDInfo, &below2G->abendInfo, NULL, NULL);
 
   /*
      TODO this function needs a new argument about recording program state at time of abend
@@ -3652,12 +3658,13 @@ static int handleHttpService(HttpServer *server,
     }
     else if (recoveryRC == RC_RCV_ABENDED) {
       zowelog(NULL, LOG_COMP_HTTPSERVER, ZOWE_LOG_SEVERE, "httpserver: ABEND %03X-%02X averted when handling %s\n",
-          abendInfo.completionCode, abendInfo.reasonCode, service->name);
+          below2G->abendInfo.completionCode, below2G->abendInfo.reasonCode, service->name);
     }
     else {
       zowelog(NULL, LOG_COMP_HTTPSERVER, ZOWE_LOG_SEVERE, "httpserver: error running service %s unknown recovery code %d\n",
           service->name, recoveryRC);
     }
+    FREE_STRUCT31(below2G);
     return handleServiceFailed(conversation, service, response);
   }
 #endif
@@ -3730,6 +3737,7 @@ static int handleHttpService(HttpServer *server,
 
 #ifdef __ZOWE_OS_ZOS
   recoveryPop();
+  FREE_STRUCT31(below2G);
 #endif
 
   return HTTP_SERVICE_SUCCESS;


### PR DESCRIPTION

<!-- Thank you for submitting a PR to Zowe! To help us understand, test, and give feedback on your code, please fill in the details below. -->

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

When built for 64-bit, zss has its stack storage above the bar, but the recovery analysis function requires 31-bit storage to communicate with the user of the recovery facility. This PR adds code that uses the `ALLOC_STRUCT31` macro to allocate the analysis function data below the bar.

The macro can potentially yield a NULL for the `below2G` pointer, but since this pattern of not checking the result is present throughout the code base and given the amount we try to allocate is tiny, it's fine.

This PR addresses Issue: #622 


## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)


## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zss/blob/v2.x/master/CONTRIBUTING.md))
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings

## Testing
<!-- Describe how this code should be tested. I've you've added an automated or unit test, then describe how to run it. Otherwise, describe how you have tested it and how others should test it. -->

See #622.