### PR TITLE
[DO NOT MERGE] Split IO and data-conversion error flags to prevent JSON truncation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Bugfix: `/unixfile` requests that force a `sourceEncoding`/`targetEncoding` pair the server cannot convert are rejected with 400 before the response starts, instead of returning 200 with an empty body; a default GET of a file whose CCSID tag cannot be converted falls back to raw binary streaming with a warning; and the streaming loop drains conversions that outgrow the translation buffer instead of truncating. [(#630)](https://github.com/zowe/zowe-common-c/pull/630)
 - Bugfix: charset conversion under ibm-clang64 (Open XL) now uses the iconv path. ibm-clang64 is `__ZOWE_COMP_CLANG`, not `__ZOWE_COMP_XLCLANG`, so `charsets.c` was routing it to the metal/CUNLCNV branch and mishandling multibyte and streaming conversion. [(zss#828)](https://github.com/zowe/zss/issues/828)
 - Enhancement: add a new function (`cmsTestAuth2`) to test any SAF level in xmem; fix ALTER SAF enum value [(#635)](https://github.com/zowe/zowe-common-c/issues/635)
+- Bugfix: A single unmappable character no longer truncates the whole JSON response. Data-conversion failures now use a separate flag from real IO errors, so output continues instead of being suppressed. [(#675)](https://github.com/zowe/zowe-common-c/pull/675)
 
 
 ## `3.5.0`

--- a/c/json.c
+++ b/c/json.c
@@ -1,5 +1,3 @@
-
-
 /*
   This program and the accompanying materials are
   made available under the terms of the Eclipse Public License v2.0 which accompanies
@@ -897,6 +895,10 @@ void jsonSetDataConversionErrorFlag(jsonPrinter *p) {
 
 int jsonCheckDataConversionErrorFlag(jsonPrinter *p) {
   return p->dataConversionErrorFlag;
+}
+
+void jsonClearDataConversionErrorFlag(jsonPrinter *p) {
+  p->dataConversionErrorFlag = FALSE;
 }
 
 int jsonShouldStopWriting(jsonPrinter *p) {

--- a/c/json.c
+++ b/c/json.c
@@ -116,6 +116,8 @@ void jsonPrinterReset(jsonPrinter *p){
   p->_conversionBufferSize = 0;
   p->_conversionBuffer = NULL;
   p->mode = JSON_MODE_NATIVE_CHARSET;
+  p->ioErrorFlag = FALSE;
+  p->dataConversionErrorFlag = FALSE;
 }
 
 jsonPrinter *makeJsonPrinter(int fd) {
@@ -415,9 +417,10 @@ void jsonConvertAndWriteBuffer(jsonPrinter *p, char *text, size_t len,
       DUMPBUF(text, len);
       newLen = convertToUtf8(p, len, text, inputCCSID);
       if (newLen < 0) {
-        JSONERROR("jsonConvertAndWriteBuffer() error: newLen = %d\n",
+        JSONERROR("jsonConvertAndWriteBuffer() conversion error: newLen = %d\n",
                   (int)newLen);
-        jsonSetIOErrorFlag(p);
+        jsonSetDataConversionErrorFlag(p);   // data, not IO: do not gate all output
+        jsonWriteBufferInternal(p, "", 0);   // placeholder so string isn't left half-open
         return;
       }
       JSON_DEBUG("utf8, len %d:\n", newLen);
@@ -886,6 +889,14 @@ void jsonAddDouble(jsonPrinter *p, char *keyOrNull, double value) {
 
 void jsonSetIOErrorFlag(jsonPrinter *p) {
   p->ioErrorFlag = TRUE;
+}
+
+void jsonSetDataConversionErrorFlag(jsonPrinter *p) {
+  p->dataConversionErrorFlag = TRUE;
+}
+
+int jsonCheckDataConversionErrorFlag(jsonPrinter *p) {
+  return p->dataConversionErrorFlag;
 }
 
 int jsonShouldStopWriting(jsonPrinter *p) {

--- a/h/json.h
+++ b/h/json.h
@@ -383,6 +383,7 @@ void jsonSetIOErrorFlag(jsonPrinter *p);
  */
 void jsonSetDataConversionErrorFlag(jsonPrinter *p);
 int jsonCheckDataConversionErrorFlag(jsonPrinter *p);
+void jsonClearDataConversionErrorFlag(jsonPrinter *p);
 
 JsonBuffer *makeJsonBuffer(void);
 void jsonBufferTerminateString(JsonBuffer *buffer);

--- a/h/json.h
+++ b/h/json.h
@@ -67,7 +67,8 @@ typedef struct jsonPrinter_tag {
   //private
   size_t _conversionBufferSize;
   char *_conversionBuffer;
-  int ioErrorFlag;
+  int ioErrorFlag;             // real write/stream failure — gates ALL output
+  int dataConversionErrorFlag; // unmappable-byte failure — does NOT gate output
   int isInMultipartString;
   bool (*filter)(void *filterContext,
                  char *keyOrNull,
@@ -374,6 +375,14 @@ int jsonCheckIOErrorFlag(jsonPrinter *p);
  * 
  */
 void jsonSetIOErrorFlag(jsonPrinter *p);
+
+/*
+ * These functions set/check the data-conversion error flag on the JSON
+ * printer when an unmappable byte is encountered during charset conversion.
+ * Unlike the IO error flag, this flag does NOT suppress further output.
+ */
+void jsonSetDataConversionErrorFlag(jsonPrinter *p);
+int jsonCheckDataConversionErrorFlag(jsonPrinter *p);
 
 JsonBuffer *makeJsonBuffer(void);
 void jsonBufferTerminateString(JsonBuffer *buffer);


### PR DESCRIPTION

## Proposed changes
Add a separate dataConversionErrorFlag so unmappable-byte conversion failures no longer latch ioErrorFlag and suppress all further output. Conversion failures now write a blank placeholder and continue, keeping
the document valid, while genuine IO errors still hard-stop via ` jsonShouldStopWriting/ioErrorFlag`. Both flags are reset in `jsonPrinterReset`.

This PR addresses Issue: 

This PR depends upon the following PRs:

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Change in a documentation
- [ ] Refactor the code 
- [ ] Chore, repository cleanup, updates the dependencies.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## PR Checklist
Please delete options that are not relevant.
- [ ] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [ ] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zss/blob/v2.x/master/CONTRIBUTING.md))
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] video or image is included if visual changes are made
- [] Relevant update to CHANGELOG.md
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works, or describe a test method below

## Testing
<!-- Describe how this code should be tested. I've you've added an automated or unit test, then describe how to run it. Otherwise, describe how you have tested it and how others should test it. -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, or if there are follow-up tasks and TODOs etc... -->
