### PR TITLE
Clamp dataLength in handleDumpService

### DIFF
--- a/c/crossmemory.c
+++ b/c/crossmemory.c
@@ -1924,6 +1924,8 @@ static int handleDumpService(CrossMemoryServer *server,
     return RC_CMS_STDSVC_PARM_BAD_EYECATCHER;
   }
 
+  localParm.dataLength = min(localParm.dataLength, sizeof(localParm.data));
+
   CrossMemoryServerMsgQueueElement *newElement = NULL;
   int allocRC = allocateMsgQueueElement(server, &newElement);
   if (allocRC != RC_CMS_OK) {


### PR DESCRIPTION
In `handleDumpService()`, the `dataLength` in the parameter indicates the how many bytes are available in the char-array `data`, so its value should not exceed the capacity of `data`, but the actual value is neither checked nor clamped.

The client function `cmsHexDump` does clamp the value of `dataLength`, but theoretically it is not the only one who can call `handleDumpService()`, so `dataLength` should be clamped in the service handler function too.

A single-line code change can make it a better place :) so why not.

Hints for unit test is ignored in this PR because the change is too small.

-----

For comparison:
https://github.com/zowe/zowe-common-c/blob/620d308c7a4b6371406ecef4dfacb1a44e295995/c/crossmemory.c#L5688-L5709