### PR TITLE
utils: fold case and classify alphanumerics correctly on ASCII builds

### DIFF
--- a/c/utils.c
+++ b/c/utils.c
@@ -374,6 +374,12 @@ int indexOfStringInsensitive(char *str, int len, char *searchString, int startPo
 }
 
 static int upchar(char c){
+#ifndef __ZOWE_EBCDIC
+  /* The bands below are EBCDIC code points, so on an ASCII build they match
+     nothing and this would return every letter unchanged. Fold with the
+     library, which knows the execution character set. */
+  return toupper((unsigned char)c);
+#else
   char low = (char)(c & 0xf);
   char high = (char)(c &0xf0);
                                           
@@ -394,6 +400,7 @@ static int upchar(char c){
   default:
     return c&0xff;
   }
+#endif
 }
 
 /*
@@ -424,6 +431,11 @@ int compareStringsIgnoringCase(char *s1, char *s2){
 }
 
 int isCharAN(char c){
+#ifndef __ZOWE_EBCDIC
+  /* As upchar(): EBCDIC bands below, so an ASCII build would call every
+     letter and digit non-alphanumeric. */
+  return isalnum((unsigned char)c) ? 1 : 0;
+#else
   char low = (char)(c & 0xf);
   char high = (char)(c &0xf0);
                                           
@@ -441,6 +453,7 @@ int isCharAN(char c){
   default:
     return 0;                             
   }                                       
+#endif
 }
 
 void freeToken(token *t){


### PR DESCRIPTION
Resolves #653.

`upchar()` and `isCharAN()` in `c/utils.c` switch on EBCDIC code-point bands
(`0x80`/`0x90`/`0xA0` for lower case, `0xC0`/`0xD0`/`0xE0` for upper, `0xF0`
for digits). On an ASCII build nothing matches and both fall to `default`:

* `upchar` returns every letter unchanged, so `compareIgnoringCase` and
  `compareStringsIgnoringCase` are case-**sensitive** off z/OS.
* `isCharAN` reports every letter and digit as non-alphanumeric, which changes
  what `tknGetAlphanumeric` and `tknGetStandard` tokenize.

The second one is the more awkward of the two: a comparison that has quietly
become case-sensitive usually shows up as a test that fails, whereas a
tokenizer that silently produces different tokens makes an off-platform test
lie rather than fail.

### The change

13 lines added, none changed. Each function gets an ASCII branch guarded on
`__ZOWE_EBCDIC`; **the EBCDIC branch is the existing code, untouched.**
`ctype.h` was already included, and `__ZOWE_EBCDIC` is already used this way in
this file (line ~607, `printableEBCDIC` vs `printableASCII`).

### z/OS is provably unaffected

`c/utils.c` compiled for z/OS before and after, with the configmgr `zos` flags
(`-fzos-le-char-mode=ebcdic -fexec-charset=IBM-1047`):

```
zbefore/utils.o  76400 bytes  cksum 1252317
zafter/utils.o   76400 bytes  cksum 1252317
cmp: identical
```

Byte-identical object code, so codegen does not move. Both compile with zero
warnings.

For what it is worth the two implementations also agree exactly: comparing the
current functions against `toupper`/`isalnum` across all 256 byte values on
z/OS gives **0 differences out of 256**. That is reassurance rather than the
mechanism -- the guard is what keeps z/OS unchanged.

### Test

No new test. `tests/strcmptest.c` has always asserted case-insensitivity; it
passed on z/OS and failed on Linux for exactly this reason.

| | before | after |
|---|---|---|
| Linux / WSL | 8 of 12 assertions BAD, exit 1 | 12 of 12 GOOD, exit 0 |
| z/OS | passing | passing (identical object code) |

### Not covered

`isCharAN` has no assertions in `strcmptest.c`. Happy to add a few lines there
if wanted, though it grows the diff. Note also that `isCharAN` is ZIS stub slot
712, so the ASCII behaviour is visible to plugins in principle -- no z/OS build
is ASCII, so nothing changes in practice.
