### PR TITLE
Check (SSCTFLG1 & SSCTLDEL) before dereferencing SSCTSUSE

### DIFF
--- a/c/discovery.c
+++ b/c/discovery.c
@@ -348,11 +348,16 @@ static void visitSSCTEntry(DiscoveryContext *context,
   void *usr1 = (void*)INT2PTR(ssctChain->ssctsuse);
   zowelog(NULL, LOG_COMP_DISCOVERY, ZOWE_LOG_DEBUG, "user pointer at 0x%x COMMON?=%s\n",usr1,isPointerCommon(gda,usr1) ? "YES" : "NO");
   if (isPointerCommon(gda,usr1)){
+    char *sname = &(ssctChain->sname[0]);
+    char *usrData = (char*)usr1;
+    bool deleted = ((ssctChain->flags & SSCTFLG1_SSCTLDEL) != 0);
+    if (deleted || !memcmp(sname, "!DEL", 4)) {
+      zowelog(NULL, LOG_COMP_DISCOVERY, ZOWE_LOG_DEBUG, "skipping logically deleted unit. sname=%4.4s, flags=0x%x\n",sname,ssctChain->flags);
+      return;
+    }
     if (context->ssctTraceLevel >= 1){
       dumpbuffer((char*)usr1,48);
     }
-    char *sname = &(ssctChain->sname[0]);
-    char *usrData = (char*)usr1;
     zowelog(NULL, LOG_COMP_DISCOVERY, ZOWE_LOG_DEBUG, "sname=%4.4s\n",sname);
     if (!memcmp(sname,"CICS",4) && (context->ssctTraceLevel >= 1)){
       dumpbuffer(usrData+0x08,6);

--- a/h/zos.h
+++ b/h/zos.h
@@ -1287,6 +1287,10 @@ typedef struct SSCT_tag{
   struct SSCT_tag *__ptr32 scta;  /* chain pointer */
   char sname[4];          /* 4 letter name */
   unsigned char flags;    /* equates */
+#define SSCTFLG1_SSCTSFOR 0x80
+#define SSCTFLG1_SSCTUPSS 0x40
+#define SSCTFLG1_SSCTARDR 0x20
+#define SSCTFLG1_SSCTLDEL 0x10
   unsigned char ssid;     /* JES2 or 3 */
   unsigned char reserved1[2];
   Addr31 ssvt;              /* SUBSYSTEM VECTOR TABLE POINTER */


### PR DESCRIPTION
Fix [issue 624](https://github.com/zowe/zowe-common-c/issues/624)

In a customer system, ZSS crashed when accessing SSCVT.SSCTSUSE. The root cause is not clear at the moment. The customer refused to continue the investigation.

However, we could try to skip unavailable items in the SSCVT chain by checking the SSCVT. SSCTFLG1 against mask SSCTLDEL. If the masked bit is 1, then the item should be skipped. _(suggested by @JoeNemo)_

[IBM's document](https://www.ibm.com/docs/en/zos/3.1.0?topic=xtl-sscvt-information) explains SSCTLDEL as below:

> "X'10'" Subsystem is logically deleted. When this flag is set, subsystem is removed from the SSCVT chain

In addition to checking the flag field, I also noticed in my test that, if I temporarily delete a subsystem by the command `SETSSI DELETE,SUBNAME=xxx,FORCE`, the subsystem name will become "!DEL", so the checking finally becomes:

```c
if((ssctChain->flags & SSCTFLG1_SSCTLDEL) || !memcmp(ssctChain->sname, "!DEL", 4)) {
    /* skip the current item */
}
```

However, I cannot fully reproduce the customer's symptom --- when I deleted a subsystem, its SSCTSUSE field was immediately set to 0 by the system, which will not pass the `isPointerCommon` test. So the problematic subsystem (QMR) in the customer's system must have experienced a different situation (such as hung up by XDC).

Therefore, this PR will not necessarily fix the issue in the customer's system, but it might make ZSS stronger, at lease it is no harm according to my internal tests.

The following is the instrumental log from my test: (this log is not included in the PR)

```
checking unit. sname=JES2, flags=0xa0, suse=0xcce6fc
checking unit. sname=MSTR, flags=0x0, suse=0x0
checking unit. sname=IZUG, flags=0x0, suse=0x0
checking unit. sname=RACF, flags=0x0, suse=0x0
checking unit. sname=SMS , flags=0x0, suse=0x0
checking unit. sname=TNF , flags=0x0, suse=0xce91a8
checking unit. sname=VMCF, flags=0x0, suse=0xce90c0
checking unit. sname=BLSR, flags=0x0, suse=0x0
checking unit. sname=IRLM, flags=0x0, suse=0x0
checking unit. sname=I10A, flags=0x0, suse=0x0
checking unit. sname=JRLM, flags=0x0, suse=0x0
checking unit. sname=!DEL, flags=0x0, suse=0x0
checking unit. sname=GSVX, flags=0x0, suse=0x0
checking unit. sname=RIM , flags=0x0, suse=0x0
checking unit. sname=RRS , flags=0x0, suse=0x1296bf80
checking unit. sname=AXR , flags=0x0, suse=0x0
checking unit. sname=!DEL, flags=0x0, suse=0x0
checking unit. sname=HASP, flags=0xa0, suse=0xcce6fc
checking unit. sname=!DEL, flags=0x0, suse=0x0
checking unit. sname=CICS, flags=0x0, suse=0x0
checking unit. sname=PDSM, flags=0x0, suse=0x0
```