### PR TITLE
Limit the number of `zos` functions available for embedded JS

### DIFF
--- a/c/embeddedjs.c
+++ b/c/embeddedjs.c
@@ -2186,7 +2186,7 @@ bool configureEmbeddedJS(EmbeddedJS *embeddedJS,
     const char *source = "import * as std from 'std';\n"
       "import * as os from 'os';\n"
 #ifdef __ZOWE_OS_ZOS
-      "import * as zos from 'zos';\n"
+      "import { changeStreamCCSID, zstat, getZosVersion, getEsm, resolveSymbol, getStatvfs } from 'zos';\n"
 #endif
       /*  "import * as experiment from 'experiment';\n" */
       /*       "import * as FFI1 from 'FFI1';\n" */

--- a/c/embeddedjs.c
+++ b/c/embeddedjs.c
@@ -2193,7 +2193,14 @@ bool configureEmbeddedJS(EmbeddedJS *embeddedJS,
       "globalThis.std = std;\n"
       "globalThis.os = os;\n"
 #ifdef __ZOWE_OS_ZOS
-      "globalThis.zos = zos;\n"
+      "globalThis.zos = {\n"
+      "  changeStreamCCSID,\n"
+      "  zstat,\n"
+      "  getZosVersion,\n"
+      "  getEsm,\n"
+      "  resolveSymbol,\n"
+      "  getStatvfs\n"
+      "};\n"
 #endif
       /* "globalThis.experiment = experiment;\n"; */
       ;


### PR DESCRIPTION
## Change

Functions considered as dangerous:
* `changeTag`
* `changeExtAttr`
* `EXTATTR_SHARELIB` - bit setting used for `changeExtAttr`
* `EXTATTR_PROGCTL` - bit setting used for `changeExtAttr`
* `dslist`

Functions available for embedded JS:
* `changeStreamCCSID`
* `zstat`
* `getZosVersion`
* `getEsm`
* `resolveSymbol`
* `getStatvfs`

`import` functionality in not possible in embedded JS.
User can not override this with for example `import * as zos from 'zos';`.
Only limited set of functions is for usage in embedded JS.

## Already used in JS
* `bin/libs/common -> zos.changeTag`
* `bin/libs/component -> zos.changeExtAttr`
