### PR TITLE
Throw an error for embedded JS on z/OS if key != 8 or supervisor state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Zowe Common C Changelog
 
 ## `3.6.0`
+- Bugfix: Embedded JS is expected to run in key 8 and problem state. [(#674)](https://github.com/zowe/zowe-common-c/pull/674)
 - Bugfix: `icsfDigestInit` in `icsf.c` contained a typo in the SHA-256 ICSF rule array keyword (`"SHA246"` instead of `"SHA256"`), causing SHA-256 hashing to fail. [(#594)](https://github.com/zowe/zowe-common-c/issues/594)
 - Bugfix: `ICSFDigest.hash` buffer in `icsf.h` was 32 bytes, too small for SHA-384 (48 bytes) and SHA-512 (64 bytes). Increased to 64 bytes to prevent buffer overflow. [(#594)](https://github.com/zowe/zowe-common-c/issues/594)
 - Enhancement: Added SHA-3 (Keccak) algorithm support to the ICSF digest wrapper: `ICSF_DIGEST_SHA3_224`, `ICSF_DIGEST_SHA3_256`, `ICSF_DIGEST_SHA3_384`, `ICSF_DIGEST_SHA3_512` with corresponding cases in `icsfDigestInit`, `icsfDigestUpdate`, and `icsfDigestFinish`. [(#594)](https://github.com/zowe/zowe-common-c/issues/594)

--- a/c/configmgr.c
+++ b/c/configmgr.c
@@ -596,7 +596,13 @@ ConfigManager *makeConfigManager(){
   mgr->traceOut = stderr;
   mgr->slh = makeShortLivedHeap(0x10000,0x100);
   EmbeddedJS *ejs = allocateEmbeddedJS(NULL);
-  configureEmbeddedJS(ejs,NULL,0,0,NULL);
+  /* configureEmbeddedJS tolerates a NULL ejs and frees ejs itself if it fails
+     partway, so the only cleanup owed here is what this function allocated. */
+  if (!configureEmbeddedJS(ejs,NULL,0,0,NULL)){
+    SLHFree(mgr->slh);
+    safeFree((char*)mgr,sizeof(ConfigManager));
+    return NULL;
+  }
   mgr->ejs = ejs;
   return mgr;
 }
@@ -1849,6 +1855,10 @@ static int simpleMain(int argc, char **argv){
   }
 
   ConfigManager *mgr = makeConfigManager();
+  if (mgr == NULL){
+    fprintf(traceOut, "Could not create the embedded JavaScript runtime.\n");
+    return ZCFG_BAD_ENVIRONMENT;
+  }
   const char *configName = "only";
   cfgSetTraceLevel(mgr,traceLevel);
   cfgSetTraceStream(mgr,traceOut);
@@ -2016,8 +2026,15 @@ int main(int argc, char **argv){
       loadMode = EJS_LOAD_NOT_MODULE;
     }
     EmbeddedJS *ejs = allocateEmbeddedJS(NULL);
+    if (ejs == NULL){
+      fprintf(stderr,"Could not create the embedded JavaScript runtime.\n");
+      return ZCFG_BAD_ENVIRONMENT;
+    }
     modules[0] = exportConfigManagerToEJS(ejs);
-    configureEmbeddedJS(ejs,modules,1,argc,argv);
+    if (!configureEmbeddedJS(ejs,modules,1,argc,argv)){
+      fprintf(stderr,"Could not configure the embedded JavaScript runtime.\n");
+      return ZCFG_BAD_ENVIRONMENT;
+    }
     /* disabled due to verbosity causing scripting errors for those who read std as a return value 
       printf("configured EJS, and starting script_______________________________________________\n");
       fflush(stdout);

--- a/c/embeddedjs.c
+++ b/c/embeddedjs.c
@@ -1914,7 +1914,7 @@ static bool evaluationVisitor(void *context, Json *json, Json *parent, char *key
 
 #define MAX_TEMPLATE_PASSES 16
 
-static Json *evaluateJsonTemplatesUnprotected(EmbeddedJS *ejs, ShortLivedHeap *slh, Json *json){
+Json *evaluateJsonTemplates(EmbeddedJS *ejs, ShortLivedHeap *slh, Json *json){
   if (!jsonIsObject(json)) {
     return NULL;
   }
@@ -1965,18 +1965,17 @@ static Json *evaluateJsonTemplatesUnprotected(EmbeddedJS *ejs, ShortLivedHeap *s
   return NULL;
 }
 
-Json *evaluateJsonTemplates(EmbeddedJS *ejs, ShortLivedHeap *slh, Json *json){
+EmbeddedJS *allocateEmbeddedJS(EmbeddedJS *sharedRuntimeEJS /* can be NULL */){
 #ifdef __ZOWE_OS_ZOS
   if (!isKey8ProblemState()){
-    printf("template evaluator: refusing to run embedded JavaScript outside key 8/problem state\n");
+    wtoMessage("allocateEmbeddedJS: embedded JavaScript requires PSW key 8 and problem state");
+    return NULL;
+  }
+  if (isCallerSRB() || isCallerCrossMemory() || isCallerLocked()){
+    wtoMessage("allocateEmbeddedJS: embedded JavaScript cannot run under an SRB, in cross-memory mode or with a lock held");
     return NULL;
   }
 #endif
-  Json *result = evaluateJsonTemplatesUnprotected(ejs, slh, json);
-  return result;
-}
-
-EmbeddedJS *allocateEmbeddedJS(EmbeddedJS *sharedRuntimeEJS /* can be NULL */){
   EmbeddedJS *embeddedJS = (EmbeddedJS*)safeMalloc(sizeof(EmbeddedJS),"EmbeddedJS");
   memset(embeddedJS,0,sizeof(EmbeddedJS));
   if (sharedRuntimeEJS){
@@ -2137,10 +2136,13 @@ JSModuleDef *ejsModuleLoader(JSContext *ctx,
 bool configureEmbeddedJS(EmbeddedJS *embeddedJS, 
                          EJSNativeModule **nativeModules, int nativeModuleCount,
                          int argc, char **argv){
-  /* 
+  /*
      JS_SetMemoryLimit(rt, memory_limit);
      JS_SetMaxStackSize(rt, stack_size);
   */
+  if (embeddedJS == NULL){ /* allocateEmbeddedJS refused or failed */
+    return false;
+  }
   js_std_set_worker_new_context_func(makeEmbeddedJSContext);
   js_std_init_handlers(embeddedJS->rt);
   JS_SetMaxStackSize(embeddedJS->rt, 1048576);

--- a/c/embeddedjs.c
+++ b/c/embeddedjs.c
@@ -67,6 +67,7 @@ typedef int64_t ssize_t;
 #ifdef __ZOWE_OS_ZOS
 
 #include "porting/polyfill.h"
+#include "zos.h"
 
 #endif
 
@@ -1913,7 +1914,7 @@ static bool evaluationVisitor(void *context, Json *json, Json *parent, char *key
 
 #define MAX_TEMPLATE_PASSES 16
 
-Json *evaluateJsonTemplates(EmbeddedJS *ejs, ShortLivedHeap *slh, Json *json){
+static Json *evaluateJsonTemplatesUnprotected(EmbeddedJS *ejs, ShortLivedHeap *slh, Json *json){
   if (!jsonIsObject(json)) {
     return NULL;
   }
@@ -1962,6 +1963,17 @@ Json *evaluateJsonTemplates(EmbeddedJS *ejs, ShortLivedHeap *slh, Json *json){
          "circular or excessively nested reference?\n",
          MAX_TEMPLATE_PASSES, evalContext.markersSeen);
   return NULL;
+}
+
+Json *evaluateJsonTemplates(EmbeddedJS *ejs, ShortLivedHeap *slh, Json *json){
+#ifdef __ZOWE_OS_ZOS
+  if (!isKey8ProblemState()){
+    printf("template evaluator: refusing to run embedded JavaScript outside key 8/problem state\n");
+    return NULL;
+  }
+#endif
+  Json *result = evaluateJsonTemplatesUnprotected(ejs, slh, json);
+  return result;
 }
 
 EmbeddedJS *allocateEmbeddedJS(EmbeddedJS *sharedRuntimeEJS /* can be NULL */){

--- a/c/rexxcmgr.c
+++ b/c/rexxcmgr.c
@@ -457,6 +457,9 @@ int REXXCMGR(REXXInvocation *invocation){
     if (invocation->traceLevel >= 1){
       printf("configmgr made at 0x%p\n",theConfigManager);
     }
+    if (!theConfigManager){
+      return ZCFG_BAD_ENVIRONMENT;
+    }
     theConfigManager->traceOut = fopen("//dd:cmgrout","w");
   }
   FILE *out = theConfigManager->traceOut;

--- a/c/zos.c
+++ b/c/zos.c
@@ -91,8 +91,6 @@ int testAuth(void)
 
 /* returns whether was in problem state */
 
-#define PROBLEM_STATE 0x00010000
-
 int extractPSW(void) {
   int highWord;
   __asm(ASM_PREFIX
@@ -146,6 +144,13 @@ int setKey(int key){
         :"r"(shiftedKey)
         :"r2");
   return oldKey;
+}
+
+bool isKey8ProblemState(void){
+  uint32 currentPSW = extractPSW();
+  uint32 currentKey = (currentPSW >> 20) & 0x0000000F;
+  bool isProblemState = (currentPSW & PROBLEM_STATE) ? true : false;
+  return (currentKey == 8) && isProblemState;
 }
 
 int64 getR12(void) {

--- a/c/zos.c
+++ b/c/zos.c
@@ -89,7 +89,7 @@ int testAuth(void)
   return rc;
 }
 
-/* returns whether was in problem state */
+#define PROBLEM_STATE 0x00010000
 
 int extractPSW(void) {
   int highWord;

--- a/h/configmgr.h
+++ b/h/configmgr.h
@@ -51,7 +51,8 @@ typedef struct ConfigManager_tag{
 #define ZCFG_VALIDATION_INTERNAL_ERROR 14
 #define ZCFG_JQ_PARSE_ERROR 15
 #define ZCFG_EXTRACT_ERROR 16
-/* Normal way to tell people the program succeded but their config is bad */
+#define ZCFG_BAD_ENVIRONMENT 17
+/* Normal way to tell people the program succeeded but their config is bad */
 #define ZCFG_CONFIG_FAILED_VALIDATION 99
 
 #define ZCFG_POINTER_TOO_DEEP JSON_POINTER_TOO_DEEP

--- a/h/zos.h
+++ b/h/zos.h
@@ -70,10 +70,12 @@
 
 #endif
 
+#define PROBLEM_STATE 0x00010000
 
 int extractPSW(void);
 int supervisorMode(int enable);
 int setKey(int key);
+bool isKey8ProblemState(void);
 int ddnameExists(char *ddname);
 int atomicIncrement(int *intPointer, int increment);
 

--- a/h/zos.h
+++ b/h/zos.h
@@ -65,17 +65,15 @@
 #define isCallerLocked        ZOSCLCKD
 #define isCallerSRB           ZOSCSRB
 #define isCallerCrossMemory   ZOSCXMEM
+#define isKey8ProblemState    ZOSK8PBS
 
 #define getExternalSecurityManager GETESM
 
 #endif
 
-#define PROBLEM_STATE 0x00010000
-
 int extractPSW(void);
 int supervisorMode(int enable);
 int setKey(int key);
-bool isKey8ProblemState(void);
 int ddnameExists(char *ddname);
 int atomicIncrement(int *intPointer, int increment);
 
@@ -1695,6 +1693,14 @@ bool isCallerSRB(void);
  * @return False if the caller's HASN=PASN=SASN, otherwise true.
  */
 bool isCallerCrossMemory(void);
+
+/**
+ * @brief Determine if the caller is in PSW key 8 and problem state.
+ * @return True only if the current PSW key is 8 and the caller is in problem
+ *         state. This is the state Language Environment requires, so callers
+ *         that need LE services can use it as a precondition check.
+ */
+bool isKey8ProblemState(void);
 
 #endif /* __ZOWE_OS_ZOS */
 

--- a/tests/jstest.c
+++ b/tests/jstest.c
@@ -98,7 +98,11 @@ int main(int argc, char **argv){
   fflush(stdout);
   
   EmbeddedJS *ejs = allocateEmbeddedJS(NULL);
-  configureEmbeddedJS(ejs,NULL,0,argc,argv);
+  if (!configureEmbeddedJS(ejs,NULL,0,argc,argv)){
+    printf("could not create the embedded JS runtime\n");
+    fflush(stdout);
+    return 8;
+  }
 
   /* no includes yet 
   for(i = 0; i < include_count; i++) {
@@ -159,8 +163,12 @@ int main(int argc, char **argv){
       }
     } else {
       Json *resultantJSON = evaluateJsonTemplates(ejs,slh,json);
-      printf("JSON templates evaluated\n");
-      jsonPrint(p,resultantJSON);
+      if (resultantJSON == NULL){
+        printf("JSON template evaluation failed\n");
+      } else {
+        printf("JSON templates evaluated\n");
+        jsonPrint(p,resultantJSON);
+      }
     }
   }
 

--- a/tests/qjstest.c
+++ b/tests/qjstest.c
@@ -231,8 +231,15 @@ int main(int argc, char **argv){
   char *filename = argv[1];
   EJSNativeModule *modules[1];
   EmbeddedJS *ejs = allocateEmbeddedJS(NULL);
+  if (ejs == NULL){
+    printf("could not create the embedded JS runtime\n");
+    return 8;
+  }
   modules[0] = makeFFITestData(ejs);
-  configureEmbeddedJS(ejs,modules,1,argc,argv);
+  if (!configureEmbeddedJS(ejs,modules,1,argc,argv)){
+    printf("could not configure the embedded JS runtime\n");
+    return 8;
+  }
 
   int evalStatus = ejsEvalFile(ejs,filename,EJS_LOAD_IS_MODULE);
   printf("File eval returns %d\n",evalStatus);


### PR DESCRIPTION
## Change - z/OS only

* New function `isKey8ProblemState`
* If the caller is not in key 8 or not in problem state, do not continue with processing of embedded JS.

AI-Assisted: Claude Sonnet 5


