### PR TITLE
On z/OS evaluate the embedded JS always in KEY 8 and PROBLEM STATE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Zowe Common C Changelog
 
 ## `3.6.0`
+- Bugfix: Embedded JavaScript always running in key 8 and problem state. [(#670)](https://github.com/zowe/zowe-common-c/pull/670)
 - Bugfix: The logging component-ID walk in `logConfigureComponent()` and `getComponent()` now tests its loop bound before indexing, instead of reading `id[4]` two bytes past the `uint64` component ID. Unreachable on z/OS with the component IDs currently defined, but triggered on every call on a little-endian host. [(#667)](https://github.com/zowe/zowe-common-c/pull/667)
 - Bugfix: `fileGetINode()` and `fileGetDeviceID()` are now implemented on POSIX hosts, and `fileGetDeviceID()` on Windows. Both are declared in `h/unixfile.h` for every platform and `fileGetINode()` is called from `httpserver.c`'s ETag computation, but only the z/OS implementations existed, so any build off z/OS that reached a file's identity failed to link. The z/OS implementations are unchanged. [(#666)](https://github.com/zowe/zowe-common-c/pull/666)
 - Bugfix: `directoryMakeDirectoryRecursive()` now publishes the required size of its path-out buffer as `USS_MKDIR_PATH_BUFFER_SIZE` and rejects a `messageLength` below it, returning -1 before anything is created. Previously an undersized buffer was filled with a truncated path, naming a directory that need not exist, and was left without a null terminator when the path was at least `messageLength` long -- which the caller then read as a string. [(zss#2094)](https://github.com/zowe/zss/issues/2094)

--- a/c/embeddedjs.c
+++ b/c/embeddedjs.c
@@ -67,6 +67,7 @@ typedef int64_t ssize_t;
 #ifdef __ZOWE_OS_ZOS
 
 #include "porting/polyfill.h"
+#include "zos.h"
 
 #endif
 
@@ -1913,7 +1914,30 @@ static bool evaluationVisitor(void *context, Json *json, Json *parent, char *key
 
 #define MAX_TEMPLATE_PASSES 16
 
-Json *evaluateJsonTemplates(EmbeddedJS *ejs, ShortLivedHeap *slh, Json *json){
+#ifdef __ZOWE_OS_ZOS
+
+typedef struct TemplateEvalPrivilege_tag {
+  int oldKey;
+  int wasAlreadyProblemState;
+} TemplateEvalPrivilege;
+
+static TemplateEvalPrivilege dropToUnauthorizedState(void){
+  TemplateEvalPrivilege saved;
+  saved.oldKey = setKey(8);
+  saved.wasAlreadyProblemState = supervisorMode(FALSE);
+  return saved;
+}
+
+static void restoreAuthorizedState(TemplateEvalPrivilege saved){
+  if (!saved.wasAlreadyProblemState){
+    supervisorMode(TRUE);
+  }
+  setKey(saved.oldKey);
+}
+
+#endif /* __ZOWE_OS_ZOS */
+
+static Json *evaluateJsonTemplatesUnprotected(EmbeddedJS *ejs, ShortLivedHeap *slh, Json *json){
   if (!jsonIsObject(json)) {
     return NULL;
   }
@@ -1962,6 +1986,17 @@ Json *evaluateJsonTemplates(EmbeddedJS *ejs, ShortLivedHeap *slh, Json *json){
          "circular or excessively nested reference?\n",
          MAX_TEMPLATE_PASSES, evalContext.markersSeen);
   return NULL;
+}
+
+Json *evaluateJsonTemplates(EmbeddedJS *ejs, ShortLivedHeap *slh, Json *json){
+#ifdef __ZOWE_OS_ZOS
+  TemplateEvalPrivilege savedPrivilege = dropToUnauthorizedState();
+#endif
+  Json *result = evaluateJsonTemplatesUnprotected(ejs, slh, json);
+#ifdef __ZOWE_OS_ZOS
+  restoreAuthorizedState(savedPrivilege);
+#endif
+  return result;
 }
 
 EmbeddedJS *allocateEmbeddedJS(EmbeddedJS *sharedRuntimeEJS /* can be NULL */){


### PR DESCRIPTION
## Change - z/OS only
```c
Json *evaluateJsonTemplates(EmbeddedJS *ejs, ShortLivedHeap *slh, Json *json){
  TemplateEvalPrivilege savedPrivilege = dropToUnauthorizedState();
  Json *result = evaluateJsonTemplatesUnprotected(ejs, slh, json);
  restoreAuthorizedState(savedPrivilege);
  return result;
}
```