### PR TITLE
Fixed wrong behavior in directoryDeleteRecursive

### DIFF
--- a/c/zosfile.c
+++ b/c/zosfile.c
@@ -1377,7 +1377,16 @@ int directoryDeleteRecursive(const char *pathName, int *retCode, int *resCode){
 
   for (int i = 0; i < validEntries; i++) {
     char pathBuffer[USS_MAX_PATH_LENGTH + 1] = {0};
-    snprintf(pathBuffer, sizeof(pathBuffer), "%s/%s", pathName, entryArray[i]);
+    int n = snprintf(pathBuffer, sizeof(pathBuffer), "%s/%s", pathName, entryArray[i]);
+    if (n < 0) {
+        *retCode = EINVAL;
+        *resCode = 0;
+        return -1;
+    } else if (n > sizeof(pathBuffer)) {
+        *retCode = ENAMETOOLONG;
+        *resCode = 0;
+        return -1;
+    }
 
     status    = fileInfo(pathBuffer, &info, &returnCode, &reasonCode);
     symstatus = symbolicFileInfo(pathBuffer, &syminfo, &returnCode, &reasonCode);

--- a/c/zosfile.c
+++ b/c/zosfile.c
@@ -1380,7 +1380,7 @@ int directoryDeleteRecursive(const char *pathName, int *retCode, int *resCode){
     snprintf(pathBuffer, sizeof(pathBuffer), "%s/%s", pathName, entryArray[i]);
 
     status    = fileInfo(pathBuffer, &info, &returnCode, &reasonCode);
-    symstatus = symbolicFileInfo(pathName, &syminfo, &returnCode, &reasonCode);
+    symstatus = symbolicFileInfo(pathBuffer, &syminfo, &returnCode, &reasonCode);
 
     if ((status == -1) && (symstatus == -1)){
       *retCode = returnCode;
@@ -1388,9 +1388,8 @@ int directoryDeleteRecursive(const char *pathName, int *retCode, int *resCode){
       return -1;
     }
 
-    /* If pathBuffer is directory, then recursively call.    */
-    /* Note: system marks symbolic as a directory            */
-    if ((status != -1 ) && fileInfoIsDirectory(&info)) {
+    /* If pathBuffer is "real" directory, then recursively call.    */
+    if ((status != -1 ) && fileInfoIsDirectory(&info) && !fileInfoIsSymbolicLink(&syminfo)) {
       status = directoryDeleteRecursive(pathBuffer, retCode, resCode);
       if (status == -1) {
         return -1;


### PR DESCRIPTION
## The issue
This PR fixes a wrong behavior of the `directoryDeleteRecursive` function.

Consider the following USS directory structure:

```
root
  |
  +--- dir1  <............................
  |     |                                .
  |     +--- file1                       .
  |                                      .
  +--- dir2                              .
        |                                .
        +--- link-to-dir1 ................
```

When you delete `/root/dir2`, the behavior of the `rm -rf` command is:
- `root/dir2/link-to-dir1` is deleted (unlinked);
- `root/dir2` is deleted;
- `root/dir1` and `root/dir1/file1` remain unchanged.

But when you call the function (e.g., by calling the `DELETE zss/api/v1/unixfile/contents/<path>` endpoint), what actually happens is:
- `root/dir2/link-to-dir1` is not deleted; (expected to be deleted)
- `root/dir2` is not deleted; (expected to be deleted)
- `root/dir1/file1` is deleted; (expected not to be deleted)

The root cause is simple: it couldn't tell a symbolic link from a real directory. According to the code comment, a symbolic link is reported as a directory by the system APIs.
https://github.com/zowe/zowe-common-c/blob/620d308c7a4b6371406ecef4dfacb1a44e295995/c/zosfile.c#L1391-L1394
So when it sees `root/dir2/link-to-dir1`, it enters the "directory" and deletes `file1`. After that, it will use `deleteDirectory` to delete the symbolic link and of course it will not work. Finally, it will use `deleteDirectory` again to delete `root/dir2` but because the contained symbolic link was not deleted, the containing directory can't be deleted either.

The fix is also simple: as long as it can distinguish symbolic link from a real directory, and treat symbolic link in the same way as a real file, the behavior will be correct. In fact, the code comment "Note: system marks symbolic as a directory" is a misunderstanding because the programmer called `symbolicFileInfo` with wrong parameter :)

## Hint for creating unit test:
### Test for directoryDeleteRecursive in zosfile.c
Notice: it can only be tested in z/OS.
Prepare the test data by shell script:
```shell
mkdir -p /tmp/testdir/dir1
mkdir -p /tmp/testdir/dir2
touch /tmp/testdir/dir1/file1
ln -s /tmp/testdir/dir1 /tmp/testdir/dir2/
```
Run C code:
```C
int ret, rsn;
if (0 != directoryDeleteRecursive("/tmp/testdir/dir2", &ret, &rsn)) {
  printf("<test name> FAILED: directoryDeleteRecursive failed, ret=%d, rsn=%d\n", ret, rsn);
}
if (!doesFileExist("/tmp/testdir/dir1/file1")) {
  puts("<test name> FAILED: dir1/file1 was incorrectly removed\n");
}
if (doesFileExist("/tmp/testdir/dir2")) {
  puts("<test name> FAILED: dir2 was not actually removed\n");
}
```