### PR TITLE
Expose a function to test any SAF level in xmem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Enhancement: take into account active PC callers during termination [(#569)](https://github.com/zowe/zowe-common-c/pull/569)
  Bugfix: Use "%.*s" version of snprintf to stop overreading in 'zosResolveSymbol()' which causes abend. [(#626)](https://github.com/zowe/zowe-common-c/pull/626)
 - Bugfix: fix recovery in 64-bit httpserver [(#622)](https://github.com/zowe/zowe-common-c/issues/622)
+- Enhancement: add a new function (`cmsTestAuth2`) to test any SAF level in xmem; fix ALTER SAF enum value [(#635)](https://github.com/zowe/zowe-common-c/issues/635)
 
 ## `3.5.0`
 - Enhancement: YAML comment preservation tooling for the YAML-to-JSON-to-YAML round-trip pipeline. Comments are scanned separately from libyaml, attached to the JSON tree, and re-emitted with configurable alignment (none, fixed, original). Opt-in; not yet enabled in configmgr. [(#583)](https://github.com/zowe/zowe-common-c/issues/583)

--- a/c/crossmemory.c
+++ b/c/crossmemory.c
@@ -1128,13 +1128,6 @@ typedef struct SAFEnityName_tag {
   char padding[7];
 } SAFEnityName;
 
-typedef enum SAFAccessAttribute_tag {
-  SAF_ACCESS_ATTRIBUTE_READ = 0x02,
-  SAF_ACCESS_ATTRIBUTE_UPDATE = 0x04,
-  SAF_ACCESS_ATTRIBUTE_CONTROL = 0x08,
-  SAF_ACCESS_ATTRIBUTE_ALTER = 0x08,
-  } SAFAccessAttribute;
-
 static void safEntityNameInit(SAFEnityName *string, char *cstring, char padChar) {
   memset(string->entityName, padChar, sizeof(string->entityName));
   unsigned int cstringLength = strlen(cstring);
@@ -1303,7 +1296,7 @@ static int racrouteLIST(char *className, int *racfRC, int *racfRSN) {
 
 __asm("GLBFSTAP RACROUTE REQUEST=FASTAUTH,MF=L" : "DS"(GLBFSTAP));
 
-static int racroutFASTAUTH(ACEE *acee, char *className, char *profileName, SAFAccessAttribute accessLevel,
+static int racroutFASTAUTH(ACEE *acee, char *className, char *profileName, CMSSAFAccessLevel accessLevel,
                            int *racfRC, int *racfRSN, int traceLevel) {
 
   __asm("GLBFSTAP RACROUTE REQUEST=FASTAUTH,MF=L" : "DS"(fastauthParmList));
@@ -1390,7 +1383,7 @@ static bool isCallerAuthorized(CrossMemoryServerGlobalArea *globalArea,
   }
 
   int racfRC = 0, racfRSN = 0;
-  int safRC = racroutFASTAUTH(callerACEEAddr, className, entityName, SAF_ACCESS_ATTRIBUTE_READ, &racfRC, &racfRSN, 0);
+  int safRC = racroutFASTAUTH(callerACEEAddr, className, entityName, CMS_SAF_ACCESS_LEVEL_READ, &racfRC, &racfRSN, 0);
   if (safRC != 0) {
     return FALSE;
   }
@@ -1410,12 +1403,32 @@ bool cmsTestAuth(CrossMemoryServerGlobalArea *globalArea,
   int racfRC = 0, racfRSN = 0;
   int safRC = racroutFASTAUTH(callerACEEAddr, (char *)className,
                               (char *)entityName,
-                              SAF_ACCESS_ATTRIBUTE_READ, &racfRC, &racfRSN, 0);
+                              CMS_SAF_ACCESS_LEVEL_READ, &racfRC, &racfRSN, 0);
   if (safRC != 0) {
     return FALSE;
   }
   return TRUE;
 
+}
+
+bool cmsTestAuth2(CrossMemoryServerGlobalArea *globalArea,
+                  const char *className,
+                  const char *entityName,
+                  CMSSAFAccessLevel accessLevel) {
+  ACEE callerACEE;
+  ACEE *callerACEEAddr = NULL;
+  cmGetCallerAddressSpaceACEE(&callerACEE, &callerACEEAddr);
+  if (callerACEEAddr == NULL) {
+    return FALSE;
+  }
+  int racfRC = 0, racfRSN = 0;
+  int safRC =
+      racroutFASTAUTH(callerACEEAddr, (char *)className, (char *)entityName,
+                      accessLevel, &racfRC, &racfRSN, 0);
+  if (safRC != 0) {
+    return FALSE;
+  }
+  return TRUE;
 }
 
 ZOWE_PRAGMA_PACK
@@ -2112,7 +2125,6 @@ static void extractServiceFunctionAbendInfo(RecoveryContext * __ptr32 context,
 static int handleUnsafeProgramCall(PCHandlerParmList *parmList,
                                    bool isSpaceSwitchPC) {
 
-  ABENDInfo abendInfo;
   LatentParmList *latentParmList = parmList->latentParmList;
   CrossMemoryServerGlobalArea *globalArea = latentParmList->parm1;
 

--- a/h/crossmemory.h
+++ b/h/crossmemory.h
@@ -194,6 +194,15 @@ typedef struct CrossMemoryService_tag {
   PAD_LONG(1, void *serviceData);
 } CrossMemoryService;
 
+#pragma enum(1)
+typedef enum CMSSAFAccessLevel_tag {
+  CMS_SAF_ACCESS_LEVEL_READ = 0x02,
+  CMS_SAF_ACCESS_LEVEL_UPDATE = 0x04,
+  CMS_SAF_ACCESS_LEVEL_CONTROL = 0x08,
+  CMS_SAF_ACCESS_LEVEL_ALTER = 0x80,
+} CMSSAFAccessLevel;
+#pragma enum(reset)
+
 /*
  * TODO this version must not be incremented until the following gets addressed.
  *
@@ -438,6 +447,7 @@ ZOWE_PRAGMA_PACK_RESET
 #define cmsGetGlobalArea CMGETGA
 #define cmsAddConfigParm CMADDPRM
 #define cmsTestAuth CMTSAUTH
+#define cmsTestAuth2 CMTSAUT2
 #define cmsCallService CMCMSRCS
 #define cmsCallService2 CMCALLS2
 #define cmsCallService3 CMCALLS3
@@ -511,6 +521,20 @@ bool cmsTestAuth(CrossMemoryServerGlobalArea *globalArea,
                  const char *className,
                  const char *entityName);
 
+/**
+ * Checks if the cross-memory caller has access to the provided class and
+ * entity.
+ *
+ * @param globalArea The global area of the server.
+ * @param className The class to be checked.
+ * @param entityName The entity to be checked.
+ * @param accessLevel The access level to be checked.
+ * @return True if the caller has access to the class/entity, otherwise false.
+ */
+bool cmsTestAuth2(CrossMemoryServerGlobalArea *globalArea,
+                  const char *className,
+                  const char *entityName,
+                  CMSSAFAccessLevel accessLevel);
 
 /* Use these inside your service functions if they need ECSA.
  * The number of allocated blocks is tracked in the CMS global area. */


### PR DESCRIPTION
<!-- Thank you for submitting a PR to Zowe! To help us understand, test, and give feedback on your code, please fill in the details below. -->

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

This new function is needed for the core services in the zss repo which will now be performing additional SAF checks for more granular security.

Additionally, the enum value of the SAF ALTER level has been corrected (`0x08` -> `0x80`).

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zss/blob/v2.x/master/CONTRIBUTING.md))
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings

## Testing
N/A; the ZSS repo change will test this.
