### PR TITLE
Minor fix about using SHLAlloc in processHttpFragment

### DIFF
--- a/c/httpserver.c
+++ b/c/httpserver.c
@@ -2348,7 +2348,7 @@ int processHttpFragment(HttpRequestParser *parser, char *data, int len){
         } else{
           zowelog(NULL, LOG_COMP_HTTPSERVER, ZOWE_LOG_DEBUG3, "_____ END OF MESSAGE HEADER _________\n");
           parser->state = HTTP_STATE_READING_FIXED_BODY;
-          parser->content = SLHAlloc2(parser->slh,parser->specifiedContentLength,true);
+          parser->content = SLHAlloc2(parser->slh,parser->specifiedContentLength,SLHALLOC2_NO_ABEND);
           if (parser->content == NULL) {
             zowelog(NULL, LOG_COMP_HTTPSERVER, ZOWE_LOG_DEBUG, "request refused because failed to allocate buffer for its content. length: %d\n", parser->specifiedContentLength);
             /* allocation failure */
@@ -2420,7 +2420,7 @@ int processHttpFragment(HttpRequestParser *parser, char *data, int len){
             parser->httpReasonCode = HTTP_STATUS_BAD_REQUEST;
             return 0;
           }
-          parser->content = SLHAlloc(parser->slh, (int) newContentLength);
+          parser->content = SLHAlloc2(parser->slh, (int) newContentLength, SLHALLOC2_NO_ABEND);
           if (parser->content == NULL) {
             zowelog(NULL, LOG_COMP_HTTPSERVER, ZOWE_LOG_DEBUG, "request refused because failed to reallocate buffer for new content chunk. Received content length: %d, new chunk length: %d\n", 
                 parser->specifiedContentLength, parser->chunkSize);

--- a/h/utils.h
+++ b/h/utils.h
@@ -285,6 +285,8 @@ char *SLHAlloc(ShortLivedHeap *slh, int size);
  *    true, otherwise it will trigger ABEND.
  */
 
+#define SLHALLOC2_NO_ABEND true
+#define SLHALLOC2_MAY_ABEND false
 char *SLHAlloc2(ShortLivedHeap *slh, int size, bool suppressAbend);
 
 /**


### PR DESCRIPTION
This is a tiny patch about using `SLHAlloc2` in `processHttpFragment()`.

In PR #603, `SLHAlloc2` was implemented to allow a caller to choose if it should ABEND or return NULL when the heap is out of space. The function `processHttpFragment()` was also changed to only use `SLHAlloc2` in "return NULL" mode because it is not protected by a recovery routine.

However, I seemed to make a mistake in PR #640. Once of `SLHAlloc2` was coincidentally changed back to `SLHAlloc`. This tiny PR corrects the mistake. I apologize for the inconvenience!

Additionally, I also defined 2 macros: `SLHALLOC2_NO_ABEND` and `SLHALLOC2_MAY_ABEND` for the third argument of `SLHAlloc2` in order for a better readability.