### PR TITLE
Bugfix: run the JS async continuation loop after configmgr script eval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Zowe Common C Changelog
 
 ## `3.6.0`
+- Bugfix: configmgr now runs the JavaScript asynchronous continuation loop (`js_std_loop`) after evaluating a script, so `os.signal` handlers, `os.sleepAsync` timers, and Promise jobs scheduled during eval are dispatched instead of silently dropped. This lets JS-based components (e.g. a launcher) catch `SIGTERM` for graceful shutdown; a purely synchronous script is unaffected (the loop returns immediately when nothing is pending). [(#631)](https://github.com/zowe/zowe-common-c/pull/631)
 - Bugfix: Internal Short Lived Heap allocation routine `SLHAlloc` checks the size [(#620)](https://github.com/zowe/zowe-common-c/issues/620)
 - Bugfix: Return code 414 (`HTTP_STATUS_URI_TOO_LONG`) for too long URI [(#597)](https://github.com/zowe/zowe-common-c/issues/597)
 - Bugfix: Various XML updates. [(#598)](https://github.com/zowe/zowe-common-c/pull/598)

--- a/c/embeddedjs.c
+++ b/c/embeddedjs.c
@@ -244,6 +244,15 @@ int ejsEvalFile(EmbeddedJS *ejs, const char *filename, int loadMode){
     else
         eval_flags = JS_EVAL_TYPE_GLOBAL;
     JSValue evalResult = ejsEvalBuffer1(ejs, buf, bufferLength, asciiFilename, eval_flags, &ret);
+    /* Run the JavaScript asynchronous continuation loop after top-level eval, to
+       fulfill the single-threaded event-loop contract. Without it, anything that
+       completes "later" -- os.signal() handlers, os.sleepAsync() timers, and
+       Promise jobs (incl. top-level await) scheduled during eval -- is never
+       dispatched, because the callbacks fire only inside js_os_poll(), reached
+       only via js_std_loop(). A purely synchronous script leaves nothing pending,
+       so this returns immediately; a script that registers a timer/handler (e.g.
+       a launcher waiting for SIGTERM) keeps spinning until it is idle again. */
+    js_std_loop(ejs->ctx);
     js_free(ejs->ctx, buf);
     JS_FreeValue(ejs->ctx, evalResult);
     return ret;

--- a/tests/js/async-sleep.js
+++ b/tests/js/async-sleep.js
@@ -1,0 +1,42 @@
+/*
+ * async-sleep.js -- POSITIVE case for configmgr signal handling.
+ *
+ * The correct pattern: an ASYNC wait that yields to the event loop every tick
+ * (await os.sleepAsync). The pending timer keeps js_os_poll alive and its
+ * select() interruptible, so a SIGTERM delivered during the wait is dispatched
+ * to the JS handler between ticks. This requires configmgr to run the async
+ * continuation loop (js_std_loop) after top-level eval -- see the fix in
+ * embeddedjs.c ejsEvalFile(). WITHOUT that fix the loop never runs, the
+ * sleepAsync timer never fires, and this script exits right after the first
+ * line (no ticks) -- which is itself the demonstration that the loop is missing.
+ *
+ *   configmgr -script tests/js/async-sleep.js    # then: kill -TERM <pid>
+ *   EXPECTED (with fix): ticks once/sec, then PASS when SIGTERM interrupts.
+ */
+import * as os from 'cm_os';
+
+const SIGTERM = (typeof os.SIGTERM === 'number') ? os.SIGTERM : 15;
+let stop = false;
+
+os.signal(SIGTERM, function () {
+  stop = true;
+  console.log('*** SIGTERM handler fired ***');
+});
+
+console.log('async-sleep: pid=' + os.getpid() + '  (send SIGTERM within ~10s)');
+
+async function main() {
+  let waited = 0;
+  while (waited < 10000 && !stop) {
+    await os.sleepAsync(1000);    /* ASYNC: yields to the loop; timer keeps it alive + interruptible */
+    waited += 1000;
+    console.log('  async tick waited=' + waited + ' stop=' + stop);
+  }
+  if (stop) {
+    console.log('PASS: handler fired, async wait interrupted cleanly');
+  } else {
+    console.log('FAIL: wait completed without a signal');
+  }
+}
+
+main();

--- a/tests/js/async-sleep.sh
+++ b/tests/js/async-sleep.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+# Simple test for async-sleep.js
+# Starts the script and send the TERM signal
+# Possible parameter is configmgr binary
+
+CONFIGMGR="../../bin/configmgr"
+
+if [ -n "${1}" ]; then
+  CONFIGMGR="${1}"
+fi
+
+if [ ! -f "${CONFIGMGR}" ]; then
+  echo "configmgr binary not found: '${CONFIGMGR}'"
+  exit 1
+fi
+
+"$CONFIGMGR" -script ./async-sleep.js &
+PID=$!
+sleep 3
+kill -TERM "${PID}"
+wait "${PID}"

--- a/tests/js/sync-sleep.js
+++ b/tests/js/sync-sleep.js
@@ -1,0 +1,39 @@
+/*
+ * sync-sleep.js -- NEGATIVE control for configmgr signal handling.
+ *
+ * Demonstrates the JavaScript single-threaded anti-pattern: a SYNCHRONOUS
+ * os.sleep() wait loop can never observe a signal. os.sleep() blocks the one
+ * JS thread and returns nothing to the event loop; os.signal() callbacks are
+ * dispatched only by the event loop (js_os_poll). A blocked thread starves the
+ * loop, so the handler cannot run during the wait -- on ANY host (Node/Deno/Bun
+ * behave identically). This holds even WITH configmgr's post-eval js_std_loop
+ * fix, because the synchronous loop runs entirely inside eval and leaves nothing
+ * pending. Included to show that NO handler fires here.
+ *
+ *   configmgr -script tests/js/sync-sleep.js     # then: kill -TERM <pid>
+ *   EXPECTED: FAIL (signal not delivered to JS).
+ */
+import * as os from 'cm_os';
+
+const SIGTERM = (typeof os.SIGTERM === 'number') ? os.SIGTERM : 15;
+let stop = false;
+
+os.signal(SIGTERM, function () {
+  stop = true;
+  console.log('*** SIGTERM handler fired ***');
+});
+
+console.log('sync-sleep: pid=' + os.getpid() + '  (send SIGTERM within ~10s)');
+
+let waited = 0;
+while (waited < 10000 && !stop) {
+  os.sleep(1000);                 /* SYNCHRONOUS: blocks the thread, starves the loop */
+  waited += 1000;
+  console.log('  sync tick waited=' + waited + ' stop=' + stop);
+}
+
+if (stop) {
+  console.log('PASS (unexpected): handler fired');
+} else {
+  console.log('FAIL (expected): synchronous os.sleep never yields; signal never reached JS');
+}

--- a/tests/js/sync-sleep.sh
+++ b/tests/js/sync-sleep.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+# Simple test for sync-sleep.js
+# Starts the script and send the TERM signal
+# Possible parameter is configmgr binary
+
+CONFIGMGR="../../bin/configmgr"
+
+if [ -n "${1}" ]; then
+  CONFIGMGR="${1}"
+fi
+
+if [ ! -f "${CONFIGMGR}" ]; then
+  echo "configmgr binary not found: '${CONFIGMGR}'"
+  exit 1
+fi
+
+"$CONFIGMGR" -script ./sync-sleep.js &
+PID=$!
+sleep 3
+kill -TERM "${PID}"
+wait "${PID}"


### PR DESCRIPTION
## Problem

configmgr evaluates a top-level script (`ejsEvalFile` — used by `-script`, `-embeddedScript`, and any embedder such as a launcher) and returns **without ever running the QuickJS event loop**: `js_std_loop()` is declared but never called. QuickJS dispatches `os.signal()` handlers, `os.sleepAsync()` timers, and Promise jobs **only** inside `js_os_poll()`, which is reached only from `js_std_loop()`. So every asynchronous continuation scheduled during eval is silently dropped — a JS component that registers a `SIGTERM` handler for graceful shutdown never sees the signal.

This is **platform-independent** (reproduces on Linux, not only z/OS): a synchronous script "works" only because all of its work happens during the straight-line eval.

## Fix

One call — `js_std_loop(ejs->ctx)` after the eval in `ejsEvalFile()` (`c/embeddedjs.c`) — fulfilling the single-threaded JS event-loop contract: after top-level eval, pump microtasks + macrotasks until the loop is idle.

- Purely synchronous script → nothing pending → returns immediately (no behavior change).
- Async / signal-waiting script → driven to completion.

## Tests (`tests/js/`)

- **`async-sleep.js`** — the correct pattern: an `await os.sleepAsync` loop that yields to the event loop each tick. Catches `SIGTERM` → **PASS** with the fix (and produces *no ticks at all* without it, since the loop never runs).
- **`sync-sleep.js`** — negative control: a synchronous `os.sleep` loop blocks the one JS thread and starves the loop, so the handler can never fire in time — true on **any** JS host (Node/Deno/Bun included), and true even with this fix. Kept to document the anti-pattern.

## Verification (native Linux/WSL, `build_cmgr_clang.sh linux`)

| build × script | result |
|---|---|
| **fixed** × async | ticks 1/s, `*** SIGTERM handler fired ***`, **PASS** |
| **fixed** × sync | 10 ticks, `stop` never flips → **FAIL**; handler fires only in the post-eval drain (too late) |
| **unfixed** × async | pid line only, **no ticks** — loop never runs |

A long-standing design-level gap: QuickJS underlies Zowe install/config, but nothing had needed the *asynchronous* half of the JS contract until signal-driven graceful shutdown.
