### PR TITLE
Consistently use USS_MAX_PATH_LENGTH instead of PATH_PAX

### DIFF
--- a/c/httpfileservice.c
+++ b/c/httpfileservice.c
@@ -41,14 +41,6 @@
 #define ENOENT 129   
 #endif
 
-#ifndef PATH_MAX
-# ifdef _POSIX_PATH_MAX
-#   define PATH_MAX  _POSIX_PATH_MAX
-# else
-#   define PATH_MAX  256
-# endif
-#endif
-
 #define MAX_BASE64_CONTENT_LENGTH (256 * 1024 * 1024)
 
 #ifdef __ZOWE_OS_ZOS
@@ -770,7 +762,7 @@ void respondWithUnixFileMetadata(HttpResponse *response, char *absolutePath) {
 
 void directoryChangeOwnerAndRespond(HttpResponse *response, char *path,
         char *user, char *group, char *Recursive, char *pattern) {
-# define RETURN_MESSAGE_SIZE (PATH_MAX + 50)
+# define RETURN_MESSAGE_SIZE (USS_MAX_PATH_LENGTH + 50)
 
   char message[RETURN_MESSAGE_SIZE] = {0};
   UserInfo  userInfo = {0};


### PR DESCRIPTION
Due to the following reasons:

1. We already have `USS_MAX_PATH_LENGTH` defined in `unixfile.h` and this header file is the common dependency of all USS file related modules (such as httpfileservice.c, zosfile.c, and etc.);
https://github.com/zowe/zowe-common-c/blob/ddfef95eedf2d2980a0e8f0834f58dd7bf1a20fd/h/unixfile.h#L494

2. The value 1023 is a better choice than 256 in today's z/OS.

We should consistently use USS_MAX_PATH_LENGTH instead of PATH_PAX.

