### PR TITLE
Bugfix: enum/const validation messages name the schema's type, not 'integer' (#563)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Zowe Common C Changelog
 
 ## `3.6.0`
+- Bugfix: schema validation messages for `enum` and `const` mismatches name the schema's type; a property without a `type` keyword (as in the `zowe.setup.certificate` alternatives) was reported as `integer`. [(#563)](https://github.com/zowe/zowe-common-c/issues/563)
 - Bugfix: `cfgSetConfigPath()` replaces the configuration path instead of appending to it, so calling it twice no longer merges both paths and duplicates array members on load. [(#571)](https://github.com/zowe/zowe-common-c/issues/571)
 - Bugfix: Embedded JS is expected to run in key 8 and problem state. [(#674)](https://github.com/zowe/zowe-common-c/pull/674)
 - Bugfix: `icsfDigestInit` in `icsf.c` contained a typo in the SHA-256 ICSF rule array keyword (`"SHA246"` instead of `"SHA256"`), causing SHA-256 hashing to fail. [(#594)](https://github.com/zowe/zowe-common-c/issues/594)

--- a/c/jsonschema.c
+++ b/c/jsonschema.c
@@ -194,35 +194,22 @@ typedef struct JSValueSpec_tag {
   struct JSValueSpec_tag *parent;
 } JSValueSpec;
 
-/* Type names for validation messages.
-
-   A spec's `type` is meaningful only when the schema names exactly one type.
-   A property without a "type" keyword is built with every type name in
-   turn, so its `type` is merely the last one assigned ("integer") while its
-   typeMask has every bit set; reporting that word made a string enum look
-   like an integer one (#563). When the schema does not pin a single type,
-   describe the value the schema itself supplies instead. */
-static char *jsonValueTypeName(Json *value){
+/* Type word for enum/const messages, taken from the schema's own value */
+static const char *jsonValueTypeName(const Json *value){
   if (value == NULL){
     return "unknown";
   }
   switch (value->type){
   case JSON_TYPE_STRING:  return "string";
   case JSON_TYPE_NUMBER:
-  case JSON_TYPE_DOUBLE:  return "number";
   case JSON_TYPE_INT64:   return "integer";
+  case JSON_TYPE_DOUBLE:  return "number";
   case JSON_TYPE_BOOLEAN: return "boolean";
   case JSON_TYPE_NULL:    return "null";
   case JSON_TYPE_OBJECT:  return "object";
   case JSON_TYPE_ARRAY:   return "array";
   default:                return "unknown";
   }
-}
-
-static char *specTypeNameForMessage(JSValueSpec *spec, Json *sample){
-  int mask = spec->typeMask;
-  bool exactlyOneType = (mask != 0) && ((mask & (mask - 1)) == 0);
-  return exactlyOneType ? getJSTypeName(spec->type) : jsonValueTypeName(sample);
 }
 
 typedef struct AccessPathUnion_tag {
@@ -1417,11 +1404,11 @@ static VResult validateJSON(JsonValidator *validator,
       if (jsonIsString(valueSpec->constValue)) {
         return simpleFailure(validator,"unequal constant value at %s; expecting value '%s' of type '%s'",
                              validatorAccessPath(validator), jsonAsString(valueSpec->constValue),
-                             specTypeNameForMessage(valueSpec, valueSpec->constValue));
+                             jsonValueTypeName(valueSpec->constValue));
       } else if (jsonIsNumber(valueSpec->constValue)) {
         return simpleFailure(validator,"unequal constant value at %s; expecting value '%d' of type '%s'",
                              validatorAccessPath(validator), jsonAsNumber(valueSpec->constValue),
-                             specTypeNameForMessage(valueSpec, valueSpec->constValue));
+                             jsonValueTypeName(valueSpec->constValue));
       } else {
         return simpleFailure(validator,"unequal constant value at %s",
                              validatorAccessPath(validator));
@@ -1491,7 +1478,7 @@ static VResult validateJSON(JsonValidator *validator,
       if (validValues && strlen(validValues) > 0) {
         return simpleFailure(validator,"no matching enum value at %s; expecting one of values '[%s]' of type '%s'",
                              validatorAccessPath(validator), validValues,
-                             specTypeNameForMessage(valueSpec, valueSpec->enumeratedValues[0]));
+                             jsonValueTypeName(valueSpec->enumeratedValues[0]));
       } else {
         return simpleFailure(validator,"no matching enum value at %s",
                              validatorAccessPath(validator));

--- a/c/jsonschema.c
+++ b/c/jsonschema.c
@@ -194,6 +194,37 @@ typedef struct JSValueSpec_tag {
   struct JSValueSpec_tag *parent;
 } JSValueSpec;
 
+/* Type names for validation messages.
+
+   A spec's `type` is meaningful only when the schema names exactly one type.
+   A property without a "type" keyword is built with every type name in
+   turn, so its `type` is merely the last one assigned ("integer") while its
+   typeMask has every bit set; reporting that word made a string enum look
+   like an integer one (#563). When the schema does not pin a single type,
+   describe the value the schema itself supplies instead. */
+static char *jsonValueTypeName(Json *value){
+  if (value == NULL){
+    return "unknown";
+  }
+  switch (value->type){
+  case JSON_TYPE_STRING:  return "string";
+  case JSON_TYPE_NUMBER:
+  case JSON_TYPE_DOUBLE:  return "number";
+  case JSON_TYPE_INT64:   return "integer";
+  case JSON_TYPE_BOOLEAN: return "boolean";
+  case JSON_TYPE_NULL:    return "null";
+  case JSON_TYPE_OBJECT:  return "object";
+  case JSON_TYPE_ARRAY:   return "array";
+  default:                return "unknown";
+  }
+}
+
+static char *specTypeNameForMessage(JSValueSpec *spec, Json *sample){
+  int mask = spec->typeMask;
+  bool exactlyOneType = (mask != 0) && ((mask & (mask - 1)) == 0);
+  return exactlyOneType ? getJSTypeName(spec->type) : jsonValueTypeName(sample);
+}
+
 typedef struct AccessPathUnion_tag {
   int dummy;
 } AccessPathUnion;
@@ -1385,10 +1416,12 @@ static VResult validateJSON(JsonValidator *validator,
     if (!eq){
       if (jsonIsString(valueSpec->constValue)) {
         return simpleFailure(validator,"unequal constant value at %s; expecting value '%s' of type '%s'",
-                             validatorAccessPath(validator), jsonAsString(valueSpec->constValue), getJSTypeName(valueSpec->type));
+                             validatorAccessPath(validator), jsonAsString(valueSpec->constValue),
+                             specTypeNameForMessage(valueSpec, valueSpec->constValue));
       } else if (jsonIsNumber(valueSpec->constValue)) {
         return simpleFailure(validator,"unequal constant value at %s; expecting value '%d' of type '%s'",
-                             validatorAccessPath(validator), jsonAsNumber(valueSpec->constValue), getJSTypeName(valueSpec->type));
+                             validatorAccessPath(validator), jsonAsNumber(valueSpec->constValue),
+                             specTypeNameForMessage(valueSpec, valueSpec->constValue));
       } else {
         return simpleFailure(validator,"unequal constant value at %s",
                              validatorAccessPath(validator));
@@ -1457,7 +1490,8 @@ static VResult validateJSON(JsonValidator *validator,
     if (!matched){
       if (validValues && strlen(validValues) > 0) {
         return simpleFailure(validator,"no matching enum value at %s; expecting one of values '[%s]' of type '%s'",
-                             validatorAccessPath(validator), validValues, getJSTypeName(valueSpec->type));
+                             validatorAccessPath(validator), validValues,
+                             specTypeNameForMessage(valueSpec, valueSpec->enumeratedValues[0]));
       } else {
         return simpleFailure(validator,"no matching enum value at %s",
                              validatorAccessPath(validator));

--- a/tests/configmgr/cli/fixtures/oneof_untyped_bad.yaml
+++ b/tests/configmgr/cli/fixtures/oneof_untyped_bad.yaml
@@ -1,0 +1,5 @@
+zowe:
+  setup:
+    certificate:
+      type: BOGUS
+      file: x

--- a/tests/configmgr/cli/fixtures/oneof_untyped_schema.json
+++ b/tests/configmgr/cli/fixtures/oneof_untyped_schema.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$id": "https://zowe.org/schemas/test-563-oneof",
+  "type": "object",
+  "properties": {
+    "zowe": { "type": "object", "properties": {
+      "setup": { "type": "object", "properties": {
+        "certificate": {
+          "type": "object",
+          "oneOf": [
+            { "properties": { "type": { "const": "PKCS12" }, "file": { "type": "string" } }, "required": ["type", "file"] },
+            { "properties": { "type": { "enum": ["JCEKS", "JCECCAKS", "JCERACFKS", "JCECCARACFKS", "JCEHYBRIDRACFKS"] }, "keyring": { "type": "string" } }, "required": ["type", "keyring"] }
+          ]
+        }
+      } }
+    } }
+  }
+}

--- a/tests/configmgr/cli/fixtures/typed_int_enum_bad.yaml
+++ b/tests/configmgr/cli/fixtures/typed_int_enum_bad.yaml
@@ -1,0 +1,3 @@
+zowe:
+  port: 9
+  mode: OTHER

--- a/tests/configmgr/cli/fixtures/typed_int_enum_schema.json
+++ b/tests/configmgr/cli/fixtures/typed_int_enum_schema.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$id": "https://zowe.org/schemas/test-563-typed",
+  "type": "object",
+  "properties": {
+    "zowe": { "type": "object", "properties": {
+      "port": { "type": "integer", "enum": [7554, 7555, 7556] },
+      "mode": { "type": "string", "const": "STANDARD" }
+    } }
+  }
+}

--- a/tests/configmgr/cli/test_enum_type_message.sh
+++ b/tests/configmgr/cli/test_enum_type_message.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+# Validation messages for enum/const mismatches name the right type
+# (zowe/zowe-common-c#563). A property without a "type" keyword, common inside
+# oneOf alternatives, used to be reported as 'integer' regardless of what the
+# schema's own values were.
+
+cd "$(dirname "$0")"
+. ./lib.sh
+
+start_suite "enum/const mismatch messages name the schema's type (#563)"
+
+FX=fixtures
+
+run_case "untyped oneOf certificate.type" \
+  "$CONFIGMGR" -s "$FX/oneof_untyped_schema.json" -p "FILE($FX/oneof_untyped_bad.yaml)" validate
+assert_exit "invalid config exits 99" 99
+assert_contains "enum message names string" "expecting one of values '[JCEKS, JCECCAKS, JCERACFKS, JCECCARACFKS, JCEHYBRIDRACFKS]' of type 'string'" "$LAST_STDOUT"
+assert_contains "const message names string" "expecting value 'PKCS12' of type 'string'" "$LAST_STDOUT"
+case "$LAST_STDOUT" in
+  *"of type 'integer'"*) echo "  FAIL  no message claims type 'integer'"; FAIL_COUNT=$((FAIL_COUNT + 1)) ;;
+  *) echo "  PASS  no message claims type 'integer'" ;;
+esac
+
+end_suite

--- a/tests/configmgr/cli/test_enum_type_message.sh
+++ b/tests/configmgr/cli/test_enum_type_message.sh
@@ -21,4 +21,11 @@ case "$LAST_STDOUT" in
   *) echo "  PASS  no message claims type 'integer'" ;;
 esac
 
+
+run_case "typed integer enum and string const" \
+  "$CONFIGMGR" -s "$FX/typed_int_enum_schema.json" -p "FILE($FX/typed_int_enum_bad.yaml)" validate
+assert_exit "invalid config exits 99" 99
+assert_contains "integer enum still says integer" "expecting one of values '[7554, 7555, 7556]' of type 'integer'" "$LAST_STDOUT"
+assert_contains "string const says string" "expecting value 'STANDARD' of type 'string'" "$LAST_STDOUT"
+
 end_suite


### PR DESCRIPTION
## Proposed changes

Schema validation messages for `enum` and `const` mismatches named the wrong type: a string enum was reported as `of type 'integer'`, which is what #563 shows and what the Zowe schema's `zowe.setup.certificate` alternatives produce today.

**Cause.** The messages print `getJSTypeName(valueSpec->type)`. A property spec without a `type` keyword, which is how the `oneOf` alternatives for `certificate` are written, is built with every type name in turn (`typeArray = allJSTypeNames`), so its `typeMask` has every bit set and its `type` is simply the last name assigned, `integer`. The word had nothing to do with the schema.

**Fix.** The message names the declared type only when the schema pins exactly one (one bit in `typeMask`). Otherwise it describes the value the schema itself supplies: the `const` value, or the first `enum` member. `jsonValueTypeName()` maps the JSON value types to the schema type names for that.

Reproduced and fixed against a reduced copy of the certificate `oneOf` (`fixtures/oneof_untyped_schema.json`):

```
before: unequal constant value at zowe.setup.certificate.type; expecting value 'PKCS12' of type 'integer'
        no matching enum value at zowe.setup.certificate.type; expecting one of values '[JCEKS, ...]' of type 'integer'
after:  ... of type 'string'
        ... of type 'string'
```

A schema that does declare `"type": "string"` on those properties was already reported correctly and still is.

This PR addresses Issue: https://github.com/zowe/zowe-common-c/issues/563

This PR depends upon the following PRs: none.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## PR Checklist
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective

## Testing

New `tests/configmgr/cli/test_enum_type_message.sh`: validates `oneof_untyped_bad.yaml` against `oneof_untyped_schema.json`, asserts exit 99, that both messages say `of type 'string'`, and that no message says `of type 'integer'`. Fails before, passes after. The whole `tests/configmgr/cli` suite passes on the Linux build from `build/build_cmgr_clang.sh linux`.

## Further comments

Only the message text changes; validation outcomes are untouched. A `const` or `enum` whose members mix types under an untyped spec is described by its first value, which is the same choice the `enum` list in the message already makes.
